### PR TITLE
Fix `wasm32_bindgen` implementation

### DIFF
--- a/rand_os/src/wasm32_bindgen.rs
+++ b/rand_os/src/wasm32_bindgen.rs
@@ -10,43 +10,10 @@
 
 use rand_core::{Error, ErrorKind};
 use super::OsRngImpl;
+use super::__wbg_shims::*;
 
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
-extern "C" {
-    pub type Function;
-    #[wasm_bindgen(constructor)]
-    pub fn new(s: &str) -> Function;
-    #[wasm_bindgen(method)]
-    pub fn call(this: &Function, self_: &JsValue) -> JsValue;
-
-    pub type This;
-    #[wasm_bindgen(method, getter, structural, js_name = self)]
-    pub fn self_(me: &This) -> JsValue;
-    #[wasm_bindgen(method, getter, structural)]
-    pub fn crypto(me: &This) -> JsValue;
-
-    #[derive(Clone, Debug)]
-    pub type BrowserCrypto;
-
-    // TODO: these `structural` annotations here ideally wouldn't be here to
-    // avoid a JS shim, but for now with feature detection they're
-    // unavoidable.
-    #[wasm_bindgen(method, js_name = getRandomValues, structural, getter)]
-    pub fn get_random_values_fn(me: &BrowserCrypto) -> JsValue;
-    #[wasm_bindgen(method, js_name = getRandomValues, structural)]
-    pub fn get_random_values(me: &BrowserCrypto, buf: &mut [u8]);
-
-    #[wasm_bindgen(js_name = require)]
-    pub fn node_require(s: &str) -> NodeCrypto;
-
-    #[derive(Clone, Debug)]
-    pub type NodeCrypto;
-
-    #[wasm_bindgen(method, js_name = randomFillSync, structural)]
-    pub fn random_fill_sync(me: &NodeCrypto, buf: &mut [u8]);
-}
 
 #[derive(Clone, Debug)]
 pub enum OsRng {


### PR DESCRIPTION
Use the `__wbg_shims` imports instead of creating new, local imports in the `wasm32_bindgen` module.

Fixes https://github.com/rustwasm/wasm-bindgen/issues/1189

+cc @alexcrichton @stevebob