### PR TITLE
Disable default features of `libc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ optional = true
 features = ["into_bits"]
 
 [target.'cfg(unix)'.dependencies]
-libc = { version = "0.2", optional = true }
+libc = { version = "0.2", optional = true, default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["minwindef", "ntsecapi", "profileapi", "winnt"], optional = true }


### PR DESCRIPTION
No need for it to be activated as `std` isn't a necessary dependency!
Should help out with `no_std` projects in some situations.