### PR TITLE
Inline Standard's SIMD float cast

### DIFF
--- a/src/distributions/utils.rs
+++ b/src/distributions/utils.rs
@@ -383,6 +383,7 @@ macro_rules! simd_impl {
                 <$ty>::from_bits(<$uty>::from_bits(self) + <$uty>::from_bits(mask))
             }
             type UInt = $uty;
+            #[inline]
             fn cast_from_int(i: Self::UInt) -> Self { i.cast() }
         }
     }


### PR DESCRIPTION
Typically adds 2 or 3 instructions to float SIMD sampling. 