### PR TITLE
ThreadRng / EntropyRng improvements

### DIFF
--- a/src/rngs/mod.rs
+++ b/src/rngs/mod.rs
@@ -175,7 +175,7 @@ mod std;
 
 
 pub use self::jitter::{JitterRng, TimerError};
-#[cfg(feature="std")] pub use self::entropy::EntropyRng;
+#[cfg(feature="std")] pub use self::entropy::{EntropyRng, CustomEntropySource, set_custom_entropy};
 
 pub use self::small::SmallRng;
 pub use self::std::StdRng;


### PR DESCRIPTION
- Remove usage of Rc from `ThreadRng` (#463 and ??) — I think we only didn't do this before because of safety concerns, but (1) use of raw pointers [automatically implies the type is neither send nor sync](https://doc.rust-lang.org/nomicon/send-and-sync.html), (2) `thread_local` instantiates automatically so there is always a valid object and (3) none of the types involved implement `Drop`
- Clean up `EntropyRng` a little (working towards #313)
- Add `set_custom_entropy` function

~~Next step: allow custom entropy source. Unfortunately the `EntropySource` trait is still not good enough for run-time injection because the size & alignment of instances is unknown (it would be nice if this could be enforced somehow).~~