### PR TITLE
Define NR_GETRANDOM for additional architectures

### DIFF
--- a/src/rngs/os.rs
+++ b/src/rngs/os.rs
@@ -407,6 +407,8 @@ mod imp {
     const NR_GETRANDOM: libc::c_long = 349;
     #[cfg(target_arch = "powerpc")]
     const NR_GETRANDOM: libc::c_long = 359;
+    #[cfg(target_arch = "powerpc64")]
+    const NR_GETRANDOM: libc::c_long = 359;
     #[cfg(target_arch = "mips")] // old ABI
     const NR_GETRANDOM: libc::c_long = 4353;
     #[cfg(target_arch = "mips64")]
@@ -414,7 +416,8 @@ mod imp {
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86",
                   target_arch = "arm", target_arch = "aarch64",
                   target_arch = "s390x", target_arch = "powerpc",
-                  target_arch = "mips", target_arch = "mips64")))]
+                  target_arch = "powerpc64", target_arch = "mips",
+                  target_arch = "mips64")))]
     const NR_GETRANDOM: libc::c_long = 0;
 
     fn getrandom(buf: &mut [u8], blocking: bool) -> libc::c_long {

--- a/src/rngs/os.rs
+++ b/src/rngs/os.rs
@@ -415,11 +415,14 @@ mod imp {
     const NR_GETRANDOM: libc::c_long = 5313;
     #[cfg(target_arch = "sparc")]
     const NR_GETRANDOM: libc::c_long = 347;
+    #[cfg(target_arch = "sparc64")]
+    const NR_GETRANDOM: libc::c_long = 347;
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86",
                   target_arch = "arm", target_arch = "aarch64",
                   target_arch = "s390x", target_arch = "powerpc",
                   target_arch = "powerpc64", target_arch = "mips",
-                  target_arch = "mips64", target_arch = "sparc")))]
+                  target_arch = "mips64", target_arch = "sparc",
+                  target_arch = "sparc64")))]
     const NR_GETRANDOM: libc::c_long = 0;
 
     fn getrandom(buf: &mut [u8], blocking: bool) -> libc::c_long {

--- a/src/rngs/os.rs
+++ b/src/rngs/os.rs
@@ -413,11 +413,13 @@ mod imp {
     const NR_GETRANDOM: libc::c_long = 4353;
     #[cfg(target_arch = "mips64")]
     const NR_GETRANDOM: libc::c_long = 5313;
+    #[cfg(target_arch = "sparc")]
+    const NR_GETRANDOM: libc::c_long = 347;
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86",
                   target_arch = "arm", target_arch = "aarch64",
                   target_arch = "s390x", target_arch = "powerpc",
                   target_arch = "powerpc64", target_arch = "mips",
-                  target_arch = "mips64")))]
+                  target_arch = "mips64", target_arch = "sparc")))]
     const NR_GETRANDOM: libc::c_long = 0;
 
     fn getrandom(buf: &mut [u8], blocking: bool) -> libc::c_long {


### PR DESCRIPTION
This defines NR_GETRANDOM for powerpc64, sparc and sparc64.