### PR TITLE
Fix quick start documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! let y: f64 = rng.gen(); // generates a float between 0 and 1
 //!
 //! let mut nums: Vec<i32> = (1..100).collect();
-//! nums.shuffle(&mut rng);
+//! rng.shuffle(&mut nums);
 //! ```
 //!
 //! # The Book


### PR DESCRIPTION
Two variables were swapped accidentally.