### PR TITLE
Re-export rand_core

### DIFF
--- a/rand_chacha/src/lib.rs
+++ b/rand_chacha/src/lib.rs
@@ -18,7 +18,7 @@
 
 #![no_std]
 
-extern crate rand_core;
+pub extern crate rand_core;
 
 mod chacha;
 

--- a/rand_hc/src/lib.rs
+++ b/rand_hc/src/lib.rs
@@ -18,7 +18,7 @@
 
 #![no_std]
 
-extern crate rand_core;
+pub extern crate rand_core;
 
 mod hc128;
 

--- a/rand_isaac/src/lib.rs
+++ b/rand_isaac/src/lib.rs
@@ -18,7 +18,7 @@
 
 #![cfg_attr(not(all(feature="serde1", test)), no_std)]
 
-extern crate rand_core;
+pub extern crate rand_core;
 
 #[cfg(feature="serde1")] extern crate serde;
 #[cfg(feature="serde1")] #[macro_use] extern crate serde_derive;

--- a/rand_pcg/src/lib.rs
+++ b/rand_pcg/src/lib.rs
@@ -36,7 +36,7 @@
 
 #![no_std]
 
-extern crate rand_core;
+pub extern crate rand_core;
 
 #[cfg(feature="serde1")] extern crate serde;
 #[cfg(feature="serde1")] #[macro_use] extern crate serde_derive;

--- a/rand_xorshift/src/lib.rs
+++ b/rand_xorshift/src/lib.rs
@@ -17,7 +17,7 @@
 
 #![no_std]
 
-extern crate rand_core;
+pub extern crate rand_core;
 
 #[cfg(feature="serde1")] extern crate serde;
 #[cfg(feature="serde1")] #[macro_use] extern crate serde_derive;

--- a/rand_xoshiro/src/lib.rs
+++ b/rand_xoshiro/src/lib.rs
@@ -76,7 +76,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
 #![no_std]
 extern crate byteorder;
-extern crate rand_core;
+pub extern crate rand_core;
 
 #[macro_use]
 mod common;


### PR DESCRIPTION
This PR re-exports `rand_core` in all RNG crates in the same way as was done for `rand_os`.