### PR TITLE
add naive wasm32 support using extern date_now()

### DIFF
--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -700,9 +700,15 @@ mod platform {
 
     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     pub fn get_nstime() -> u64 {
-        unreachable!()
+        (unsafe { date_now() } as u64)
+    }
+
+    extern {
+        pub fn date_now()  -> u32;
     }
 }
+
+
 
 // A function that is opaque to the optimizer to assist in avoiding dead-code
 // elimination. Taken from `bencher`.

--- a/src/os.rs
+++ b/src/os.rs
@@ -551,14 +551,21 @@ mod imp {
 
     impl OsRng {
         pub fn new() -> io::Result<OsRng> {
-            Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+            //Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+            Ok(OsRng)
         }
     }
 
     impl Rng for OsRng {
         fn next_u32(&mut self) -> u32 {
-            panic!("Not supported")
+            //panic!("Not supported")
+            let n:u32 = unsafe { date_now() };
+            (n/1000) as u32
         }
+    }
+
+    extern {
+        pub fn date_now()  -> u32;
     }
 }
 


### PR DESCRIPTION
This is not a sophisticated solution but is better than panic and makes several libs that depend on rand work on wasm32