### PR TITLE
impl<R: RngCore> RngCore for Rc<RefCell<R>>

### DIFF
--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -388,6 +388,32 @@ impl<R: RngCore + ?Sized> RngCore for Box<R> {
     }
 }
 
+// Implement `RngCore` for Rc<RefCell<..>> references to a `RngCore`.
+// Force inlining all functions, so that it is up to the `RngCore`
+// implementation and the optimizer to decide on inlining.
+#[cfg(feature="std")]
+impl<R: RngCore> RngCore for ::std::rc::Rc<::std::cell::RefCell<R>> {
+    #[inline(always)]
+    fn next_u32(&mut self) -> u32 {
+        self.borrow_mut().next_u32()
+    }
+
+    #[inline(always)]
+    fn next_u64(&mut self) -> u64 {
+        self.borrow_mut().next_u64()
+    }
+
+    #[inline(always)]
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.borrow_mut().fill_bytes(dest)
+    }
+
+    #[inline(always)]
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        self.borrow_mut().try_fill_bytes(dest)
+    }
+}
+
 #[cfg(feature="std")]
 impl std::io::Read for RngCore {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error> {

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -391,8 +391,12 @@ impl<R: RngCore + ?Sized> RngCore for Box<R> {
 // Implement `RngCore` for Rc<RefCell<..>> references to a `RngCore`.
 // Force inlining all functions, so that it is up to the `RngCore`
 // implementation and the optimizer to decide on inlining.
-#[cfg(feature="std")]
-impl<R: RngCore> RngCore for ::std::rc::Rc<::std::cell::RefCell<R>> {
+//
+// We do not actually use `Rc` here because it requires `std` but its
+// `Deref` should make this suffice, and this can be used on the stack.
+// #[cfg(feature="std")]
+// impl<R: RngCore> RngCore for ::std::rc::Rc<::std::cell::RefCell<R>> {
+impl<'a,R: RngCore> RngCore for &'a ::core::cell::RefCell<R> {
     #[inline(always)]
     fn next_u32(&mut self) -> u32 {
         self.borrow_mut().next_u32()


### PR DESCRIPTION
I'd think `RefCell` adjusting its borrow counter sounds more cache friendly than forking `Rng`s.  We should check various details, like if `Rc` needs only `alloc`, not `std`.  

We cannot avoid `RefCell` by using `UnsafeCell`, etc. here because we cannot prevent user supplied methods like `next_u32` from referencing us again.  See the [the `Copy` requirement](https://github.com/rust-lang/rust/issues/50186) on [Cell::update](https://doc.rust-lang.org/std/cell/struct.Cell.html#method.update). 

I've tried to permit users to bypass the `Rc` counter and allocation when possible by instead providing, which should still support `Rc<RefCell<R>` via `Rc: Deref`.
```
impl<'a,R: RngCore> RngCore for &'a ::core::cell::RefCell<R>
```