### PR TITLE
Implement Standard support for NonZero* types (Rustc ≥ 1.28)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,4 +7,5 @@ fn main() {
     ac.emit_rustc_version(1, 25);
     ac.emit_rustc_version(1, 26);
     ac.emit_rustc_version(1, 27);
+    ac.emit_rustc_version(1, 28);
 }


### PR DESCRIPTION
Closes #727 

There is some performance impact over the base type, but it's small given the required test and branch:
```
test distr_standard_f32             ... bench:       2,702 ns/iter (+/- 106) = 1480 MB/s
test distr_standard_f64             ... bench:       2,829 ns/iter (+/- 42) = 2827 MB/s
test distr_standard_i128            ... bench:       2,479 ns/iter (+/- 37) = 6454 MB/s
test distr_standard_i16             ... bench:       1,219 ns/iter (+/- 26) = 1640 MB/s
test distr_standard_i32             ... bench:       1,197 ns/iter (+/- 23) = 3341 MB/s
test distr_standard_i64             ... bench:       1,197 ns/iter (+/- 23) = 6683 MB/s
test distr_standard_i8              ... bench:       1,199 ns/iter (+/- 20) = 834 MB/s
test distr_standard_nz128           ... bench:       2,678 ns/iter (+/- 41) = 5974 MB/s
test distr_standard_nz16            ... bench:       1,344 ns/iter (+/- 18) = 1488 MB/s
test distr_standard_nz32            ... bench:       1,345 ns/iter (+/- 82) = 2973 MB/s
test distr_standard_nz64            ... bench:       1,364 ns/iter (+/- 119) = 5865 MB/s
test distr_standard_nz8             ... bench:       1,450 ns/iter (+/- 139) = 689 MB/s
```