### PR TITLE
Disable default features for rand_core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,4 @@ fuchsia-zircon = "0.3.2"
 
 [target.'cfg(target_env = "sgx")'.dependencies]
 rdrand = "0.4.0"
-rand_core = "0.3.0"
+rand_core = { version = "0.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
I haven't added `std = ["rand_core/std"]`, as I am not sure how it will work for optional dependency.

#688 