### PR TITLE
Prepare 0.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
 
+## [0.6.1] - 2018-11-22
+- Support sampling `Duration` also for `no_std` (only since Rust 1.25) (#649)
+- Disable default features of `libc` (#647)
+
 ## [0.6.0] - 2018-11-14
 
 ### Project organisation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.6.0" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.6.1" # NB: When modifying, also modify html_root_url in lib.rs
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand/0.6.0")]
+       html_root_url = "https://docs.rs/rand/0.6.1")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]


### PR DESCRIPTION
Requested by @alexcrichton for use by https://github.com/rust-lang/rust/pull/56092.

Edit: I'll make the release tomorrow morning, assuming no issues arise.