### PR TITLE
Bump rand_os version number

### DIFF
--- a/rand_os/CHANGELOG.md
+++ b/rand_os/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.2] - 2019-01-28
+### Changes
+- Fuchsia: Replaced fuchsia-zircon with fuchsia-cprng
+
 ## [0.1.1] - 2019-01-08
 ### Additions
 - Add support for x86_64-fortanix-unknown-sgx target (#670)

--- a/rand_os/Cargo.toml
+++ b/rand_os/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_os"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Rand Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
I missed that rand got refactored, and the fuchsia update in #706 should have triggered a release for rand_os, not rand. I'm sorry to be a bother again, but would it be possible to get one more release for rand_os 0.1.2? Thanks so much helping us out!