### PR TITLE
rand_pcg: prepare 0.1.2 release with i128 auto-detection

### DIFF
--- a/rand_pcg/CHANGELOG.md
+++ b/rand_pcg/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.2] - unreleased
-- potential blocker: https://github.com/TyOverby/bincode/issues/250
-- make `bincode` a dev-dependency again
+## [0.1.2] - 2019-02-23
+- require `bincode` 1.1.2 for i128 auto-detection
+- make `bincode` a dev-dependency again #663
 - clean up tests and Serde support
 
 ## [0.1.1] - 2018-10-04

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_pcg"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Rand Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -29,9 +29,8 @@ serde_derive = { version = "^1.0.38", optional = true }
 [dev-dependencies]
 # This is for testing serde, unfortunately we can't specify feature-gated dev
 # deps yet, see: https://github.com/rust-lang/cargo/issues/1596
-# TODO: we shouldn't have to depend on i128 directly; it breaks tests on old
-# compilers. `bincode` should automatically support this.
-bincode = { version = "1", features = ["i128"] }
+# We require at least 1.1.2 for i128 auto-detection
+bincode = { version = "1.1.2" }
 
 [build-dependencies]
 autocfg = "0.1"

--- a/rand_pcg/README.md
+++ b/rand_pcg/README.md
@@ -29,18 +29,10 @@ Links:
 
 ## Crate Features
 
-`rand_pcg` is `no_std` compatible. It does not require any functionality
-outside of the `core` lib, thus there are no features to configure.
+`rand_pcg` is `no_std` compatible by default.
 
 The `serde1` feature includes implementations of `Serialize` and `Deserialize`
-for the included RNGs. NOTE: to use binary serialisation with any of the 64-bit
-output (128-bit internal) RNGs, you must add the following dependency, since the
-`i128` feature is not current enabled by default (this should be fixed soon):
-
-```
-bincode = { version = "1", features = ["i128"] }
-```
-
+for the included RNGs.
 
 ## License
 


### PR DESCRIPTION
Fixes #663 

This is slated for release tomorrow. Reviews welcome.

Unfortunately the previous release occurred when this was part of the `small-rngs` repository, hence there is no git commit here to compare against.