### PR TITLE
Distribution::sample_iter changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,13 +206,19 @@ pub trait Rng: RngCore {
 
     /// Create an iterator that generates values using the given distribution.
     ///
+    /// Note that this function takes its arguments by value. This works since
+    /// `(&mut R): Rng where R: Rng` and
+    /// `(&D): Distribution where D: Distribution`,
+    /// however borrowing is not automatic hence `rng.sample_iter(...)` may
+    /// need to be replaced with `(&mut rng).sample_iter(...)`.
+    ///
     /// # Example
     ///
     /// ```
     /// use rand::{thread_rng, Rng};
     /// use rand::distributions::{Alphanumeric, Uniform, Standard};
     ///
-    /// let mut rng = thread_rng();
+    /// let rng = thread_rng();
     ///
     /// // Vec of 16 x f32:
     /// let v: Vec<f32> = rng.sample_iter(Standard).take(16).collect();
@@ -231,8 +237,8 @@ pub trait Rng: RngCore {
     ///     println!("Not a 6; rolling again!");
     /// }
     /// ```
-    fn sample_iter<'a, T, D>(&'a mut self, distr: D) -> distributions::DistIter<'a, D, Self, T>
-    where D: Distribution<T>, Self: 'a {
+    fn sample_iter<T, D>(self, distr: D) -> distributions::DistIter<D, Self, T>
+    where D: Distribution<T>, Self: Sized {
         distr.sample_iter(self)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,26 +215,24 @@ pub trait Rng: RngCore {
     /// let mut rng = thread_rng();
     ///
     /// // Vec of 16 x f32:
-    /// let v: Vec<f32> = thread_rng().sample_iter(&Standard).take(16).collect();
+    /// let v: Vec<f32> = rng.sample_iter(Standard).take(16).collect();
     ///
     /// // String:
-    /// let s: String = rng.sample_iter(&Alphanumeric).take(7).collect();
+    /// let s: String = rng.sample_iter(Alphanumeric).take(7).collect();
     ///
     /// // Combined values
-    /// println!("{:?}", thread_rng().sample_iter(&Standard).take(5)
+    /// println!("{:?}", rng.sample_iter(Standard).take(5)
     ///                              .collect::<Vec<(f64, bool)>>());
     ///
     /// // Dice-rolling:
     /// let die_range = Uniform::new_inclusive(1, 6);
-    /// let mut roll_die = rng.sample_iter(&die_range);
+    /// let mut roll_die = rng.sample_iter(die_range);
     /// while roll_die.next().unwrap() != 6 {
     ///     println!("Not a 6; rolling again!");
     /// }
     /// ```
-    fn sample_iter<'a, T, D: Distribution<T>>(
-        &'a mut self, distr: &'a D,
-    ) -> distributions::DistIter<'a, D, Self, T>
-    where Self: Sized {
+    fn sample_iter<'a, T, D>(&'a mut self, distr: D) -> distributions::DistIter<'a, D, Self, T>
+    where D: Distribution<T>, Self: 'a {
         distr.sample_iter(self)
     }
 

--- a/src/rngs/thread.rs
+++ b/src/rngs/thread.rs
@@ -67,7 +67,7 @@ const THREAD_RNG_RESEED_THRESHOLD: u64 = 32*1024*1024; // 32 MiB
 /// [`ReseedingRng`]: crate::rngs::adapter::ReseedingRng
 /// [`StdRng`]: crate::rngs::StdRng
 /// [HC-128]: rand_hc::Hc128Rng
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct ThreadRng {
     // use of raw pointer implies type is neither Send nor Sync
     rng: *mut ReseedingRng<Hc128Core, OsRng>,


### PR DESCRIPTION
Implements #602, #725. (In fact, the former makes the latter irrelevant.)

I am happy with the first commit (#725).

The second (#602) is a little controversial, and unfortunately does not match up with `fn sample`. See the comments.

@fizyk20 @huonw @burdges review please?