### PR TITLE
Disable i128 and u128 on emscripten (fixes #669)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,8 +138,10 @@ matrix:
       addons:
         chrome: stable
       script:
-        # testing wasm32-unknown-emscripten fails because of rust-lang/rust#49877
-        - cargo build --target wasm32-unknown-emscripten
+        # Testing wasm32-unknown-emscripten fails because of rust-lang/rust#49877
+        # However, we can still build and link all tests to make sure that works.
+        # This is actually useful as it finds stuff such as rust-random/rand#669
+        - EMCC_CFLAGS="-s ERROR_ON_UNDEFINED_SYMBOLS=0" cargo web test --target wasm32-unknown-emscripten --no-run
         #- cargo web test --target wasm32-unknown-emscripten
         #- cargo web test --nodejs --target wasm32-unknown-emscripten
         - cargo build --target wasm32-unknown-unknown # without any features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
 
+## [0.6.2] - Unreleased
+- Disable `i128` and `u128` if the `target_os` is `emscripten`.
+
 ## [0.6.1] - 2018-11-22
 - Support sampling `Duration` also for `no_std` (only since Rust 1.25) (#649)
 - Disable default features of `libc` (#647)

--- a/rand_chacha/src/chacha.rs
+++ b/rand_chacha/src/chacha.rs
@@ -114,7 +114,7 @@ impl ChaChaRng {
     /// byte-offset.
     ///
     /// Note: this function is currently only available with Rust 1.26 or later.
-    #[cfg(rustc_1_26)]
+    #[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
     pub fn get_word_pos(&self) -> u128 {
         let mut c = (self.0.core.state[13] as u64) << 32
                   | (self.0.core.state[12] as u64);
@@ -135,7 +135,7 @@ impl ChaChaRng {
     /// 60 bits.
     ///
     /// Note: this function is currently only available with Rust 1.26 or later.
-    #[cfg(rustc_1_26)]
+    #[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
     pub fn set_word_pos(&mut self, word_offset: u128) {
         let index = (word_offset as usize) & 0xF;
         let counter = (word_offset >> 4) as u64;
@@ -330,7 +330,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(rustc_1_26)]
+    #[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
     fn test_chacha_true_values_c() {
         // Test vector 4 from
         // https://tools.ietf.org/html/draft-nir-cfrg-chacha20-poly1305-04

--- a/rand_pcg/src/lib.rs
+++ b/rand_pcg/src/lib.rs
@@ -42,7 +42,7 @@ extern crate rand_core;
 #[cfg(feature="serde1")] #[macro_use] extern crate serde_derive;
 
 mod pcg64;
-#[cfg(rustc_1_26)] mod pcg128;
+#[cfg(all(rustc_1_26, not(target_os = "emscripten")))] mod pcg128;
 
 pub use self::pcg64::{Pcg32, Lcg64Xsh32};
-#[cfg(rustc_1_26)] pub use self::pcg128::{Pcg64Mcg, Mcg128Xsl64};
+#[cfg(all(rustc_1_26, not(target_os = "emscripten")))] pub use self::pcg128::{Pcg64Mcg, Mcg128Xsl64};

--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -151,12 +151,12 @@ impl SeedableRng for ChaChaRng {
 }
 
 impl ChaChaRng {
-    #[cfg(rustc_1_26)]
+    #[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
     pub fn get_word_pos(&self) -> u128 {
         self.0.get_word_pos()
     }
 
-    #[cfg(rustc_1_26)]
+    #[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
     pub fn set_word_pos(&mut self, word_offset: u128) {
         self.0.set_word_pos(word_offset)
     }

--- a/src/distributions/integer.rs
+++ b/src/distributions/integer.rs
@@ -45,7 +45,7 @@ impl Distribution<u64> for Standard {
     }
 }
 
-#[cfg(rustc_1_26)]
+#[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
 impl Distribution<u128> for Standard {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u128 {
@@ -85,7 +85,7 @@ impl_int_from_uint! { i8, u8 }
 impl_int_from_uint! { i16, u16 }
 impl_int_from_uint! { i32, u32 }
 impl_int_from_uint! { i64, u64 }
-#[cfg(rustc_1_26)] impl_int_from_uint! { i128, u128 }
+#[cfg(all(rustc_1_26, not(target_os = "emscripten")))] impl_int_from_uint! { i128, u128 }
 impl_int_from_uint! { isize, usize }
 
 #[cfg(feature="simd_support")]
@@ -147,7 +147,7 @@ mod tests {
         rng.sample::<i16, _>(Standard);
         rng.sample::<i32, _>(Standard);
         rng.sample::<i64, _>(Standard);
-        #[cfg(rustc_1_26)]
+        #[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
         rng.sample::<i128, _>(Standard);
         
         rng.sample::<usize, _>(Standard);
@@ -155,7 +155,7 @@ mod tests {
         rng.sample::<u16, _>(Standard);
         rng.sample::<u32, _>(Standard);
         rng.sample::<u64, _>(Standard);
-        #[cfg(rustc_1_26)]
+        #[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
         rng.sample::<u128, _>(Standard);
     }
 }

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -473,7 +473,7 @@ uniform_int_impl! { i8, i8, u8, i32, u32 }
 uniform_int_impl! { i16, i16, u16, i32, u32 }
 uniform_int_impl! { i32, i32, u32, i32, u32 }
 uniform_int_impl! { i64, i64, u64, i64, u64 }
-#[cfg(rustc_1_26)]
+#[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
 uniform_int_impl! { i128, i128, u128, u128, u128 }
 uniform_int_impl! { isize, isize, usize, isize, usize }
 uniform_int_impl! { u8, i8, u8, i32, u32 }
@@ -481,7 +481,7 @@ uniform_int_impl! { u16, i16, u16, i32, u32 }
 uniform_int_impl! { u32, i32, u32, i32, u32 }
 uniform_int_impl! { u64, i64, u64, i64, u64 }
 uniform_int_impl! { usize, isize, usize, isize, usize }
-#[cfg(rustc_1_26)]
+#[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
 uniform_int_impl! { u128, u128, u128, i128, u128 }
 
 #[cfg(all(feature = "simd_support", feature = "nightly"))]
@@ -990,7 +990,7 @@ mod tests {
     fn test_integers() {
         use core::{i8, i16, i32, i64, isize};
         use core::{u8, u16, u32, u64, usize};
-        #[cfg(rustc_1_26)]
+        #[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
         use core::{i128, u128};
 
         let mut rng = ::test::rng(251);
@@ -1054,7 +1054,7 @@ mod tests {
         }
         t!(i8, i16, i32, i64, isize,
            u8, u16, u32, u64, usize);
-        #[cfg(rustc_1_26)]
+        #[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
         t!(i128, u128);
 
         #[cfg(all(feature = "simd_support", feature = "nightly"))]

--- a/src/distributions/utils.rs
+++ b/src/distributions/utils.rs
@@ -61,7 +61,7 @@ macro_rules! wmul_impl {
 wmul_impl! { u8, u16, 8 }
 wmul_impl! { u16, u32, 16 }
 wmul_impl! { u32, u64, 32 }
-#[cfg(rustc_1_26)]
+#[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
 wmul_impl! { u64, u128, 64 }
 
 // This code is a translation of the __mulddi3 function in LLVM's
@@ -125,9 +125,9 @@ macro_rules! wmul_impl_large {
         )+
     };
 }
-#[cfg(not(rustc_1_26))]
+#[cfg(not(all(rustc_1_26, not(target_os = "emscripten"))))]
 wmul_impl_large! { u64, 32 }
-#[cfg(rustc_1_26)]
+#[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
 wmul_impl_large! { u128, 64 }
 
 macro_rules! wmul_impl_usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,13 +549,13 @@ macro_rules! impl_as_byte_slice {
 impl_as_byte_slice!(u16);
 impl_as_byte_slice!(u32);
 impl_as_byte_slice!(u64);
-#[cfg(rustc_1_26)] impl_as_byte_slice!(u128);
+#[cfg(all(rustc_1_26, not(target_os = "emscripten")))] impl_as_byte_slice!(u128);
 impl_as_byte_slice!(usize);
 impl_as_byte_slice!(i8);
 impl_as_byte_slice!(i16);
 impl_as_byte_slice!(i32);
 impl_as_byte_slice!(i64);
-#[cfg(rustc_1_26)] impl_as_byte_slice!(i128);
+#[cfg(all(rustc_1_26, not(target_os = "emscripten")))] impl_as_byte_slice!(i128);
 impl_as_byte_slice!(isize);
 
 macro_rules! impl_as_byte_slice_arrays {

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -10,9 +10,9 @@
 
 use {RngCore, SeedableRng, Error};
 
-#[cfg(all(rustc_1_26, target_pointer_width = "64"))]
+#[cfg(all(all(rustc_1_26, not(target_os = "emscripten")), target_pointer_width = "64"))]
 type Rng = ::rand_pcg::Pcg64Mcg;
-#[cfg(not(all(rustc_1_26, target_pointer_width = "64")))]
+#[cfg(not(all(all(rustc_1_26, not(target_os = "emscripten")), target_pointer_width = "64")))]
 type Rng = ::rand_pcg::Pcg32;
 
 /// An RNG recommended when small state, cheap initialization and good


### PR DESCRIPTION
This was also reported as https://github.com/rust-random/rand/issues/669, https://github.com/koute/cargo-web/issues/152 and https://github.com/kripken/emscripten-fastcomp/issues/169.

Basically emscripten can't properly deal with `i128` and `u128`. This should be fixed in emscripten upstream but it's unlikely to happen. This is the best we can do. This also changes the `.travis-ci.yml` so that this problem doesn't re-occur without getting caught.