### PR TITLE
Add comments in basic usage block

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,10 +18,10 @@
 //! a random value is to use [`random()`].
 //!
 //! ```
-//! let x: u8 = rand::random();
+//! let x: u8 = rand::random(); // generates an integer within u8 bounds
 //! println!("{}", x);
 //!
-//! let y = rand::random::<f64>();
+//! let y = rand::random::<f64>(); // generates a float between 0 and 1
 //! println!("{}", y);
 //!
 //! if rand::random() { // generates a boolean


### PR DESCRIPTION
I wanted a quick way to generate a float between 0 and 1 and wasn't sure if rand::random::\<f64>() did what I needed until I played around with it. I think adding comments in the basic usage block may be useful to those in a similar position who just need a quick way to generate random numbers.