### PR TITLE
Fix rand_jitter on older versions of rust

### DIFF
--- a/rand_jitter/src/platform.rs
+++ b/rand_jitter/src/platform.rs
@@ -21,6 +21,8 @@ pub fn get_nstime() -> u64 {
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 pub fn get_nstime() -> u64 {
+    use libc;
+    
     // On Mac OS and iOS std::time::SystemTime only has 1000ns resolution.
     // We use `mach_absolute_time` instead. This provides a CPU dependent
     // unit, to get real nanoseconds the result should by multiplied by


### PR DESCRIPTION
In at least rust 1.26 on osx, rand_jitter has a compile error due to libc not being imported. I'm guessing this was fixed as part of the 2018 edition, which is why this isn't showing up on the stable build.