### PR TITLE
Fix deprecation warnings for atomics initialization

### DIFF
--- a/rand_jitter/src/lib.rs
+++ b/rand_jitter/src/lib.rs
@@ -75,7 +75,10 @@ pub use error::TimerError;
 
 use core::{fmt, mem, ptr};
 #[cfg(feature = "std")]
-use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(feature = "std")]
+#[allow(deprecated)]  // Required for compatibility with Rust < 1.24.
+use std::sync::atomic::ATOMIC_USIZE_INIT;
 
 const MEMORY_BLOCKS: usize = 64;
 const MEMORY_BLOCKSIZE: usize = 32;
@@ -167,6 +170,7 @@ impl Clone for JitterRng {
 
 // Initialise to zero; must be positive
 #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+#[allow(deprecated)]
 static JITTER_ROUNDS: AtomicUsize = ATOMIC_USIZE_INIT;
 
 impl JitterRng {

--- a/rand_os/src/linux_android.rs
+++ b/rand_os/src/linux_android.rs
@@ -18,7 +18,9 @@ use std::io;
 use std::io::Read;
 use std::fs::{File, OpenOptions};
 use std::os::unix::fs::OpenOptionsExt;
-use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
+#[allow(deprecated)]  // Required for compatibility with Rust < 1.24.
+use std::sync::atomic::ATOMIC_BOOL_INIT;
 use std::sync::{Once, ONCE_INIT};
 
 #[derive(Clone, Debug)]
@@ -53,6 +55,7 @@ impl OsRngImpl for OsRng {
     fn test_initialized(&mut self, dest: &mut [u8], blocking: bool)
         -> Result<usize, Error>
     {
+        #[allow(deprecated)]
         static OS_RNG_INITIALIZED: AtomicBool = ATOMIC_BOOL_INIT;
         if !self.initialized {
             self.initialized = OS_RNG_INITIALIZED.load(Ordering::Relaxed);
@@ -160,6 +163,7 @@ fn getrandom_try_fill(dest: &mut [u8], blocking: bool) -> Result<(), Error> {
 
 fn is_getrandom_available() -> bool {
     static CHECKER: Once = ONCE_INIT;
+    #[allow(deprecated)]
     static AVAILABLE: AtomicBool = ATOMIC_BOOL_INIT;
 
     if NR_GETRANDOM == 0 { return false };

--- a/rand_os/src/netbsd.rs
+++ b/rand_os/src/netbsd.rs
@@ -14,7 +14,9 @@ use super::OsRngImpl;
 
 use std::fs::File;
 use std::io::Read;
-use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
+#[allow(deprecated)]  // Required for compatibility with Rust < 1.24.
+use std::sync::atomic::ATOMIC_BOOL_INIT;
 
 #[derive(Clone, Debug)]
 pub struct OsRng { initialized: bool }
@@ -34,6 +36,7 @@ impl OsRngImpl for OsRng {
     fn test_initialized(&mut self, dest: &mut [u8], _blocking: bool)
         -> Result<usize, Error>
     {
+        #[allow(deprecated)]
         static OS_RNG_INITIALIZED: AtomicBool = ATOMIC_BOOL_INIT;
         if !self.initialized {
             self.initialized = OS_RNG_INITIALIZED.load(Ordering::Relaxed);

--- a/rand_os/src/solarish.rs
+++ b/rand_os/src/solarish.rs
@@ -28,7 +28,9 @@ use std::io;
 use std::io::Read;
 use std::fs::{File, OpenOptions};
 use std::os::unix::fs::OpenOptionsExt;
-use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering, AtomicUsize};
+use std::sync::atomic::{AtomicBool, Ordering, AtomicUsize};
+#[allow(deprecated)]  // Required for compatibility with Rust < 1.24.
+use std::sync::atomic::ATOMIC_BOOL_INIT;
 use std::cmp;
 use std::mem;
 
@@ -68,6 +70,7 @@ impl OsRngImpl for OsRng {
     fn test_initialized(&mut self, dest: &mut [u8], blocking: bool)
         -> Result<usize, Error>
     {
+        #[allow(deprecated)]
         static OS_RNG_INITIALIZED: AtomicBool = ATOMIC_BOOL_INIT;
         if !self.initialized {
             self.initialized = OS_RNG_INITIALIZED.load(Ordering::Relaxed);

--- a/src/rngs/adapter/reseeding.rs
+++ b/src/rngs/adapter/reseeding.rs
@@ -286,8 +286,9 @@ where R: BlockRngCore + SeedableRng + CryptoRng,
 mod fork {
     extern crate libc;
 
-    use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
-    use core::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT};
+    use core::sync::atomic::{AtomicUsize, AtomicBool, Ordering};
+    #[allow(deprecated)]  // Required for compatibility with Rust < 1.24.
+    use core::sync::atomic::{ATOMIC_USIZE_INIT, ATOMIC_BOOL_INIT};
 
     // Fork protection
     //
@@ -301,12 +302,14 @@ mod fork {
     // don't update `fork_counter`, so a reseed is attempted as soon as
     // possible.
 
+    #[allow(deprecated)]
     static RESEEDING_RNG_FORK_COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
 
     pub fn get_fork_counter() -> usize {
         RESEEDING_RNG_FORK_COUNTER.load(Ordering::Relaxed)
     }
 
+    #[allow(deprecated)]
     static FORK_HANDLER_REGISTERED: AtomicBool = ATOMIC_BOOL_INIT;
 
     extern fn fork_handler() {


### PR DESCRIPTION
Since Rust 1.34, `ATOMIC_*_INIT` is deprecated in favor of
`Atomic*::new`. However, this requires the latter to be `const`, which
is not the case for older Rust versions.

Alternatively, we could detect the Rust version by introducing build
scripts to the crates lacking them. However, this increases build time
for a very minor benefit, so the deprecation warnings are ignored
instead.

Fixes #736.