### PR TITLE
Add '/' to all documents on github.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand"
+documentation = "https://rust-random.github.io/rand/"
 homepage = "https://crates.io/crates/rand"
 description = """
 Random number generators and other randomness functionality.

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_chacha"
+documentation = "https://rust-random.github.io/rand/rand_chacha/"
 homepage = "https://crates.io/crates/rand_chacha"
 description = """
 ChaCha random number generator

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_core"
+documentation = "https://rust-random.github.io/rand/rand_core/"
 homepage = "https://crates.io/crates/rand_core"
 description = """
 Core random number generator traits and tools for implementation.

--- a/rand_hc/Cargo.toml
+++ b/rand_hc/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_hc"
+documentation = "https://rust-random.github.io/rand/rand_hc/"
 homepage = "https://crates.io/crates/rand_hc"
 description = """
 HC128 random number generator

--- a/rand_isaac/Cargo.toml
+++ b/rand_isaac/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_isaac"
+documentation = "https://rust-random.github.io/rand/rand_isaac/"
 homepage = "https://crates.io/crates/rand_isaac"
 description = """
 ISAAC random number generator

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_pcg"
+documentation = "https://rust-random.github.io/rand/rand_pcg/"
 homepage = "https://crates.io/crates/rand_pcg"
 description = """
 Selected PCG random number generators

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_xorshift"
+documentation = "https://rust-random.github.io/rand/rand_xorshift/"
 homepage = "https://crates.io/crates/rand_xorshift"
 description = """
 Xorshift random number generator


### PR DESCRIPTION
It seems github.io has an issue that if you enter something like `https://rust-random.github.io/rand/rand_chacha`, it would 301 redirect to `http://rust-random.github.io/rand/rand_chacha/` (`https` downgraded to `http` for the trailing slash).

This PR adds the trailing slash to all documentation links to github.io to avoid this downgrade.

(I should probably report this to GitHub as well, since it's quite unfortunate.)