### PR TITLE
Speed up Uniform Duration sampling.

### DIFF
--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -106,11 +106,13 @@ distr_int!(distr_uniform_i128, i128, Uniform::new(-123_456_789_123i128, 123_456_
 distr_float!(distr_uniform_f32, f32, Uniform::new(2.26f32, 2.319));
 distr_float!(distr_uniform_f64, f64, Uniform::new(2.26f64, 2.319));
 
+const LARGE_SEC: u64 = u64::max_value() / 1000;
+
 distr_duration!(distr_uniform_duration_largest,
     Uniform::new_inclusive(Duration::new(0, 0), Duration::new(u64::max_value(), 999_999_999))
 );
 distr_duration!(distr_uniform_duration_large,
-    Uniform::new(Duration::new(0, 0), Duration::new(u64::max_value() / 1000, 1_000_000_000 / 2))
+    Uniform::new(Duration::new(0, 0), Duration::new(LARGE_SEC, 1_000_000_000 / 2))
 );
 distr_duration!(distr_uniform_duration_one,
     Uniform::new(Duration::new(0, 0), Duration::new(1, 0))
@@ -119,7 +121,7 @@ distr_duration!(distr_uniform_duration_variety,
     Uniform::new(Duration::new(10000, 423423), Duration::new(200000, 6969954))
 );
 distr_duration!(distr_uniform_duration_edge,
-    Uniform::new_inclusive(Duration::new(u64::max_value() / 10, 999_999_999), Duration::new((u64::max_value() / 10) + 1, 0))
+    Uniform::new_inclusive(Duration::new(LARGE_SEC, 999_999_999), Duration::new(LARGE_SEC + 1, 1))
 );
 
 

--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -106,10 +106,21 @@ distr_int!(distr_uniform_i128, i128, Uniform::new(-123_456_789_123i128, 123_456_
 distr_float!(distr_uniform_f32, f32, Uniform::new(2.26f32, 2.319));
 distr_float!(distr_uniform_f64, f64, Uniform::new(2.26f64, 2.319));
 
-distr_duration!(distr_uniform_duration_largest, Uniform::new(Duration::new(0, 0), Duration::new(u64::max_value(), 999_999_999)));
-distr_duration!(distr_uniform_duration_large, Uniform::new(Duration::new(0, 0), Duration::new(u64::max_value()/1000, 1_000_000_000/2)));
-distr_duration!(distr_uniform_duration_one, Uniform::new(Duration::new(0, 0), Duration::new(1, 0)));
-distr_duration!(distr_uniform_duration_variety, Uniform::new(Duration::new(10000, 423423), Duration::new(200000, 6969954)));
+distr_duration!(distr_uniform_duration_largest,
+    Uniform::new_inclusive(Duration::new(0, 0), Duration::new(u64::max_value(), 999_999_999))
+);
+distr_duration!(distr_uniform_duration_large,
+    Uniform::new(Duration::new(0, 0), Duration::new(u64::max_value() / 1000, 1_000_000_000 / 2))
+);
+distr_duration!(distr_uniform_duration_one,
+    Uniform::new(Duration::new(0, 0), Duration::new(1, 0))
+);
+distr_duration!(distr_uniform_duration_variety,
+    Uniform::new(Duration::new(10000, 423423), Duration::new(200000, 6969954))
+);
+distr_duration!(distr_uniform_duration_edge,
+    Uniform::new_inclusive(Duration::new(u64::max_value() / 10, 999_999_999), Duration::new((u64::max_value() / 10) + 1, 0))
+);
 
 
 // standard

--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -9,6 +9,7 @@ const RAND_BENCH_N: u64 = 1000;
 
 use std::mem::size_of;
 use test::Bencher;
+use std::time::Duration;
 
 use rand::{Rng, FromEntropy};
 use rand::rngs::SmallRng;
@@ -54,6 +55,26 @@ macro_rules! distr_float {
     }
 }
 
+macro_rules! distr_duration {
+    ($fnn:ident, $distr:expr) => {
+        #[bench]
+        fn $fnn(b: &mut Bencher) {
+            let mut rng = SmallRng::from_entropy();
+            let distr = $distr;
+
+            b.iter(|| {
+                let mut accum = Duration::new(0, 0);
+                for _ in 0..::RAND_BENCH_N {
+                    let x: Duration = distr.sample(&mut rng);
+                    accum = accum.checked_add(x).unwrap_or(Duration::new(u64::max_value(), 999_999_999));
+                }
+                accum
+            });
+            b.bytes = size_of::<Duration>() as u64 * ::RAND_BENCH_N;
+        }
+    }
+}
+
 macro_rules! distr {
     ($fnn:ident, $ty:ty, $distr:expr) => {
         #[bench]
@@ -84,6 +105,12 @@ distr_int!(distr_uniform_i128, i128, Uniform::new(-123_456_789_123i128, 123_456_
 
 distr_float!(distr_uniform_f32, f32, Uniform::new(2.26f32, 2.319));
 distr_float!(distr_uniform_f64, f64, Uniform::new(2.26f64, 2.319));
+
+distr_duration!(distr_uniform_duration_largest, Uniform::new(Duration::new(0, 0), Duration::new(u64::max_value(), 999_999_999)));
+distr_duration!(distr_uniform_duration_large, Uniform::new(Duration::new(0, 0), Duration::new(u64::max_value()/1000, 1_000_000_000/2)));
+distr_duration!(distr_uniform_duration_one, Uniform::new(Duration::new(0, 0), Duration::new(1, 0)));
+distr_duration!(distr_uniform_duration_variety, Uniform::new(Duration::new(10000, 423423), Duration::new(200000, 6969954)));
+
 
 // standard
 distr_int!(distr_standard_i8, i8, Standard);

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -751,9 +751,6 @@ impl UniformSampler for UniformDuration {
         if high_n < low_n {
             high_s = high_s - 1;
             high_n = high_n + 1_000_000_000;
-        } else {
-            high_s = high_s;
-            high_n = high_n;
         }
 
         let mode = if low_s == high_s {

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -693,7 +693,6 @@ uniform_float_impl! { f64x8, u64x8, f64, u64, 64 - 52 }
 #[cfg(feature = "std")]
 #[derive(Clone, Copy, Debug)]
 pub struct UniformDuration {
-    offset: Duration,
     mode: UniformDurationMode,
 }
 
@@ -701,10 +700,17 @@ pub struct UniformDuration {
 #[derive(Debug, Copy, Clone)]
 enum UniformDurationMode {
     Small {
+        secs: u64,
+        nanos: Uniform<u32>,
+    },
+    Medium {
         nanos: Uniform<u64>,
     },
     Large {
-        size: Duration,
+        min_secs: u64,
+        min_nanos: u32,
+        max_secs: u64,
+        max_nanos: u32,
         secs: Uniform<u64>,
     }
 }
@@ -737,52 +743,65 @@ impl UniformSampler for UniformDuration {
         let low = *low_b.borrow();
         let high = *high_b.borrow();
         assert!(low <= high, "Uniform::new_inclusive called with `low > high`");
-        let size = high - low;
-        let nanos = size
-            .as_secs()
-            .checked_mul(1_000_000_000)
-            .and_then(|n| n.checked_add(size.subsec_nanos() as u64));
+        
+        let low_s = low.as_secs();
+        let low_n = low.subsec_nanos();
+        let high_s = high.as_secs();
+        let high_n = high.subsec_nanos();
 
-        let mode = match nanos {
-            Some(nanos) => {
-                UniformDurationMode::Small {
-                    nanos: Uniform::new_inclusive(0, nanos),
-                }
+        let mode = if low_s == high_s {
+            UniformDurationMode::Small {
+                secs: low_s,
+                nanos: Uniform::new_inclusive(low_n, high_n),
             }
-            None => {
+        } else {
+            let max = high_s
+                .checked_mul(1_000_000_000)
+                .and_then(|n| n.checked_add(high_n as u64));
+
+            if let Some(higher_bound) = max {
+                let lower_bound = low_s * 1_000_000_000 + low_n as u64;
+                UniformDurationMode::Medium {
+                    nanos: Uniform::new_inclusive(lower_bound, higher_bound),
+                }
+            } else {
                 UniformDurationMode::Large {
-                    size: size,
-                    secs: Uniform::new_inclusive(0, size.as_secs()),
+                    min_secs: low_s,
+                    min_nanos: low_n,
+                    max_secs: high_s,
+                    max_nanos: high_n,
+                    secs: Uniform::new_inclusive(low_s, high_s),
                 }
             }
         };
-
         UniformDuration {
-            mode,
-            offset: low,
+            mode
         }
     }
 
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Duration {
-        let d = match self.mode {
-            UniformDurationMode::Small { nanos } => {
+        match self.mode {
+            UniformDurationMode::Small { secs, nanos } => {
+                let n = nanos.sample(rng);
+                Duration::new(secs, n)
+            }
+            UniformDurationMode::Medium { nanos } => {
                 let nanos = nanos.sample(rng);
                 Duration::new(nanos / 1_000_000_000, (nanos % 1_000_000_000) as u32)
             }
-            UniformDurationMode::Large { size, secs } => {
+            UniformDurationMode::Large { min_secs, min_nanos, max_secs, max_nanos, secs } => {
                 // constant folding means this is at least as fast as `gen_range`
                 let nano_range = Uniform::new(0, 1_000_000_000);
                 loop {
-                    let d = Duration::new(secs.sample(rng), nano_range.sample(rng));
-                    if d <= size {
-                        break d;
+                    let s = secs.sample(rng);
+                    let n = nano_range.sample(rng);
+                    if !((s == max_secs && n > max_nanos) || (s == min_secs && n < min_nanos))  {
+                        break Duration::new(s, n);
                     }
                 }
             }
-        };
-
-        self.offset + d
+        }
     }
 }
 


### PR DESCRIPTION
These changes speed up the process of sampling Durations from a uniform distribution primarily by avoiding two expensive operations:
- Creating a Duration (now only done once per sample call)
- Addition of Durations (now never done)

I also added some simple benchmarks to measure these changes.
Before:
```
test distr_uniform_duration_large   ... bench:      13,007 ns/iter (+/- 189) = 1230 MB/s
test distr_uniform_duration_largest ... bench:       9,263 ns/iter (+/- 136) = 1727 MB/s
test distr_uniform_duration_one     ... bench:      12,346 ns/iter (+/- 353) = 1295 MB/s
test distr_uniform_duration_variety ... bench:      12,371 ns/iter (+/- 130) = 1293 MB/s
```
After:
```
test distr_uniform_duration_large   ... bench:      12,523 ns/iter (+/- 41) = 1277 MB/s
test distr_uniform_duration_largest ... bench:       8,395 ns/iter (+/- 102) = 1905 MB/s
test distr_uniform_duration_one     ... bench:       9,907 ns/iter (+/- 422) = 1615 MB/s
test distr_uniform_duration_variety ... bench:      10,504 ns/iter (+/- 90) = 1523 MB/s
```
To really avoid any regressions, I also used a more comprehensive benchmark. 
The code for those benchmarks (rust to bench and python to graph) can be found [here](https://gist.github.com/Pazzaz/91aa3c475ead8096daae2f0d7af7574b).
<details> <summary>Comprehensive Benchmark Results</summary>


In these heatmaps, the x axis is the upper bound and the y axis is the lower bound. 800 different Durations were used, ranging from 0s to 18446744074.7095512s, in order.
The z-value is the average number of nanoseconds it took to sample from the corresponding distribution. 
Before:

![screenshot from 2018-08-04 21-16-25](https://user-images.githubusercontent.com/16006944/43688562-7d46ecb8-98eb-11e8-84a8-23927f4ca933.png)

After:
![screenshot from 2018-08-04 21-16-36](https://user-images.githubusercontent.com/16006944/43688563-7d5d8f40-98eb-11e8-9f51-fd350d260551.png)
Percentage of improvement:
![screenshot from 2018-08-05 21-58-40](https://user-images.githubusercontent.com/16006944/43689424-cf66fb46-98fa-11e8-8f61-6d7b501ff8bd.png)
Zoomed in:
![screenshot from 2018-08-04 21-15-40](https://user-images.githubusercontent.com/16006944/43688561-7d2d6fa4-98eb-11e8-8e90-803f30bcce9b.png)
So about a 10-20% improvement and the values outside of that range seem to be just noise.
</details>

Edit: changed a call to `Duration::from_nanos` to `Duration::new(nanos / 1_000_000_000, (nanos % 1_000_000_000) as u32)` for compatibility with older rust versions. Shouldn't make much of a difference but the benchmark can be rerun.