### PR TITLE
Switch rand_os to use fuchsia-cprng crate in rand-0.6

### DIFF
--- a/rand_os/Cargo.toml
+++ b/rand_os/Cargo.toml
@@ -28,7 +28,7 @@ winapi = { version = "0.3", features = ["minwindef", "ntsecapi", "winnt"] }
 cloudabi = "0.0.3"
 
 [target.'cfg(target_os = "fuchsia")'.dependencies]
-fuchsia-zircon = "0.3.2"
+fuchsia-cprng = "0.1.0"
 
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = { version = "0.2.12", optional = true }

--- a/rand_os/src/fuchsia.rs
+++ b/rand_os/src/fuchsia.rs
@@ -8,9 +8,9 @@
 
 //! Implementation for Fuchsia Zircon
 
-extern crate fuchsia_zircon;
+extern crate fuchsia_cprng;
 
-use rand_core::{Error, ErrorKind};
+use rand_core::Error;
 use super::OsRngImpl;
 
 #[derive(Clone, Debug)]
@@ -20,23 +20,8 @@ impl OsRngImpl for OsRng {
     fn new() -> Result<OsRng, Error> { Ok(OsRng) }
 
     fn fill_chunk(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        let mut read = 0;
-        while read < dest.len() {
-            match fuchsia_zircon::cprng_draw(&mut dest[read..]) {
-                Ok(actual) => read += actual,
-                Err(e) => {
-                    return Err(Error::with_cause(
-                        ErrorKind::Unavailable,
-                        "cprng_draw failed",
-                        e.into_io_error()));
-                }
-            };
-        }
+        fuchsia_cprng::cprng_draw(dest);
         Ok(())
-    }
-
-    fn max_chunk_size(&self) -> usize {
-        fuchsia_zircon::sys::ZX_CPRNG_DRAW_MAX_LEN
     }
 
     fn method_str(&self) -> &'static str { "cprng_draw" }


### PR DESCRIPTION
The fuchsia team has spun out a new crate, [fuchsia-cprng](https://crates.io/crates/fuchsia-cprng), which reduces your exposure to changes in our syscalls, which are still not stable. This crate just exposes the CPRNG syscall, which we do not expect to change.

Also note, the underlying syscall, [zx_cprng_draw](https://fuchsia.googlesource.com/zircon/+/HEAD/docs/syscalls/cprng_draw.md) no longer needs the loop. Instead, we guarantee that the buffer always be filled with randomness.

If this patch is accepted, would it be possible to get a release of rand_os? We also have some dependencies that are using 0.3, 0.4, and 0.5, so would you also be interested in patches for those versions as well?

Thanks!