### PR TITLE
Add Default for ThreadRng

### DIFF
--- a/src/rngs/thread.rs
+++ b/src/rngs/thread.rs
@@ -87,10 +87,11 @@ thread_local!(
     }
 );
 
-/// Retrieve the lazily-initialized thread-local random number
-/// generator, seeded by the system. Intended to be used in method
-/// chaining style, e.g. `thread_rng().gen::<i32>()`, or cached locally, e.g.
-/// `let mut rng = thread_rng();`.
+/// Retrieve the lazily-initialized thread-local random number generator,
+/// seeded by the system. Intended to be used in method chaining style,
+/// e.g. `thread_rng().gen::<i32>()`, or cached locally, e.g.
+/// `let mut rng = thread_rng();`.  Invoked by the `Default` trait, making
+/// `ThreadRng::default()` equivelent.
 ///
 /// For more information see [`ThreadRng`].
 ///

--- a/src/rngs/thread.rs
+++ b/src/rngs/thread.rs
@@ -99,6 +99,12 @@ pub fn thread_rng() -> ThreadRng {
     ThreadRng { rng: THREAD_RNG_KEY.with(|t| t.get()) }
 }
 
+impl Default for ThreadRng {
+    fn default() -> ThreadRng {
+        ::prelude::thread_rng()
+    }
+}
+
 impl RngCore for ThreadRng {
     #[inline(always)]
     fn next_u32(&mut self) -> u32 {


### PR DESCRIPTION
Appears harmless.  I'm unsure if this actually helps anything, especially since doing this for `OsRng` requires `unwrap`, but `RandomState: Default` though so..
