### PR TITLE
os.rs: fix wrong syscall number for PowerPC

### DIFF
--- a/src/os.rs
+++ b/src/os.rs
@@ -102,7 +102,7 @@ mod imp {
         #[cfg(target_arch = "aarch64")]
         const NR_GETRANDOM: libc::c_long = 278;
         #[cfg(target_arch = "powerpc")]
-        const NR_GETRANDOM: libc::c_long = 384;
+        const NR_GETRANDOM: libc::c_long = 359;
 
         unsafe {
             syscall(NR_GETRANDOM, buf.as_mut_ptr(), buf.len(), 0)


### PR DESCRIPTION
`__NR_getrandom` is 359 on PowerPC, added from torvalds/linux@7d59deb50aa v3.17-rc5.
The bug was introduced from 05f23d275 3 years ago, affecting from *0.1.1* to before *0.5.0-pre.0*.
It has already been fixed on the 0.5 branch at 00713a61c so this is a backport.