### PR TITLE
Switch documentation to rust-random.github.io and prepare 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
 
+## [0.6.1] - 2018-11-22
+- Support sampling `Duration` also for `no_std` (only since Rust 1.25) (#649)
+- Disable default features of `libc` (#647)
+
 ## [0.6.0] - 2018-11-14
 
 ### Project organisation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.6.0" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.6.1" # NB: When modifying, also modify html_root_url in lib.rs
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rand"
-version = "0.6.1" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.6.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://docs.rs/rand"
+documentation = "https://rust-random.github.io/rand"
 homepage = "https://crates.io/crates/rand"
 description = """
 Random number generators and other randomness functionality.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 [![Build Status](https://travis-ci.org/rust-random/rand.svg?branch=master)](https://travis-ci.org/rust-random/rand)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-random/rand?svg=true)](https://ci.appveyor.com/project/rust-random/rand)
-[![Latest version](https://img.shields.io/crates/v/rand.svg)](https://crates.io/crates/rand)
-[![Documentation](https://docs.rs/rand/badge.svg)](https://docs.rs/rand)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-yellow.svg)](https://github.com/rust-random/rand#rust-version-requirements)
-[![License](https://img.shields.io/crates/l/rand.svg)](https://github.com/rust-random/rand#license)
+[![Crate](https://img.shields.io/crates/v/rand.svg)](https://crates.io/crates/rand)
+[![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
+[![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand)
+[![API](https://docs.rs/rand/badge.svg)](https://docs.rs/rand)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 A Rust library for random number generation.
 
@@ -18,9 +19,9 @@ implementations should prefer to use `rand_core` while most other users should
 depend on `rand`.
 
 Documentation:
--   [The Rust Rand Book](https://rust-random.github.io/book/)
--   [API reference for the latest release](https://docs.rs/rand/)
--   [API reference for the master branch](https://rust-random.github.io/rand/)
+-   [The Rust Rand Book](https://rust-random.github.io/book)
+-   [API reference (master)](https://rust-random.github.io/rand)
+-   [API reference (docs.rs)](https://docs.rs/rand)
 
 
 ## Usage
@@ -32,7 +33,7 @@ Add this to your `Cargo.toml`:
 rand = "0.6"
 ```
 
-To get started using Rand, see [The Book](https://rust-random.github.io/book/).
+To get started using Rand, see [The Book](https://rust-random.github.io/book).
 
 
 ## Versions

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rand_chacha"
-version = "0.1.0" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.1.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://docs.rs/rand_chacha"
+documentation = "https://rust-random.github.io/rand/rand_chacha"
 homepage = "https://crates.io/crates/rand_chacha"
 description = """
 ChaCha random number generator

--- a/rand_chacha/README.md
+++ b/rand_chacha/README.md
@@ -3,9 +3,10 @@
 [![Build Status](https://travis-ci.org/rust-random/rand.svg)](https://travis-ci.org/rust-random/rand)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-random/rand?svg=true)](https://ci.appveyor.com/project/rust-random/rand)
 [![Latest version](https://img.shields.io/crates/v/rand_chacha.svg)](https://crates.io/crates/rand_chacha)
-[![Documentation](https://docs.rs/rand_chacha/badge.svg)](https://docs.rs/rand_chacha)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-yellow.svg)](https://github.com/rust-random/rand#rust-version-requirements)
-[![License](https://img.shields.io/crates/l/rand_chacha.svg)](https://github.com/rust-random/rand/tree/master/rand_chacha#license)
+[![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
+[![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_chacha)
+[![API](https://docs.rs/rand_chacha/badge.svg)](https://docs.rs/rand_chacha)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 A cryptographically secure random number generator that uses the ChaCha
 algorithm.
@@ -15,11 +16,11 @@ as an RNG. It is an improved variant of the Salsa20 cipher family, which was
 selected as one of the "stream ciphers suitable for widespread adoption" by
 eSTREAM[^2].
 
-Documentation:
-[master branch](https://rust-random.github.io/rand/rand_chacha/index.html),
-[by release](https://docs.rs/rand_chacha)
+Links:
 
-[Changelog](CHANGELOG.md)
+-   [API documentation (master)](https://rust-random.github.io/rand/rand_chacha)
+-   [API documentation (docs.rs)](https://docs.rs/rand_chacha)
+-   [Changelog](CHANGELOG.md)
 
 [rand]: https://crates.io/crates/rand
 [^1]: D. J. Bernstein, [*ChaCha, a variant of Salsa20*](

--- a/rand_chacha/src/lib.rs
+++ b/rand_chacha/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand_chacha/0.1.0")]
+       html_root_url = "https://rust-random.github.io/rand/")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rand_core"
-version = "0.3.0" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.3.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://docs.rs/rand_core"
+documentation = "https://rust-random.github.io/rand/rand_core"
 homepage = "https://crates.io/crates/rand_core"
 description = """
 Core random number generator traits and tools for implementation.

--- a/rand_core/README.md
+++ b/rand_core/README.md
@@ -3,9 +3,10 @@
 [![Build Status](https://travis-ci.org/rust-random/rand.svg)](https://travis-ci.org/rust-random/rand)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-random/rand?svg=true)](https://ci.appveyor.com/project/rust-random/rand)
 [![Latest version](https://img.shields.io/crates/v/rand_core.svg)](https://crates.io/crates/rand_core)
-[![Documentation](https://docs.rs/rand_core/badge.svg)](https://docs.rs/rand_core)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-yellow.svg)](https://github.com/rust-random/rand#rust-version-requirements)
-[![License](https://img.shields.io/crates/l/rand_core.svg)](https://github.com/rust-random/rand/tree/master/rand_core#license)
+[![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
+[![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_core)
+[![API](https://docs.rs/rand_core/badge.svg)](https://docs.rs/rand_core)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 Core traits and error types of the [rand] library, plus tools for implementing
 RNGs.
@@ -20,11 +21,11 @@ applications (including sampling from restricted ranges, conversion to floating
 point, list permutations and secure initialisation of RNGs). Most users should
 prefer to use the main [rand] crate.
 
-Documentation:
-[master branch](https://rust-random.github.io/rand/rand_core/index.html),
-[by release](https://docs.rs/rand_core)
+Links:
 
-[Changelog](CHANGELOG.md)
+-   [API documentation (master)](https://rust-random.github.io/rand/rand_core)
+-   [API documentation (docs.rs)](https://docs.rs/rand_core)
+-   [Changelog](CHANGELOG.md)
 
 [rand]: https://crates.io/crates/rand
 

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -34,7 +34,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand_core/0.3.0")]
+       html_root_url = "https://rust-random.github.io/rand/")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/rand_hc/Cargo.toml
+++ b/rand_hc/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rand_hc"
-version = "0.1.0" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.1.0"
 authors = ["The Rand Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://docs.rs/rand_hc"
+documentation = "https://rust-random.github.io/rand/rand_hc"
 homepage = "https://crates.io/crates/rand_hc"
 description = """
 HC128 random number generator

--- a/rand_hc/README.md
+++ b/rand_hc/README.md
@@ -3,9 +3,10 @@
 [![Build Status](https://travis-ci.org/rust-random/rand.svg)](https://travis-ci.org/rust-random/rand)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-random/rand?svg=true)](https://ci.appveyor.com/project/rust-random/rand)
 [![Latest version](https://img.shields.io/crates/v/rand_hc.svg)](https://crates.io/crates/rand_hc)
-[![Documentation](https://docs.rs/rand_hc/badge.svg)](https://docs.rs/rand_hc)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-yellow.svg)](https://github.com/rust-random/rand#rust-version-requirements)
-[![License](https://img.shields.io/crates/l/rand_hc.svg)](https://github.com/rust-random/rand/tree/master/rand_hc#license)
+[[![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
+[![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_hc)
+[![API](https://docs.rs/rand_hc/badge.svg)](https://docs.rs/rand_hc)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 A cryptographically secure random number generator that uses the HC-128
 algorithm.
@@ -14,11 +15,11 @@ HC-128 is a stream cipher designed by Hongjun Wu[^1], that we use as an
 RNG. It is selected as one of the "stream ciphers suitable for widespread
 adoption" by eSTREAM[^2].
 
-Documentation:
-[master branch](https://rust-random.github.io/rand/rand_hc/index.html),
-[by release](https://docs.rs/rand_hc)
+Links:
 
-[Changelog](CHANGELOG.md)
+-   [API documentation (master)](https://rust-random.github.io/rand/rand_hc)
+-   [API documentation (docs.rs)](https://docs.rs/rand_hc)
+-   [Changelog](CHANGELOG.md)
 
 [rand]: https://crates.io/crates/rand
 [^1]: Hongjun Wu (2008). ["The Stream Cipher HC-128"](

--- a/rand_hc/src/lib.rs
+++ b/rand_hc/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand_hc/0.1.0")]
+       html_root_url = "https://rust-random.github.io/rand/")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/rand_isaac/Cargo.toml
+++ b/rand_isaac/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rand_isaac"
-version = "0.1.0" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.1.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://docs.rs/rand_isaac"
+documentation = "https://rust-random.github.io/rand/rand_isaac"
 homepage = "https://crates.io/crates/rand_isaac"
 description = """
 ISAAC random number generator

--- a/rand_isaac/README.md
+++ b/rand_isaac/README.md
@@ -3,9 +3,10 @@
 [![Build Status](https://travis-ci.org/rust-random/rand.svg)](https://travis-ci.org/rust-random/rand)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-random/rand?svg=true)](https://ci.appveyor.com/project/rust-random/rand)
 [![Latest version](https://img.shields.io/crates/v/rand_isaac.svg)](https://crates.io/crates/rand_isaac)
-[![Documentation](https://docs.rs/rand_isaac/badge.svg)](https://docs.rs/rand_isaac)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-yellow.svg)](https://github.com/rust-random/rand#rust-version-requirements)
-[![License](https://img.shields.io/crates/l/rand_isaac.svg)](https://github.com/rust-random/rand/tree/master/rand_isaac#license)
+[![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
+[![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_isaac)
+[![API](https://docs.rs/rand_isaac/badge.svg)](https://docs.rs/rand_isaac)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 Implements the ISAAC and ISAAC-64 random number generators.
 
@@ -17,14 +18,13 @@ in 1996[^1][^2].
 ISAAC is notably fast and produces excellent quality random numbers for
 non-cryptographic applications.
 
-Documentation:
-[master branch](https://rust-random.github.io/rand/rand_isaac/index.html),
-[by release](https://docs.rs/rand_isaac)
+Links:
 
-[Changelog](CHANGELOG.md)
+-   [API documentation (master)](https://rust-random.github.io/rand/rand_isaac)
+-   [API documentation (docs.rs)](https://docs.rs/rand_isaac)
+-   [Changelog](CHANGELOG.md)
 
 [rand]: https://crates.io/crates/rand
-
 [^1]: Bob Jenkins, [*ISAAC: A fast cryptographic random number generator*](http://burtleburtle.net/bob/rand/isaacafa.html)
 [^2]: Bob Jenkins, [*ISAAC and RC4*](http://burtleburtle.net/bob/rand/isaac.html)
 

--- a/rand_isaac/src/lib.rs
+++ b/rand_isaac/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand_isaac/0.1.0")]
+       html_root_url = "https://rust-random.github.io/rand/")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rand_pcg"
-version = "0.1.1" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.1.1"
 authors = ["The Rand Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://docs.rs/rand_pcg"
+documentation = "https://rust-random.github.io/rand/rand_pcg"
 homepage = "https://crates.io/crates/rand_pcg"
 description = """
 Selected PCG random number generators

--- a/rand_pcg/README.md
+++ b/rand_pcg/README.md
@@ -3,9 +3,10 @@
 [![Build Status](https://travis-ci.org/rust-random/rand.svg?branch=master)](https://travis-ci.org/rust-random/rand)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-random/rand?svg=true)](https://ci.appveyor.com/project/rust-random/rand)
 [![Latest version](https://img.shields.io/crates/v/rand_pcg.svg)](https://crates.io/crates/rand_pcg)
-[![Documentation](https://docs.rs/rand_pcg/badge.svg)](https://docs.rs/rand_pcg)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-yellow.svg)](https://github.com/rust-random/rand#rust-version-requirements)
-[![License](https://img.shields.io/crates/l/rand_pcg.svg)](https://github.com/rust-random/rand/tree/master/rand_pcg#license)
+[[![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
+[![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_pcg)
+[![API](https://docs.rs/rand_pcg/badge.svg)](https://docs.rs/rand_pcg)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 Implements a selection of PCG random number generators.
 
@@ -19,11 +20,11 @@ See the [pcg-random website](http://www.pcg-random.org/).
 This crate depends on [rand_core](https://crates.io/crates/rand_core) and is
 part of the [Rand project](https://github.com/rust-random/rand).
 
-Documentation:
-[master branch](https://rust-random.github.io/rand/rand_pcg/index.html),
-[by release](https://docs.rs/rand_pcg)
+Links:
 
-[Changelog](CHANGELOG.md)
+-   [API documentation (master)](https://rust-random.github.io/rand/rand_pcg)
+-   [API documentation (docs.rs)](https://docs.rs/rand_pcg)
+-   [Changelog](CHANGELOG.md)
 
 
 ## Crate Features

--- a/rand_pcg/src/lib.rs
+++ b/rand_pcg/src/lib.rs
@@ -29,7 +29,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand_pcg/0.1.1")]
+       html_root_url = "https://rust-random.github.io/rand/")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rand_xorshift"
-version = "0.1.0" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.1.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://docs.rs/rand_xorshift"
+documentation = "https://rust-random.github.io/rand/rand_xorshift"
 homepage = "https://crates.io/crates/rand_xorshift"
 description = """
 Xorshift random number generator

--- a/rand_xorshift/README.md
+++ b/rand_xorshift/README.md
@@ -3,9 +3,10 @@
 [![Build Status](https://travis-ci.org/rust-random/rand.svg)](https://travis-ci.org/rust-random/rand)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-random/rand?svg=true)](https://ci.appveyor.com/project/rust-random/rand)
 [![Latest version](https://img.shields.io/crates/v/rand_xorshift.svg)](https://crates.io/crates/rand_xorshift)
-[![Documentation](https://docs.rs/rand_xorshift/badge.svg)](https://docs.rs/rand_xorshift)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-yellow.svg)](https://github.com/rust-random/rand#rust-version-requirements)
-[![License](https://img.shields.io/crates/l/rand_xorshift.svg)](https://github.com/rust-random/rand/tree/master/rand_xorshift#license)
+[![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
+[![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_xorshift)
+[![API](https://docs.rs/rand_xorshift/badge.svg)](https://docs.rs/rand_xorshift)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 Implements the Xorshift random number generator.
 
@@ -17,11 +18,11 @@ requirements, use a more secure one such as `StdRng` or `OsRng`.
       ["Xorshift RNGs"](https://www.jstatsoft.org/v08/i14/paper).
       *Journal of Statistical Software*. Vol. 8 (Issue 14).
 
-Documentation:
-[master branch](https://rust-random.github.io/rand/rand_xorshift/index.html),
-[by release](https://docs.rs/rand_xorshift)
+Links:
 
-[Changelog](CHANGELOG.md)
+-   [API documentation (master)](https://rust-random.github.io/rand/rand_xorshift)
+-   [API documentation (docs.rs)](https://docs.rs/rand_xorshift)
+-   [Changelog](CHANGELOG.md)
 
 [rand]: https://crates.io/crates/rand
 

--- a/rand_xorshift/src/lib.rs
+++ b/rand_xorshift/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand_xorshift/0.1.0")]
+       html_root_url = "https://rust-random.github.io/rand/")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand/0.6.1")]
+       html_root_url = "https://rust-random.github.io/rand/")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand/0.6.0")]
+       html_root_url = "https://docs.rs/rand/0.6.1")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -67,8 +67,8 @@ type Rng = ::rand_pcg::Pcg32;
 /// [`FromEntropy`]: ../trait.FromEntropy.html
 /// [`StdRng`]: struct.StdRng.html
 /// [`thread_rng`]: ../fn.thread_rng.html
-/// [`Pcg64Mcg`]: https://docs.rs/rand_pcg/0.1.0/rand_pcg/type.Pcg64Mcg.html
-/// [`Pcg32`]: https://docs.rs/rand_pcg/0.1.0/rand_pcg/type.Pcg32.html
+/// [`Pcg64Mcg`]: ../../rand_pcg/type.Pcg64Mcg.html
+/// [`Pcg32`]: ../../rand_pcg/type.Pcg32.html
 #[derive(Clone, Debug)]
 pub struct SmallRng(Rng);
 


### PR DESCRIPTION
This is based on top of the commit in #651 so only one of these needs to be merged.

Possible solution to #646.