### PR TITLE
Fix rand_jitter on windows for older rust versions

### DIFF
--- a/rand_jitter/src/platform.rs
+++ b/rand_jitter/src/platform.rs
@@ -34,6 +34,8 @@ pub fn get_nstime() -> u64 {
 
 #[cfg(target_os = "windows")]
 pub fn get_nstime() -> u64 {
+    use winapi;
+
     unsafe {
         let mut t = super::mem::zeroed();
         winapi::um::profileapi::QueryPerformanceCounter(&mut t);


### PR DESCRIPTION
This is a similar issue to #720.