### PR TITLE
Fix simd_support (stable and nightly)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,9 +57,8 @@ sudo: false
 #   `cargo test --package rand_isaac --features=serde1`
 #   `cargo test --package rand_xorshift --features=serde1`
 # 
-# TODO: SIMD support
-# All tests using packed_simd are disabled for now due to general instability
-# of the crate (both releases and the git tree failing on nightly and stable).
+# TODO: SIMD support on stable releases
+# NOTE: SIMD support is unreliable on nightly; we track the latest release
 matrix:
   include:
     - rust: 1.22.0
@@ -112,8 +111,7 @@ matrix:
         - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
       script:
         - cargo test --lib --no-default-features --features=alloc
-        # TODO: use --all-features once simd_support is sufficiently stable:
-        - cargo test --features=serde1,log
+        - cargo test --all-features
         - cargo test --benches --features=nightly
         - cargo test --examples
         - cargo test --package rand_core
@@ -158,13 +156,12 @@ matrix:
         - rustup target add x86_64-unknown-netbsd
         - rustup target add x86_64-unknown-redox
       script:
-        # TODO: use --all-features once simd_support is sufficiently stable:
-        - cargo build --target=x86_64-sun-solaris --features=serde1,log
-        - cargo build --target=x86_64-unknown-cloudabi --features=serde1,log
-        - cargo build --target=x86_64-unknown-freebsd --features=serde1,log
-        #- cargo build --target=x86_64-unknown-fuchsia --features=serde1,log
-        - cargo build --target=x86_64-unknown-netbsd --features=serde1,log
-        - cargo build --target=x86_64-unknown-redox --features=serde1,log
+        - cargo build --target=x86_64-sun-solaris --all-features
+        - cargo build --target=x86_64-unknown-cloudabi --all-features
+        - cargo build --target=x86_64-unknown-freebsd --all-features
+        #- cargo build --target=x86_64-unknown-fuchsia --all-features
+        - cargo build --target=x86_64-unknown-netbsd --all-features
+        - cargo build --target=x86_64-unknown-redox --all-features
 
     # Trust cross-built/emulated targets. We must repeat all non-default values.
     - rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ matrix:
       script:
         - cargo test --lib --no-default-features
         # TODO: add simd_support feature:
-        - cargo test --features=serde1,log,i128_support
+        - cargo test --features=serde1,log
         - cargo test --examples
         - cargo test --package rand_core
         - cargo test --package rand_core --no-default-features
@@ -96,7 +96,7 @@ matrix:
       script:
         - cargo test --lib --no-default-features
         # TODO: add simd_support feature:
-        - cargo test --features=serde1,log,i128_support
+        - cargo test --features=serde1,log
         - cargo test --examples
         - cargo test --package rand_core
         - cargo test --package rand_core --no-default-features
@@ -113,7 +113,7 @@ matrix:
       script:
         - cargo test --lib --no-default-features --features=alloc
         # TODO: use --all-features once simd_support is sufficiently stable:
-        - cargo test --features=serde1,log,i128_support
+        - cargo test --features=serde1,log
         - cargo test --benches --features=nightly
         - cargo test --examples
         - cargo test --package rand_core
@@ -159,12 +159,12 @@ matrix:
         - rustup target add x86_64-unknown-redox
       script:
         # TODO: use --all-features once simd_support is sufficiently stable:
-        - cargo build --target=x86_64-sun-solaris --features=serde1,log,i128_support
-        - cargo build --target=x86_64-unknown-cloudabi --features=serde1,log,i128_support
-        - cargo build --target=x86_64-unknown-freebsd --features=serde1,log,i128_support
-        #- cargo build --target=x86_64-unknown-fuchsia --features=serde1,log,i128_support
-        - cargo build --target=x86_64-unknown-netbsd --features=serde1,log,i128_support
-        - cargo build --target=x86_64-unknown-redox --features=serde1,log,i128_support
+        - cargo build --target=x86_64-sun-solaris --features=serde1,log
+        - cargo build --target=x86_64-unknown-cloudabi --features=serde1,log
+        - cargo build --target=x86_64-unknown-freebsd --features=serde1,log
+        #- cargo build --target=x86_64-unknown-fuchsia --features=serde1,log
+        - cargo build --target=x86_64-unknown-netbsd --features=serde1,log
+        - cargo build --target=x86_64-unknown-redox --features=serde1,log
 
     # Trust cross-built/emulated targets. We must repeat all non-default values.
     - rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,10 @@ sudo: false
 #   `cargo test --package rand_core --no-default-features`
 #   `cargo test --package rand_isaac --features=serde1`
 #   `cargo test --package rand_xorshift --features=serde1`
+# 
+# TODO: SIMD support
+# All tests using packed_simd are disabled for now due to general instability
+# of the crate (both releases and the git tree failing on nightly and stable).
 matrix:
   include:
     - rust: 1.22.0
@@ -77,6 +81,7 @@ matrix:
         - rustup target add aarch64-apple-ios
       script:
         - cargo test --lib --no-default-features
+        # TODO: add simd_support feature:
         - cargo test --features=serde1,log,i128_support
         - cargo test --examples
         - cargo test --package rand_core
@@ -90,6 +95,7 @@ matrix:
       install:
       script:
         - cargo test --lib --no-default-features
+        # TODO: add simd_support feature:
         - cargo test --features=serde1,log,i128_support
         - cargo test --examples
         - cargo test --package rand_core
@@ -106,7 +112,8 @@ matrix:
         - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
       script:
         - cargo test --lib --no-default-features --features=alloc
-        - cargo test --all-features
+        # TODO: use --all-features once simd_support is sufficiently stable:
+        - cargo test --features=serde1,log,i128_support
         - cargo test --benches --features=nightly
         - cargo test --examples
         - cargo test --package rand_core
@@ -151,12 +158,13 @@ matrix:
         - rustup target add x86_64-unknown-netbsd
         - rustup target add x86_64-unknown-redox
       script:
-        - cargo build --target=x86_64-sun-solaris --all-features
-        - cargo build --target=x86_64-unknown-cloudabi --all-features
-        - cargo build --target=x86_64-unknown-freebsd --all-features
-        #- cargo build --target=x86_64-unknown-fuchsia --all-features
-        - cargo build --target=x86_64-unknown-netbsd --all-features
-        - cargo build --target=x86_64-unknown-redox --all-features
+        # TODO: use --all-features once simd_support is sufficiently stable:
+        - cargo build --target=x86_64-sun-solaris --features=serde1,log,i128_support
+        - cargo build --target=x86_64-unknown-cloudabi --features=serde1,log,i128_support
+        - cargo build --target=x86_64-unknown-freebsd --features=serde1,log,i128_support
+        #- cargo build --target=x86_64-unknown-fuchsia --features=serde1,log,i128_support
+        - cargo build --target=x86_64-unknown-netbsd --features=serde1,log,i128_support
+        - cargo build --target=x86_64-unknown-redox --features=serde1,log,i128_support
 
     # Trust cross-built/emulated targets. We must repeat all non-default values.
     - rust: stable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,6 @@ benchmark results in the PR (or to report nothing's changed).
 ```sh
 # Benchmarks (requires nightly)
 cargo bench
-# Some benchmarks have a faster path with i128_support
+# Potentially nightly features allow different code paths
 cargo bench --features=nightly
 ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ log = { version = "0.4", optional = true }
 
 [dependencies.packed_simd]
 # NOTE: so far no version works reliably due to dependence on unstable features
-version = "0.2"
+version = "0.3"
 # git = "https://github.com/rust-lang-nursery/packed_simd"
 optional = true
 features = ["into_bits"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,13 @@ rand_core = { path = "rand_core", version = "0.2", default-features = false }
 rand_isaac = { path = "rand_isaac", version = "0.1" }
 rand_xorshift = { path = "rand_xorshift", version = "0.1" }
 log = { version = "0.4", optional = true }
-packed_simd = { version = "0.1", optional = true, features = ["into_bits"] }
+
+[dependencies.packed_simd]
+# NOTE: so far no version works reliably due to dependence on unstable features
+version = "0.2"
+# git = "https://github.com/rust-lang-nursery/packed_simd"
+optional = true
+features = ["into_bits"]
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,8 @@ build: false
 
 test_script:
   - cargo test --lib --no-default-features --features alloc
-  - cargo test --all-features
+  # TODO: use --all-features once simd_support is sufficiently stable:
+  - cargo test --features=serde1,log,i128_support
   - cargo test --benches --features=nightly
   - cargo test --examples
   - cargo test --package rand_core

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ build: false
 test_script:
   - cargo test --lib --no-default-features --features alloc
   # TODO: use --all-features once simd_support is sufficiently stable:
-  - cargo test --features=serde1,log,i128_support
+  - cargo test --features=serde1,log
   - cargo test --benches --features=nightly
   - cargo test --examples
   - cargo test --package rand_core

--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -7,8 +7,6 @@
 // except according to those terms.
 
 #![feature(test)]
-#![cfg_attr(all(feature="i128_support", feature="nightly"), allow(stable_features))] // stable since 2018-03-27
-#![cfg_attr(all(feature="i128_support", feature="nightly"), feature(i128_type, i128))]
 
 extern crate test;
 extern crate rand;
@@ -108,7 +106,6 @@ distr_int!(distr_uniform_i8, i8, Uniform::new(20i8, 100));
 distr_int!(distr_uniform_i16, i16, Uniform::new(-500i16, 2000));
 distr_int!(distr_uniform_i32, i32, Uniform::new(-200_000_000i32, 800_000_000));
 distr_int!(distr_uniform_i64, i64, Uniform::new(3i64, 123_456_789_123));
-#[cfg(feature = "i128_support")]
 distr_int!(distr_uniform_i128, i128, Uniform::new(-123_456_789_123i128, 123_456_789_123_456_789));
 
 distr_float!(distr_uniform_f32, f32, Uniform::new(2.26f32, 2.319));
@@ -138,7 +135,6 @@ distr_int!(distr_standard_i8, i8, Standard);
 distr_int!(distr_standard_i16, i16, Standard);
 distr_int!(distr_standard_i32, i32, Standard);
 distr_int!(distr_standard_i64, i64, Standard);
-#[cfg(feature = "i128_support")]
 distr_int!(distr_standard_i128, i128, Standard);
 
 distr!(distr_standard_bool, bool, Standard);
@@ -195,7 +191,6 @@ gen_range_int!(gen_range_i8, i8, -20i8, 100);
 gen_range_int!(gen_range_i16, i16, -500i16, 2000);
 gen_range_int!(gen_range_i32, i32, -200_000_000i32, 800_000_000);
 gen_range_int!(gen_range_i64, i64, 3i64, 123_456_789_123);
-#[cfg(feature = "i128_support")]
 gen_range_int!(gen_range_i128, i128, -12345678901234i128, 123_456_789_123_456_789);
 
 // construct and sample from a floating-point range

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -481,7 +481,7 @@ uniform_int_impl! { usize, isize, usize, isize, usize }
 #[cfg(rust_1_26)]
 uniform_int_impl! { u128, u128, u128, i128, u128 }
 
-#[cfg(feature = "simd_support")]
+#[cfg(all(feature = "simd_support", feature = "nightly"))]
 macro_rules! uniform_simd_int_impl {
     ($ty:ident, $unsigned:ident, $u_scalar:ident) => {
         // The "pick the largest zone that can fit in an `u32`" optimization
@@ -588,7 +588,7 @@ macro_rules! uniform_simd_int_impl {
     };
 }
 
-#[cfg(feature = "simd_support")]
+#[cfg(all(feature = "simd_support", feature = "nightly"))]
 uniform_simd_int_impl! {
     (u64x2, i64x2),
     (u64x4, i64x4),
@@ -596,7 +596,7 @@ uniform_simd_int_impl! {
     u64
 }
 
-#[cfg(feature = "simd_support")]
+#[cfg(all(feature = "simd_support", feature = "nightly"))]
 uniform_simd_int_impl! {
     (u32x2, i32x2),
     (u32x4, i32x4),
@@ -605,7 +605,7 @@ uniform_simd_int_impl! {
     u32
 }
 
-#[cfg(feature = "simd_support")]
+#[cfg(all(feature = "simd_support", feature = "nightly"))]
 uniform_simd_int_impl! {
     (u16x2, i16x2),
     (u16x4, i16x4),
@@ -615,7 +615,7 @@ uniform_simd_int_impl! {
     u16
 }
 
-#[cfg(feature = "simd_support")]
+#[cfg(all(feature = "simd_support", feature = "nightly"))]
 uniform_simd_int_impl! {
     (u8x2, i8x2),
     (u8x4, i8x4),
@@ -1054,7 +1054,7 @@ mod tests {
         #[cfg(rust_1_26)]
         t!(i128, u128);
 
-        #[cfg(feature = "simd_support")]
+        #[cfg(all(feature = "simd_support", feature = "nightly"))]
         {
             t!(u8x2, u8x4, u8x8, u8x16, u8x32, u8x64 => u8);
             t!(i8x2, i8x4, i8x8, i8x16, i8x32, i8x64 => i8);

--- a/src/distributions/utils.rs
+++ b/src/distributions/utils.rs
@@ -148,7 +148,7 @@ wmul_impl_usize! { u32 }
 #[cfg(target_pointer_width = "64")]
 wmul_impl_usize! { u64 }
 
-#[cfg(feature = "simd_support")]
+#[cfg(all(feature = "simd_support", feature = "nightly"))]
 mod simd_wmul {
     #[cfg(target_arch = "x86")]
     use core::arch::x86::*;
@@ -215,7 +215,7 @@ mod simd_wmul {
     wmul_impl_large! { (u32x16,) u32, 16 }
     wmul_impl_large! { (u64x2, u64x4, u64x8,) u64, 32 }
 }
-#[cfg(feature = "simd_support")]
+#[cfg(all(feature = "simd_support", feature = "nightly"))]
 pub use self::simd_wmul::*;
 
 

--- a/utils/ci/script.sh
+++ b/utils/ci/script.sh
@@ -22,7 +22,7 @@ main() {
         cross test --package rand_xorshift --features=serde1 --target $TARGET
     else    # have stable Rust
         cross test --lib --no-default-features --target $TARGET
-        cross test --features=serde1,log,i128_support --target $TARGET
+        cross test --features=serde1,log --target $TARGET
         cross test --examples --target $TARGET
         cross test --package rand_core --target $TARGET
         cross test --package rand_core --no-default-features --target $TARGET


### PR DESCRIPTION
Stable: disable code requiring nightly features
Nightly: use packed_simd from git because of frequent breakage

This also adds CI tests for stable SIMD usage since there weren't any.