### PR TITLE
Universal seeder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ simd_support = ["packed_simd"] # enables SIMD support
 serde1 = ["rand_core/serde1", "rand_isaac/serde1", "rand_xorshift/serde1"] # enables serialization for PRNGs
 
 [workspace]
-members = ["rand_core", "rand_isaac", "rand_xorshift"]
+members = ["rand_core", "rand_isaac", "rand_xorshift", "rand_seeder"]
 
 [dependencies]
 rand_core = { path = "rand_core", version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ wasm-bindgen = { version = "0.2.12", optional = true }
 [dev-dependencies]
 # This has a histogram implementation used for testing uniformity.
 average = "0.9.2"
+# for benchmarking
+rand_seeder = { path = "rand_seeder", version = "0.1" }
 
 [build-dependencies]
 rustc_version = "0.2"

--- a/benches/generators.rs
+++ b/benches/generators.rs
@@ -3,6 +3,7 @@
 extern crate test;
 extern crate rand;
 extern crate rand_isaac;
+extern crate rand_seeder;
 extern crate rand_xorshift;
 
 const RAND_BENCH_N: u64 = 1000;
@@ -17,6 +18,7 @@ use rand::prng::hc128::Hc128Core;
 use rand::rngs::adapter::ReseedingRng;
 use rand::rngs::{OsRng, JitterRng, EntropyRng};
 use rand_isaac::{IsaacRng, Isaac64Rng};
+use rand_seeder::SipRng;
 use rand_xorshift::XorShiftRng;
 
 macro_rules! gen_bytes {
@@ -41,6 +43,7 @@ gen_bytes!(gen_bytes_chacha20, ChaChaRng::from_entropy());
 gen_bytes!(gen_bytes_hc128, Hc128Rng::from_entropy());
 gen_bytes!(gen_bytes_isaac, IsaacRng::from_entropy());
 gen_bytes!(gen_bytes_isaac64, Isaac64Rng::from_entropy());
+gen_bytes!(gen_bytes_sip, SipRng::from_entropy());
 gen_bytes!(gen_bytes_std, StdRng::from_entropy());
 gen_bytes!(gen_bytes_small, SmallRng::from_entropy());
 gen_bytes!(gen_bytes_os, OsRng::new().unwrap());
@@ -67,6 +70,7 @@ gen_uint!(gen_u32_chacha20, u32, ChaChaRng::from_entropy());
 gen_uint!(gen_u32_hc128, u32, Hc128Rng::from_entropy());
 gen_uint!(gen_u32_isaac, u32, IsaacRng::from_entropy());
 gen_uint!(gen_u32_isaac64, u32, Isaac64Rng::from_entropy());
+gen_uint!(gen_u32_sip, u32, SipRng::from_entropy());
 gen_uint!(gen_u32_std, u32, StdRng::from_entropy());
 gen_uint!(gen_u32_small, u32, SmallRng::from_entropy());
 gen_uint!(gen_u32_os, u32, OsRng::new().unwrap());
@@ -76,6 +80,7 @@ gen_uint!(gen_u64_chacha20, u64, ChaChaRng::from_entropy());
 gen_uint!(gen_u64_hc128, u64, Hc128Rng::from_entropy());
 gen_uint!(gen_u64_isaac, u64, IsaacRng::from_entropy());
 gen_uint!(gen_u64_isaac64, u64, Isaac64Rng::from_entropy());
+gen_uint!(gen_u64_sip, u64, SipRng::from_entropy());
 gen_uint!(gen_u64_std, u64, StdRng::from_entropy());
 gen_uint!(gen_u64_small, u64, SmallRng::from_entropy());
 gen_uint!(gen_u64_os, u64, OsRng::new().unwrap());
@@ -108,6 +113,7 @@ init_gen!(init_xorshift, XorShiftRng);
 init_gen!(init_hc128, Hc128Rng);
 init_gen!(init_isaac, IsaacRng);
 init_gen!(init_isaac64, Isaac64Rng);
+init_gen!(init_sip, SipRng);
 init_gen!(init_chacha, ChaChaRng);
 
 #[bench]

--- a/rand_seeder/CHANGELOG.md
+++ b/rand_seeder/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - TODO
+Initial release

--- a/rand_seeder/Cargo.toml
+++ b/rand_seeder/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rand_seeder"
+version = "0.1.0" # NB: When modifying, also modify html_root_url in lib.rs
+authors = ["The Rust Project Developers"]
+license = "MIT/Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/rust-lang-nursery/rand"
+documentation = "https://docs.rs/rand_seeder"
+homepage = "https://crates.io/crates/rand_seeder"
+description = """
+A universal random number seeder using SipHash.
+"""
+keywords = ["random", "rng"]
+categories = ["algorithms", "no-std"]
+
+[badges]
+travis-ci = { repository = "rust-lang-nursery/rand" }
+appveyor = { repository = "dhardy/rand" }
+
+[dependencies]
+rand_core = { path = "../rand_core", version = "0.2", default-features = false }

--- a/rand_seeder/LICENSE-APACHE
+++ b/rand_seeder/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     https://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/rand_seeder/LICENSE-MIT
+++ b/rand_seeder/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/rand_seeder/README.md
+++ b/rand_seeder/README.md
@@ -9,6 +9,31 @@
 
 A universal seeder based on [`SipHash`](https://131002.net/siphash/).
 
+This crate provides three things:
+
+-   a portable implementation of SipHash-2-4, `SipHasher`
+-   `SipRng`, based around the `SipHash` state and mixing operations
+-   `Seeder`, a convenience wrapper
+
+`Seeder` can be used to seed any `SeedableRng` from any hashable value. It is
+portable and reproducible, and should turn any input into a good RNG seed.
+It is intended for use in simulations and games where reproducibility is
+important.
+
+We do not recommend using `Seeder` for cryptographic applications and
+strongly advise against usage for authentication (password hashing).
+
+Example:
+
+```rust
+use rand_core::RngCore;         // for next_u32
+use rand::prng::XorShiftRng;    // or whatever you like
+use rand_seeder::Seeder;
+
+let mut rng: XorShiftRng = Seeder::from("stripy zebra").make_rng();
+println!("First value: {}", rng.next_u32());
+```
+
 Documentation:
 [master branch](https://rust-lang-nursery.github.io/rand/rand_seeder/index.html),
 [by release](https://docs.rs/rand_seeder)

--- a/rand_seeder/README.md
+++ b/rand_seeder/README.md
@@ -1,0 +1,26 @@
+# rand_seeder
+
+[![Build Status](https://travis-ci.org/rust-lang-nursery/rand.svg)](https://travis-ci.org/rust-lang-nursery/rand)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-lang-nursery/rand?svg=true)](https://ci.appveyor.com/project/dhardy/rand)
+[![Latest version](https://img.shields.io/crates/v/rand_seeder.svg)](https://crates.io/crates/rand_seeder)
+[![Documentation](https://docs.rs/rand_seeder/badge.svg)](https://docs.rs/rand_seeder)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-yellow.svg)](https://github.com/rust-lang-nursery/rand#rust-version-requirements)
+[![License](https://img.shields.io/crates/l/rand_seeder.svg)](https://github.com/rust-lang-nursery/rand/tree/master/rand_seeder#license)
+
+A universal seeder based on [`SipHash`](https://131002.net/siphash/).
+
+Documentation:
+[master branch](https://rust-lang-nursery.github.io/rand/rand_seeder/index.html),
+[by release](https://docs.rs/rand_seeder)
+
+[Changelog](CHANGELOG.md)
+
+[rand]: https://crates.io/crates/rand
+
+
+# License
+
+`rand_seeder` is distributed under the terms of both the MIT license and the
+Apache License (Version 2.0).
+
+See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.

--- a/rand_seeder/src/lib.rs
+++ b/rand_seeder/src/lib.rs
@@ -29,3 +29,75 @@ extern crate rand_core;
 mod sip;
 
 pub use sip::{SipHasher, SipRng};
+
+use core::hash::Hash;
+use rand_core::{RngCore, SeedableRng};
+
+/// A universal seeder.
+/// 
+/// `Seeder` can be used to seed any `SeedableRng` from any hashable value. It
+/// is portable and reproducible, and should turn any input into a good RNG
+/// seed. It is intended for use in simulations and games where reproducibility
+/// is important.
+/// 
+/// We do not recommend using `Seeder` for cryptographic applications and
+/// strongly advise against usage for authentication (password hashing).
+/// 
+/// Example:
+/// 
+/// ```rust
+/// # extern crate rand_core;
+/// # extern crate rand_seeder;
+/// use rand_core::RngCore;
+/// use rand_seeder::{Seeder, SipRng};
+/// 
+/// // Use any SeedableRng you like in place of SipRng:
+/// let mut rng: SipRng = Seeder::from("stripy zebra").make_rng();
+/// println!("First value: {}", rng.next_u32());
+/// ```
+#[derive(Debug, Clone)]
+pub struct Seeder {
+    rng: SipRng,
+}
+
+impl Seeder {
+    /// Construct an RNG (of type `R: SeedableRng`), seeded from the internal
+    /// `SipRng`.
+    /// 
+    /// Mutliple RNGs may be constructed using the same `Seeder`.
+    pub fn make_rng<R: SeedableRng>(&mut self) -> R {
+        let mut seed = R::Seed::default();
+        self.rng.fill_bytes(seed.as_mut());
+        R::from_seed(seed)
+    }
+}
+
+impl<H: Hash> From<H> for Seeder {
+    #[inline]
+    fn from(h: H) -> Seeder {
+        let hasher = SipHasher::from(h);
+        Seeder {
+            rng: hasher.make_rng()
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    
+    #[test]
+    fn make_seeder() {
+        let _ = Seeder::from(0u64);
+        let _ = Seeder::from("a static string");
+        let _ = Seeder::from([1u8, 2, 3]);
+    }
+    
+    #[test]
+    fn make_rng() {
+        let mut seeder = Seeder::from("test string");
+        let mut rng = seeder.make_rng::<SipRng>();
+        assert_eq!(rng.next_u64(), 7267854722795183454);
+        assert_eq!(rng.next_u64(), 602994585684902144);
+    }
+}

--- a/rand_seeder/src/lib.rs
+++ b/rand_seeder/src/lib.rs
@@ -1,0 +1,25 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// https://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! This crate provides three things:
+//! 
+//! -   a portable implementation of `SipHasher`
+//! -   `SipRng`, based around the `SipHash` state and mixing operations
+//! -   `Seeder`, a universal seeder
+
+#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
+       html_favicon_url = "https://www.rust-lang.org/favicon.ico",
+       html_root_url = "https://docs.rs/rand_seeder/0.1.0")]
+
+#![deny(missing_docs)]
+#![deny(missing_debug_implementations)]
+#![doc(test(attr(allow(unused_variables), deny(warnings))))]
+
+#![no_std]

--- a/rand_seeder/src/lib.rs
+++ b/rand_seeder/src/lib.rs
@@ -24,6 +24,8 @@
 
 #![no_std]
 
+extern crate rand_core;
+
 mod sip;
 
-pub use sip::{SipHasher};
+pub use sip::{SipHasher, SipRng};

--- a/rand_seeder/src/lib.rs
+++ b/rand_seeder/src/lib.rs
@@ -23,3 +23,7 @@
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 
 #![no_std]
+
+mod sip;
+
+pub use sip::{SipHasher};

--- a/rand_seeder/src/sip.rs
+++ b/rand_seeder/src/sip.rs
@@ -1,0 +1,375 @@
+// Copyright 2012-2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! An implementation of SipHash.
+//! 
+//! Shamelessly stolen from the Rust std lib (libcore/hash/sip.rs) and adapted.
+//! 
+//! Only the official variant, SipHash 2-4, is included. Other variants such
+//! as the reduced 1-3 (used by libstd's `DefaultHasher`) could be added easily.
+
+use core::marker::PhantomData;
+use core::{cmp, hash, mem, ptr, slice};
+
+/// A portable implementation of SipHash 2-4.
+/// 
+/// This implementation will produce 8-byte (`u64`) output compliant with the
+/// reference implementation. Additionally, it can be extended into an RNG able
+/// to produce unlimited output, `SipRng`.
+///
+/// See: <https://131002.net/siphash/>
+///
+/// SipHash is a general-purpose hashing function: it runs at a good
+/// speed (competitive with Spooky and City) and permits strong _keyed_
+/// hashing. This lets you key your hashtables from a strong RNG, such as
+/// [`rand::os::OsRng`](https://doc.rust-lang.org/rand/rand/os/struct.OsRng.html).
+///
+/// Although the SipHash algorithm is considered to be generally strong,
+/// it is not intended for cryptographic purposes. As such, all
+/// cryptographic uses of this implementation are _strongly discouraged_.
+#[derive(Debug, Clone, Default)]
+pub struct SipHasher {
+    hasher: Hasher<Sip24Rounds>,
+}
+
+#[derive(Debug)]
+struct Hasher<S: Sip> {
+    k0: u64,
+    k1: u64,
+    length: usize, // how many bytes we've processed
+    state: State, // hash State
+    tail: u64, // unprocessed bytes le
+    ntail: usize, // how many bytes in tail are valid
+    _marker: PhantomData<S>,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct State {
+    // v0, v2 and v1, v3 show up in pairs in the algorithm,
+    // and simd implementations of SipHash will use vectors
+    // of v02 and v13. By placing them in this order in the struct,
+    // the compiler can pick up on just a few simd optimizations by itself.
+    v0: u64,
+    v2: u64,
+    v1: u64,
+    v3: u64,
+}
+
+macro_rules! compress {
+    ($state:expr) => ({
+        compress!($state.v0, $state.v1, $state.v2, $state.v3)
+    });
+    ($v0:expr, $v1:expr, $v2:expr, $v3:expr) =>
+    ({
+        $v0 = $v0.wrapping_add($v1); $v1 = $v1.rotate_left(13); $v1 ^= $v0;
+        $v0 = $v0.rotate_left(32);
+        $v2 = $v2.wrapping_add($v3); $v3 = $v3.rotate_left(16); $v3 ^= $v2;
+        $v0 = $v0.wrapping_add($v3); $v3 = $v3.rotate_left(21); $v3 ^= $v0;
+        $v2 = $v2.wrapping_add($v1); $v1 = $v1.rotate_left(17); $v1 ^= $v2;
+        $v2 = $v2.rotate_left(32);
+    });
+}
+
+/// Load an u64 using up to 8 bytes of a byte slice.
+///
+/// Unsafe because: unchecked indexing at start..start+len
+#[inline]
+unsafe fn u8to64_le(buf: &[u8], start: usize, len: usize) -> u64 {
+    debug_assert!(len <= 8);
+    debug_assert!(start + len  <= buf.len());
+    let mut out = 0u64;
+    ptr::copy_nonoverlapping(buf.get_unchecked(start),
+                                &mut out as *mut u64 as *mut u8,
+                                len);
+    out.to_le()
+}
+
+impl SipHasher {
+    /// Creates a new `SipHasher` with the two initial keys set to 0.
+    #[inline]
+    pub fn new() -> Self {
+        SipHasher::new_with_keys(0, 0)
+    }
+
+    /// Creates a `SipHasher` that is keyed off the provided keys.
+    #[inline]
+    pub fn new_with_keys(key0: u64, key1: u64) -> Self {
+        SipHasher {
+            hasher: Hasher::new_with_keys(key0, key1)
+        }
+    }
+}
+
+impl<S: Sip> Hasher<S> {
+    #[inline]
+    fn new_with_keys(key0: u64, key1: u64) -> Hasher<S> {
+        let mut state = Hasher {
+            k0: key0,
+            k1: key1,
+            length: 0,
+            state: State {
+                v0: 0,
+                v1: 0,
+                v2: 0,
+                v3: 0,
+            },
+            tail: 0,
+            ntail: 0,
+            _marker: PhantomData,
+        };
+        state.reset();
+        state
+    }
+
+    #[inline]
+    fn reset(&mut self) {
+        self.length = 0;
+        self.state.v0 = self.k0 ^ 0x736f6d6570736575;
+        self.state.v1 = self.k1 ^ 0x646f72616e646f6d;
+        self.state.v2 = self.k0 ^ 0x6c7967656e657261;
+        self.state.v3 = self.k1 ^ 0x7465646279746573;
+        self.ntail = 0;
+    }
+
+    // Specialized write function that is only valid for buffers with len <= 8.
+    // It's used to force inlining of write_u8 and write_usize, those would normally be inlined
+    // except for composite types (that includes slices and str hashing because of delimiter).
+    // Without this extra push the compiler is very reluctant to inline delimiter writes,
+    // degrading performance substantially for the most common use cases.
+    #[inline]
+    fn short_write(&mut self, msg: &[u8]) {
+        debug_assert!(msg.len() <= 8);
+        let length = msg.len();
+        self.length += length;
+
+        let needed = 8 - self.ntail;
+        let fill = cmp::min(length, needed);
+        if fill == 8 {
+            self.tail = unsafe { u8to64_le(msg, 0, 8) };
+        } else {
+            self.tail |= unsafe { u8to64_le(msg, 0, fill) } << (8 * self.ntail);
+            if length < needed {
+                self.ntail += length;
+                return;
+            }
+        }
+        self.state.v3 ^= self.tail;
+        S::c_rounds(&mut self.state);
+        self.state.v0 ^= self.tail;
+
+        // Buffered tail is now flushed, process new input.
+        self.ntail = length - needed;
+        self.tail = unsafe { u8to64_le(msg, needed, self.ntail) };
+    }
+}
+
+impl hash::Hasher for SipHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.hasher.finish()
+    }
+    
+    #[inline]
+    fn write(&mut self, msg: &[u8]) {
+        self.hasher.write(msg)
+    }
+    
+    // the following default implementation is portable: write_u8
+    // all i* default implementations simply convert to u*
+    
+    // the following must be re-implemented for portability:
+    
+    #[inline]
+    fn write_u16(&mut self, i: u16) {
+        self.write(&unsafe { mem::transmute::<_, [u8; 2]>(i.to_le()) })
+    }
+    
+    #[inline]
+    fn write_u32(&mut self, i: u32) {
+        self.write(&unsafe { mem::transmute::<_, [u8; 4]>(i.to_le()) })
+    }
+    
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.write(&unsafe { mem::transmute::<_, [u8; 8]>(i.to_le()) })
+    }
+    
+    #[inline]
+    fn write_u128(&mut self, i: u128) {
+        self.write(&unsafe { mem::transmute::<_, [u8; 16]>(i.to_le()) })
+    }
+    
+    #[inline]
+    fn write_usize(&mut self, i: usize) {
+        // standardise the size for portability
+        // `u128` is big enough for most platforms
+        self.write_u128(i as u128);
+    }
+}
+
+impl<S: Sip> hash::Hasher for Hasher<S> {
+    // see short_write comment for explanation
+    #[inline]
+    fn write_usize(&mut self, i: usize) {
+        let bytes = unsafe {
+            slice::from_raw_parts(&i as *const usize as *const u8, mem::size_of::<usize>())
+        };
+        self.short_write(bytes);
+    }
+
+    // see short_write comment for explanation
+    #[inline]
+    fn write_u8(&mut self, i: u8) {
+        self.short_write(&[i]);
+    }
+
+    #[inline]
+    fn write(&mut self, msg: &[u8]) {
+        let length = msg.len();
+        self.length += length;
+
+        let mut needed = 0;
+
+        if self.ntail != 0 {
+            needed = 8 - self.ntail;
+            self.tail |= unsafe { u8to64_le(msg, 0, cmp::min(length, needed)) } << 8 * self.ntail;
+            if length < needed {
+                self.ntail += length;
+                return
+            } else {
+                self.state.v3 ^= self.tail;
+                S::c_rounds(&mut self.state);
+                self.state.v0 ^= self.tail;
+                self.ntail = 0;
+            }
+        }
+
+        // Buffered tail is now flushed, process new input.
+        let len = length - needed;
+        let left = len & 0x7;
+
+        let mut i = needed;
+        while i < len - left {
+            let mi = unsafe { u8to64_le(msg, i, 8) };
+
+            self.state.v3 ^= mi;
+            S::c_rounds(&mut self.state);
+            self.state.v0 ^= mi;
+
+            i += 8;
+        }
+
+        self.tail = unsafe { u8to64_le(msg, i, left) };
+        self.ntail = left;
+    }
+
+    /// Reduces the state to a `u64` value, as in the reference implementation.
+    #[inline]
+    fn finish(&self) -> u64 {
+        let mut state = self.state;
+
+        let b: u64 = ((self.length as u64 & 0xff) << 56) | self.tail;
+
+        state.v3 ^= b;
+        S::c_rounds(&mut state);
+        state.v0 ^= b;
+
+        state.v2 ^= 0xff;
+        S::d_rounds(&mut state);
+
+        state.v0 ^ state.v1 ^ state.v2 ^ state.v3
+    }
+}
+
+impl<H: hash::Hash> From<H> for SipHasher {
+    #[inline]
+    fn from(h: H) -> SipHasher {
+        let mut hasher = SipHasher::new();
+        h.hash(&mut hasher);
+        hasher
+    }
+}
+
+impl<S: Sip> Clone for Hasher<S> {
+    #[inline]
+    fn clone(&self) -> Hasher<S> {
+        Hasher {
+            k0: self.k0,
+            k1: self.k1,
+            length: self.length,
+            state: self.state,
+            tail: self.tail,
+            ntail: self.ntail,
+            _marker: self._marker,
+        }
+    }
+}
+
+impl<S: Sip> Default for Hasher<S> {
+    /// Creates a `Hasher<S>` with the two initial keys set to 0.
+    #[inline]
+    fn default() -> Hasher<S> {
+        Hasher::new_with_keys(0, 0)
+    }
+}
+
+#[doc(hidden)]
+trait Sip {
+    fn c_rounds(_: &mut State);
+    fn d_rounds(_: &mut State);
+}
+
+#[derive(Debug, Clone, Default)]
+struct Sip24Rounds;
+
+impl Sip for Sip24Rounds {
+    #[inline]
+    fn c_rounds(state: &mut State) {
+        compress!(state);
+        compress!(state);
+    }
+
+    #[inline]
+    fn d_rounds(state: &mut State) {
+        compress!(state);
+        compress!(state);
+        compress!(state);
+        compress!(state);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::hash::Hasher;
+    use super::*;
+    
+    #[test]
+    fn test_hash_vectors() {
+        let k_bytes = [0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+        let (k0, k1) = unsafe{ (u8to64_le(&k_bytes, 0, 8), u8to64_le(&k_bytes, 8, 8)) };
+        
+        let mut msg = [0u8; 64];
+        for (pos, i) in msg.iter_mut().zip(0u8..64) {
+            *pos = i;
+        }
+        
+        // From reference vectors, converted to u64:
+        let tests = [(0, 0x726fdb47dd0e0e31),
+                     (1, 0x74f839c593dc67fd),
+                     (63, 0x958a324ceb064572)];
+        
+        for (len, val) in &tests {
+            let mut hasher = SipHasher::new_with_keys(k0, k1);
+            hasher.write(&msg[0..*len]);
+            assert_eq!(hasher.finish(), *val, "mismatch with reference vector for i={}", *len);
+        }
+    }
+}


### PR DESCRIPTION
This is much more powerful than `seed_from_u64` (#537).

```rust
let mut rng = Seeder::from("stripy zebra").make_rng::<XorShiftRng>()
```

[`SipRng` code](https://github.com/dhardy/rand/blob/seeder/rand_sip/src/sip.rs#L146)

SipHash is a keyed hash function optimised for speed on short messages. I adapted this to support unlimited length output with `SipRng`.

Quality should be roughly crypto-grade, though I haven't attempted any kind of crypto-analysis and would not like to bet on the strength without at least some further review.

Unsurprisingly, PractRand hasn't picked up any issues (two "unusual" items under 64 GiB on this run, none up to 128 GiB with a slightly different construction).

Performance is reasonable though of course not close to fast RNGs (I didn't bother using caching for `next_u32` here; for seeding at least it's not useful):
```
test gen_bytes_sip         ... bench:     701,138 ns/iter (+/- 15,817) = 1460 MB/s
test gen_u32_sip           ... bench:       5,167 ns/iter (+/- 145) = 774 MB/s
test gen_u64_sip           ... bench:       5,212 ns/iter (+/- 98) = 1534 MB/s
test init_sip              ... bench:          25 ns/iter (+/- 1)
# for comparison:
test gen_bytes_hc128       ... bench:     448,607 ns/iter (+/- 35,948) = 2282 MB/s
test gen_u32_hc128         ... bench:       2,196 ns/iter (+/- 214) = 1821 MB/s
test gen_u64_hc128         ... bench:       3,938 ns/iter (+/- 240) = 2031 MB/s
test init_hc128            ... bench:       4,863 ns/iter (+/- 382)
test gen_bytes_xorshift    ... bench:     298,913 ns/iter (+/- 8,830) = 3425 MB/s
test gen_u32_xorshift      ... bench:       1,206 ns/iter (+/- 54) = 3316 MB/s
test gen_u64_xorshift      ... bench:       1,804 ns/iter (+/- 107) = 4434 MB/s
test init_xorshift         ... bench:          13 ns/iter (+/- 0)
```
For the intended usage, seeding other RNGs, this performance is perfectly adequate.

Note that the `Seeder` type is mostly for convenience. We could just recommend using `from_rng`, *except* that this method is currently documented as not being value-stable (which thus defeats the whole point of this code).

I may still make some tweaks to this, but so far it looks quite nice to me. Comments welcome.