### PR TITLE
Fix rand_xoshiro dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ rand_isaac = { path = "rand_isaac", version = "0.1" }
 rand_chacha = { path = "rand_chacha", version = "0.1" }
 rand_hc = { path = "rand_hc", version = "0.1" }
 rand_xorshift = { path = "rand_xorshift", version = "0.1" }
-rand_xoshiro = { path = "rand_xoshiro", version = "0.1" }
 log = { version = "0.4", optional = true }
 
 [dependencies.packed_simd]
@@ -69,6 +68,8 @@ winapi = { version = "0.3", features = ["minwindef", "ntsecapi", "profileapi", "
 [dev-dependencies]
 # This has a histogram implementation used for testing uniformity.
 average = "0.9.2"
+# Only for benches:
+rand_xoshiro = { path = "rand_xoshiro", version = "0.1" }
 
 [build-dependencies]
 autocfg = "0.1"

--- a/rand_xoshiro/Cargo.toml
+++ b/rand_xoshiro/Cargo.toml
@@ -16,4 +16,4 @@ byteorder = { version = "1", default-features=false }
 rand_core = { path = "../rand_core", version = "0.3", default-features=false }
 
 [dev-dependencies]
-rand = { path = "..", default-features=false }  # needed for doctests
+rand = { path = "..", version = "0.6", default-features=false }  # needed for doctests


### PR DESCRIPTION
Last-minute fixes for `rand_xoshiro`

@vks note that the crate doesn't need to be a full dependency of `rand` (although even as a dev-dependency it still blocks publishing `rand` 0.6.2 until this is published...)