### PR TITLE
Move `rustc_version` dep to `autocfg`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ wasm-bindgen = { version = "0.2.12", optional = true }
 average = "0.9.2"
 
 [build-dependencies]
-rustc_version = "0.2"
+autocfg = "0.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,10 @@
-extern crate rustc_version;
-use rustc_version::{version, Version};
+extern crate autocfg;
 
 fn main() {
-    if version().unwrap() >= Version::parse("1.25.0").unwrap() {
-        println!("cargo:rustc-cfg=rust_1_25");
-    }
-    if version().unwrap() >= Version::parse("1.26.0").unwrap() {
-        println!("cargo:rustc-cfg=rust_1_26");
-    }
-    if version().unwrap() >= Version::parse("1.27.0").unwrap() {
-        println!("cargo:rustc-cfg=rust_1_27");
-    }
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let ac = autocfg::new();
+    ac.emit_rustc_version(1, 25);
+    ac.emit_rustc_version(1, 26);
+    ac.emit_rustc_version(1, 27);
 }

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -22,4 +22,4 @@ appveyor = { repository = "rust-random/rand" }
 rand_core = { path = "../rand_core", version = ">=0.2, <0.4", default-features=false }
 
 [build-dependencies]
-rustc_version = "0.2"
+autocfg = "0.1"

--- a/rand_chacha/build.rs
+++ b/rand_chacha/build.rs
@@ -1,8 +1,7 @@
-extern crate rustc_version;
-use rustc_version::{version, Version};
+extern crate autocfg;
 
 fn main() {
-    if version().unwrap() >= Version::parse("1.26.0").unwrap() {
-        println!("cargo:rustc-cfg=rust_1_26");
-    }
+    println!("cargo:rerun-if-changed=build.rs");
+    let ac = autocfg::new();
+    ac.emit_rustc_version(1, 26);
 }

--- a/rand_chacha/src/chacha.rs
+++ b/rand_chacha/src/chacha.rs
@@ -114,7 +114,7 @@ impl ChaChaRng {
     /// byte-offset.
     ///
     /// Note: this function is currently only available with Rust 1.26 or later.
-    #[cfg(rust_1_26)]
+    #[cfg(rustc_1_26)]
     pub fn get_word_pos(&self) -> u128 {
         let mut c = (self.0.core.state[13] as u64) << 32
                   | (self.0.core.state[12] as u64);
@@ -135,7 +135,7 @@ impl ChaChaRng {
     /// 60 bits.
     ///
     /// Note: this function is currently only available with Rust 1.26 or later.
-    #[cfg(rust_1_26)]
+    #[cfg(rustc_1_26)]
     pub fn set_word_pos(&mut self, word_offset: u128) {
         let index = (word_offset as usize) & 0xF;
         let counter = (word_offset >> 4) as u64;
@@ -330,7 +330,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(rust_1_26)]
+    #[cfg(rustc_1_26)]
     fn test_chacha_true_values_c() {
         // Test vector 4 from
         // https://tools.ietf.org/html/draft-nir-cfrg-chacha20-poly1305-04

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -34,4 +34,4 @@ serde_derive = { version = "^1.0.38", optional = true }
 bincode = { version = "1", features = ["i128"] }
 
 [build-dependencies]
-rustc_version = "0.2"
+autocfg = "0.1"

--- a/rand_pcg/build.rs
+++ b/rand_pcg/build.rs
@@ -1,8 +1,7 @@
-extern crate rustc_version;
-use rustc_version::{version, Version};
+extern crate autocfg;
 
 fn main() {
-    if version().unwrap() >= Version::parse("1.26.0").unwrap() {
-        println!("cargo:rustc-cfg=rust_1_26");
-    }
+    println!("cargo:rerun-if-changed=build.rs");
+    let ac = autocfg::new();
+    ac.emit_rustc_version(1, 26);
 }

--- a/rand_pcg/src/lib.rs
+++ b/rand_pcg/src/lib.rs
@@ -42,7 +42,7 @@ extern crate rand_core;
 #[cfg(feature="serde1")] #[macro_use] extern crate serde_derive;
 
 mod pcg64;
-#[cfg(rust_1_26)] mod pcg128;
+#[cfg(rustc_1_26)] mod pcg128;
 
 pub use self::pcg64::{Pcg32, Lcg64Xsh32};
-#[cfg(rust_1_26)] pub use self::pcg128::{Pcg64Mcg, Mcg128Xsl64};
+#[cfg(rustc_1_26)] pub use self::pcg128::{Pcg64Mcg, Mcg128Xsl64};

--- a/rand_pcg/tests/mcg128xsl64.rs
+++ b/rand_pcg/tests/mcg128xsl64.rs
@@ -1,4 +1,4 @@
-#![cfg(rust_1_26)]
+#![cfg(rustc_1_26)]
 extern crate rand_pcg;
 extern crate rand_core;
 #[cfg(all(feature="serde1", test))] extern crate bincode;

--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -151,12 +151,12 @@ impl SeedableRng for ChaChaRng {
 }
 
 impl ChaChaRng {
-    #[cfg(rust_1_26)]
+    #[cfg(rustc_1_26)]
     pub fn get_word_pos(&self) -> u128 {
         self.0.get_word_pos()
     }
 
-    #[cfg(rust_1_26)]
+    #[cfg(rustc_1_26)]
     pub fn set_word_pos(&mut self, word_offset: u128) {
         self.0.set_word_pos(word_offset)
     }

--- a/src/distributions/integer.rs
+++ b/src/distributions/integer.rs
@@ -45,7 +45,7 @@ impl Distribution<u64> for Standard {
     }
 }
 
-#[cfg(rust_1_26)]
+#[cfg(rustc_1_26)]
 impl Distribution<u128> for Standard {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u128 {
@@ -85,7 +85,7 @@ impl_int_from_uint! { i8, u8 }
 impl_int_from_uint! { i16, u16 }
 impl_int_from_uint! { i32, u32 }
 impl_int_from_uint! { i64, u64 }
-#[cfg(rust_1_26)] impl_int_from_uint! { i128, u128 }
+#[cfg(rustc_1_26)] impl_int_from_uint! { i128, u128 }
 impl_int_from_uint! { isize, usize }
 
 #[cfg(feature="simd_support")]
@@ -147,7 +147,7 @@ mod tests {
         rng.sample::<i16, _>(Standard);
         rng.sample::<i32, _>(Standard);
         rng.sample::<i64, _>(Standard);
-        #[cfg(rust_1_26)]
+        #[cfg(rustc_1_26)]
         rng.sample::<i128, _>(Standard);
         
         rng.sample::<usize, _>(Standard);
@@ -155,7 +155,7 @@ mod tests {
         rng.sample::<u16, _>(Standard);
         rng.sample::<u32, _>(Standard);
         rng.sample::<u64, _>(Standard);
-        #[cfg(rust_1_26)]
+        #[cfg(rustc_1_26)]
         rng.sample::<u128, _>(Standard);
     }
 }

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -182,7 +182,7 @@
 //! [`Weibull`]: struct.Weibull.html
 //! [`WeightedIndex`]: struct.WeightedIndex.html
 
-#[cfg(any(rust_1_26, features="nightly"))]
+#[cfg(any(rustc_1_26, features="nightly"))]
 use core::iter;
 use Rng;
 
@@ -316,7 +316,7 @@ impl<'a, D, R, T> Iterator for DistIter<'a, D, R, T>
     }
 }
 
-#[cfg(rust_1_26)]
+#[cfg(rustc_1_26)]
 impl<'a, D, R, T> iter::FusedIterator for DistIter<'a, D, R, T>
     where D: Distribution<T>, R: Rng + 'a {}
 
@@ -328,7 +328,7 @@ impl<'a, D, R, T> iter::TrustedLen for DistIter<'a, D, R, T>
 /// A generic random value distribution, implemented for many primitive types.
 /// Usually generates values with a numerically uniform distribution, and with a
 /// range appropriate to the type.
-/// 
+///
 /// ## Built-in Implementations
 ///
 /// Assuming the provided `Rng` is well-behaved, these implementations

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -111,7 +111,7 @@
 
 #[cfg(feature = "std")]
 use std::time::Duration;
-#[cfg(all(not(feature = "std"), rust_1_25))]
+#[cfg(all(not(feature = "std"), rustc_1_25))]
 use core::time::Duration;
 
 use Rng;
@@ -277,7 +277,7 @@ impl<X: SampleUniform> From<::core::ops::Range<X>> for Uniform<X> {
     }
 }
 
-#[cfg(rust_1_27)]
+#[cfg(rustc_1_27)]
 impl<X: SampleUniform> From<::core::ops::RangeInclusive<X>> for Uniform<X> {
     fn from(r: ::core::ops::RangeInclusive<X>) -> Uniform<X> {
         Uniform::new_inclusive(r.start(), r.end())
@@ -472,7 +472,7 @@ uniform_int_impl! { i8, i8, u8, i32, u32 }
 uniform_int_impl! { i16, i16, u16, i32, u32 }
 uniform_int_impl! { i32, i32, u32, i32, u32 }
 uniform_int_impl! { i64, i64, u64, i64, u64 }
-#[cfg(rust_1_26)]
+#[cfg(rustc_1_26)]
 uniform_int_impl! { i128, i128, u128, u128, u128 }
 uniform_int_impl! { isize, isize, usize, isize, usize }
 uniform_int_impl! { u8, i8, u8, i32, u32 }
@@ -480,7 +480,7 @@ uniform_int_impl! { u16, i16, u16, i32, u32 }
 uniform_int_impl! { u32, i32, u32, i32, u32 }
 uniform_int_impl! { u64, i64, u64, i64, u64 }
 uniform_int_impl! { usize, isize, usize, isize, usize }
-#[cfg(rust_1_26)]
+#[cfg(rustc_1_26)]
 uniform_int_impl! { u128, u128, u128, i128, u128 }
 
 #[cfg(all(feature = "simd_support", feature = "nightly"))]
@@ -835,14 +835,14 @@ uniform_float_impl! { f64x8, u64x8, f64, u64, 64 - 52 }
 ///
 /// [`UniformSampler`]: trait.UniformSampler.html
 /// [`Uniform`]: struct.Uniform.html
-#[cfg(any(feature = "std", rust_1_25))]
+#[cfg(any(feature = "std", rustc_1_25))]
 #[derive(Clone, Copy, Debug)]
 pub struct UniformDuration {
     mode: UniformDurationMode,
     offset: u32,
 }
 
-#[cfg(any(feature = "std", rust_1_25))]
+#[cfg(any(feature = "std", rustc_1_25))]
 #[derive(Debug, Copy, Clone)]
 enum UniformDurationMode {
     Small {
@@ -859,12 +859,12 @@ enum UniformDurationMode {
     }
 }
 
-#[cfg(any(feature = "std", rust_1_25))]
+#[cfg(any(feature = "std", rustc_1_25))]
 impl SampleUniform for Duration {
     type Sampler = UniformDuration;
 }
 
-#[cfg(any(feature = "std", rust_1_25))]
+#[cfg(any(feature = "std", rustc_1_25))]
 impl UniformSampler for UniformDuration {
     type X = Duration;
 
@@ -989,7 +989,7 @@ mod tests {
     fn test_integers() {
         use core::{i8, i16, i32, i64, isize};
         use core::{u8, u16, u32, u64, usize};
-        #[cfg(rust_1_26)]
+        #[cfg(rustc_1_26)]
         use core::{i128, u128};
 
         let mut rng = ::test::rng(251);
@@ -1053,7 +1053,7 @@ mod tests {
         }
         t!(i8, i16, i32, i64, isize,
            u8, u16, u32, u64, usize);
-        #[cfg(rust_1_26)]
+        #[cfg(rustc_1_26)]
         t!(i128, u128);
 
         #[cfg(all(feature = "simd_support", feature = "nightly"))]
@@ -1208,11 +1208,11 @@ mod tests {
 
 
     #[test]
-    #[cfg(any(feature = "std", rust_1_25))]
+    #[cfg(any(feature = "std", rustc_1_25))]
     fn test_durations() {
         #[cfg(feature = "std")]
         use std::time::Duration;
-        #[cfg(all(not(feature = "std"), rust_1_25))]
+        #[cfg(all(not(feature = "std"), rustc_1_25))]
         use core::time::Duration;
 
         let mut rng = ::test::rng(253);
@@ -1283,7 +1283,7 @@ mod tests {
         assert_eq!(r.inner.scale, 5.0);
     }
 
-    #[cfg(rust_1_27)]
+    #[cfg(rustc_1_27)]
     #[test]
     fn test_uniform_from_std_range_inclusive() {
         let r = Uniform::from(2u32..=6);

--- a/src/distributions/utils.rs
+++ b/src/distributions/utils.rs
@@ -61,7 +61,7 @@ macro_rules! wmul_impl {
 wmul_impl! { u8, u16, 8 }
 wmul_impl! { u16, u32, 16 }
 wmul_impl! { u32, u64, 32 }
-#[cfg(rust_1_26)]
+#[cfg(rustc_1_26)]
 wmul_impl! { u64, u128, 64 }
 
 // This code is a translation of the __mulddi3 function in LLVM's
@@ -125,9 +125,9 @@ macro_rules! wmul_impl_large {
         )+
     };
 }
-#[cfg(not(rust_1_26))]
+#[cfg(not(rustc_1_26))]
 wmul_impl_large! { u64, 32 }
-#[cfg(rust_1_26)]
+#[cfg(rustc_1_26)]
 wmul_impl_large! { u128, 64 }
 
 macro_rules! wmul_impl_usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,13 +549,13 @@ macro_rules! impl_as_byte_slice {
 impl_as_byte_slice!(u16);
 impl_as_byte_slice!(u32);
 impl_as_byte_slice!(u64);
-#[cfg(rust_1_26)] impl_as_byte_slice!(u128);
+#[cfg(rustc_1_26)] impl_as_byte_slice!(u128);
 impl_as_byte_slice!(usize);
 impl_as_byte_slice!(i8);
 impl_as_byte_slice!(i16);
 impl_as_byte_slice!(i32);
 impl_as_byte_slice!(i64);
-#[cfg(rust_1_26)] impl_as_byte_slice!(i128);
+#[cfg(rustc_1_26)] impl_as_byte_slice!(i128);
 impl_as_byte_slice!(isize);
 
 macro_rules! impl_as_byte_slice_arrays {

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -10,9 +10,9 @@
 
 use {RngCore, SeedableRng, Error};
 
-#[cfg(all(rust_1_26, target_pointer_width = "64"))]
+#[cfg(all(rustc_1_26, target_pointer_width = "64"))]
 type Rng = ::rand_pcg::Pcg64Mcg;
-#[cfg(not(all(rust_1_26, target_pointer_width = "64")))]
+#[cfg(not(all(rustc_1_26, target_pointer_width = "64")))]
 type Rng = ::rand_pcg::Pcg32;
 
 /// An RNG recommended when small state, cheap initialization and good


### PR DESCRIPTION
The `rustc_version` dependency is weighty and suffers from
Kimundi/rustc-version-rs#11 which makes it more difficult to change
rustc over time.