### PR TITLE
Follow up on #591: update authors and add new copyright where missed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rand"
 version = "0.5.5" # NB: When modifying, also modify html_root_url in lib.rs
-authors = ["The Rust Project Developers"]
+authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,3 +1,4 @@
+Copyright 2018 Developers of the Rand project
 Copyright (c) 2014 The Rust Project Developers
 
 Permission is hereby granted, free of charge, to any

--- a/examples/monte-carlo.rs
+++ b/examples/monte-carlo.rs
@@ -1,3 +1,4 @@
+// Copyright 2018 Developers of the Rand project.
 // Copyright 2013-2018 The Rust Project Developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/examples/monty-hall.rs
+++ b/examples/monty-hall.rs
@@ -1,3 +1,4 @@
+// Copyright 2018 Developers of the Rand project.
 // Copyright 2013-2018 The Rust Project Developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rand_core"
 version = "0.2.1" # NB: When modifying, also modify html_root_url in lib.rs
-authors = ["The Rust Project Developers"]
+authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"

--- a/rand_core/LICENSE-MIT
+++ b/rand_core/LICENSE-MIT
@@ -1,3 +1,4 @@
+Copyright 2018 Developers of the Rand project
 Copyright (c) 2014 The Rust Project Developers
 
 Permission is hereby granted, free of charge, to any

--- a/rand_isaac/Cargo.toml
+++ b/rand_isaac/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rand_isaac"
 version = "0.1.0" # NB: When modifying, also modify html_root_url in lib.rs
-authors = ["The Rust Project Developers"]
+authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"

--- a/rand_isaac/LICENSE-MIT
+++ b/rand_isaac/LICENSE-MIT
@@ -1,3 +1,4 @@
+Copyright 2018 Developers of the Rand project
 Copyright (c) 2014 The Rust Project Developers
 
 Permission is hereby granted, free of charge, to any

--- a/rand_isaac/src/isaac.rs
+++ b/rand_isaac/src/isaac.rs
@@ -1,3 +1,4 @@
+// Copyright 2018 Developers of the Rand project.
 // Copyright 2013-2018 The Rust Project Developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/rand_isaac/src/isaac64.rs
+++ b/rand_isaac/src/isaac64.rs
@@ -1,3 +1,4 @@
+// Copyright 2018 Developers of the Rand project.
 // Copyright 2013-2018 The Rust Project Developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/rand_isaac/src/isaac_array.rs
+++ b/rand_isaac/src/isaac_array.rs
@@ -1,3 +1,4 @@
+// Copyright 2018 Developers of the Rand project.
 // Copyright 2017-2018 The Rust Project Developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rand_xorshift"
 version = "0.1.0" # NB: When modifying, also modify html_root_url in lib.rs
-authors = ["The Rust Project Developers"]
+authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"

--- a/rand_xorshift/LICENSE-MIT
+++ b/rand_xorshift/LICENSE-MIT
@@ -1,4 +1,5 @@
-Copyright (c) 2018 The Rust Project Developers
+Copyright 2018 Developers of the Rand project
+Copyright (c) 2014 The Rust Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/rand_xorshift/src/xorshift.rs
+++ b/rand_xorshift/src/xorshift.rs
@@ -1,3 +1,4 @@
+// Copyright 2018 Developers of the Rand project.
 // Copyright 2017 The Rust Project Developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -1,3 +1,4 @@
+// Copyright 2018 Developers of the Rand project.
 // Copyright 2013 The Rust Project Developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -1,3 +1,4 @@
+// Copyright 2018 Developers of the Rand project.
 // Copyright 2013 The Rust Project Developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -1,3 +1,4 @@
+// Copyright 2018 Developers of the Rand project.
 // Copyright 2013 The Rust Project Developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/src/distributions/ziggurat_tables.rs
+++ b/src/distributions/ziggurat_tables.rs
@@ -1,3 +1,4 @@
+// Copyright 2018 Developers of the Rand project.
 // Copyright 2013 The Rust Project Developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -1,3 +1,4 @@
+// Copyright 2018 Developers of the Rand project.
 // Copyright 2014 The Rust Project Developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/src/rngs/adapter/read.rs
+++ b/src/rngs/adapter/read.rs
@@ -1,3 +1,4 @@
+// Copyright 2018 Developers of the Rand project.
 // Copyright 2013 The Rust Project Developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/src/rngs/adapter/reseeding.rs
+++ b/src/rngs/adapter/reseeding.rs
@@ -1,3 +1,4 @@
+// Copyright 2018 Developers of the Rand project.
 // Copyright 2013 The Rust Project Developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/utils/ziggurat_tables.py
+++ b/utils/ziggurat_tables.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 #
+# Copyright 2018 Developers of the Rand project.
 # Copyright 2013 The Rust Project Developers.
 #
 # Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -103,7 +104,8 @@ def render_table(name, values):
 
 
 with open('ziggurat_tables.rs', 'w') as f:
-    f.write('''// Copyright 2013 The Rust Project Developers.
+    f.write('''// Copyright 2018 Developers of the Rand project.
+// Copyright 2013 The Rust Project Developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license


### PR DESCRIPTION
Apparently I missed adding copyright "Developers of the Rand project" in several places in #591.

Additionally, the "authors" field in `Cargo.toml` should be updated; I decided to list both projects here, though new additions (including Hc128Rng) can only list the Rand project.

Details. Still, it would be nice to know there are no objections @pitdicker @vks @huonw.