### PR TITLE
Remove unnecessary import of fuchsia-zircon in rand-0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.3.22"
+version = "0.3.23"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -26,6 +26,3 @@ rand = "0.4"
 
 [workspace]
 members = ["rand-derive"]
-
-[target.'cfg(target_os = "fuchsia")'.dependencies]
-fuchsia-zircon = "0.3.2"


### PR DESCRIPTION
The fuchsia project is trying to purge users of fuchsia-zircon
and instead replace them with the much slimmer fuchsia-cprng,
which only exposes the CPRNG for the OS. There are still a few
users of 0.3.x, like multipart and rust-crypto. Since rand 0.3
is just re-exporting 0.4, there is no reason to explicitly
depend on fuchsia-zircon, so this just removes this dependency.

If this is accepted, could a new version of 0.3 be cut?

Thanks so much!