### PR TITLE
Bump MSRV to 1.32.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,9 @@ sudo: false
 # CRATE FEATURES, TESTS, AND SUB-CRATES
 # Goal: Run unit tests, doctests, examples, and test benchmarks for all crates,
 #       in configurations that cover all interesting combinations of features.
-# (`--lib` only runs unit tests just like `--tests`, but the latter is not
-# available in Rust 1.22.0)
 # Tests run on rand:
 # - test no_std support, but only the unit tests:
-#   `cargo test --lib --no-default-features`
+#   `cargo test --tests --no-default-features`
 # - run unit tests and doctests with all features which are available on stable:
 #   `cargo test --features=serde1,log`
 # - test examples:
@@ -47,7 +45,7 @@ sudo: false
 # - run unit tests and doctests with all features which are available on nightly:
 #   `cargo test --all-features`
 # - test no_std support, including the nightly alloc feature:
-#   cargo test --lib --no-default-features --features=alloc
+#   cargo test --tests --no-default-features --features=alloc
 # - run benchmarks as tests:
 #   `cargo test --benches --features=nightly`
 # Tests on subcrates:
@@ -58,12 +56,12 @@ sudo: false
 # NOTE: SIMD support is unreliable on nightly; we track the latest release
 matrix:
   include:
-    - rust: 1.22.0
-      env: DESCRIPTION="Linux, 1.22.0"
+    - rust: 1.32.0
+      env: DESCRIPTION="Linux, 1.32.0"
       os: linux
       script:
         # Differs from standard script: rand_pcg features
-        - cargo test --lib --no-default-features
+        - cargo test --tests --no-default-features
         # TODO: add simd_support feature:
         - cargo test --features=serde1,log
         - cargo test --examples
@@ -78,12 +76,12 @@ matrix:
         - cargo test --manifest-path rand_jitter/Cargo.toml
         - cargo test --manifest-path rand_os/Cargo.toml
 
-    - rust: 1.22.0
-      env: DESCRIPTION="OSX, 1.22.0"
+    - rust: 1.32.0
+      env: DESCRIPTION="OSX, 1.32.0"
       os: osx
       script:
         # Differs from standard script: rand_pcg features
-        - cargo test --lib --no-default-features
+        - cargo test --tests --no-default-features
         # TODO: add simd_support feature:
         - cargo test --features=serde1,log
         - cargo test --examples
@@ -108,7 +106,7 @@ matrix:
         - rustup target add aarch64-apple-ios
       script:
         # Differs from standard script: includes aarch64-apple-ios cross-build
-        - cargo test --lib --no-default-features
+        - cargo test --tests --no-default-features
         # TODO: add simd_support feature:
         - cargo test --features=serde1,log
         - cargo test --examples
@@ -137,7 +135,7 @@ matrix:
         - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
       script:
         # Differs from standard script: alloc feature, all features, doc build
-        - cargo test --lib --no-default-features --features=alloc
+        - cargo test --tests --no-default-features --features=alloc
         - cargo test --all-features
         - cargo test --benches --features=nightly
         - cargo test --examples
@@ -166,7 +164,7 @@ matrix:
         - cargo deadlinks -V
       script:
         # Differs from standard script: alloc feature, all features, doc build
-        - cargo test --lib --no-default-features --features=alloc
+        - cargo test --tests --no-default-features --features=alloc
         - cargo test --all-features
         - cargo test --benches --features=nightly
         - cargo test --examples
@@ -257,7 +255,7 @@ before_install:
   - rustup self update
 
 script:
-  - cargo test --lib --no-default-features
+  - cargo test --tests --no-default-features
   # TODO: add simd_support feature:
   - cargo test --features=serde1,log
   - cargo test --examples

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand)
 [![API](https://docs.rs/rand/badge.svg)](https://docs.rs/rand)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.32+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 A Rust library for random number generation.
 
@@ -57,8 +57,9 @@ reading the [Upgrade Guide](https://rust-random.github.io/book/update.html).
 
 ### Rust version requirements
 
-Since version 0.5, Rand requires **Rustc version 1.22 or greater**.
-Rand 0.4 and 0.3 (since approx. June 2017) require Rustc version 1.15 or
+Since version 0.7 (unreleased), Rand requires **Rustc version 1.32 or greater**.
+Rand 0.5 requires Rustc 1.22 or greater while versions
+0.4 and 0.3 (since approx. June 2017) require Rustc version 1.15 or
 greater. Subsets of the Rand code may work with older Rust versions, but this
 is not supported.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
 build: false
 
 test_script:
-  - cargo test --lib --no-default-features --features alloc
+  - cargo test --tests --no-default-features --features alloc
   # TODO: use --all-features once simd_support is sufficiently stable:
   - cargo test --features=serde1,log
   - cargo test --benches --features=nightly

--- a/rand_chacha/README.md
+++ b/rand_chacha/README.md
@@ -6,7 +6,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_chacha)
 [![API](https://docs.rs/rand_chacha/badge.svg)](https://docs.rs/rand_chacha)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.32+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 A cryptographically secure random number generator that uses the ChaCha
 algorithm.

--- a/rand_core/README.md
+++ b/rand_core/README.md
@@ -6,7 +6,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_core)
 [![API](https://docs.rs/rand_core/badge.svg)](https://docs.rs/rand_core)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.32+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 Core traits and error types of the [rand] library, plus tools for implementing
 RNGs.

--- a/rand_hc/README.md
+++ b/rand_hc/README.md
@@ -6,7 +6,7 @@
 [[![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_hc)
 [![API](https://docs.rs/rand_hc/badge.svg)](https://docs.rs/rand_hc)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.32+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 A cryptographically secure random number generator that uses the HC-128
 algorithm.

--- a/rand_isaac/README.md
+++ b/rand_isaac/README.md
@@ -6,7 +6,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_isaac)
 [![API](https://docs.rs/rand_isaac/badge.svg)](https://docs.rs/rand_isaac)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.32+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 Implements the ISAAC and ISAAC-64 random number generators.
 

--- a/rand_jitter/README.md
+++ b/rand_jitter/README.md
@@ -5,7 +5,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_jitter)
 [![API](https://docs.rs/rand_os/badge.svg)](https://docs.rs/rand_jitter)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.32+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 Non-physical true random number generator based on timing jitter.
 

--- a/rand_os/README.md
+++ b/rand_os/README.md
@@ -6,7 +6,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_os)
 [![API](https://docs.rs/rand_os/badge.svg)](https://docs.rs/rand_os)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.32+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 A random number generator that retrieves randomness straight from the
 operating system.

--- a/rand_pcg/README.md
+++ b/rand_pcg/README.md
@@ -6,7 +6,7 @@
 [[![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_pcg)
 [![API](https://docs.rs/rand_pcg/badge.svg)](https://docs.rs/rand_pcg)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.32+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 Implements a selection of PCG random number generators.
 

--- a/rand_xorshift/README.md
+++ b/rand_xorshift/README.md
@@ -6,7 +6,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_xorshift)
 [![API](https://docs.rs/rand_xorshift/badge.svg)](https://docs.rs/rand_xorshift)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.32+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 Implements the Xorshift random number generator.
 

--- a/rand_xoshiro/README.md
+++ b/rand_xoshiro/README.md
@@ -6,7 +6,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_xoshiro)
 [![API](https://docs.rs/rand_xoshiro/badge.svg)](https://docs.rs/rand_xoshiro)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.32+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 Rust implementation of the [xoshiro, xoroshiro and splitmix64](http://xoshiro.di.unimi.it) random number generators.
 

--- a/utils/ci/script.sh
+++ b/utils/ci/script.sh
@@ -3,7 +3,7 @@
 set -ex
 
 main() {
-    cross test --target $TARGET --lib --no-default-features
+    cross test --target $TARGET --tests --no-default-features
   # TODO: add simd_support feature:
     cross test --target $TARGET --features=serde1,log
     cross test --target $TARGET --examples


### PR DESCRIPTION
Increase the minimum supported Rustc version to 1.32.0.

Closes #719. Required for #761.

This has been discussed in #719. The consensus appears to be that nobody cares enough to request support for older compilers, thus it makes sense to take advantage of modern features. This is a last chance to raise objections, although Rand 0.6.x will likely continue to support 1.22.

This PR does not clean up build scripts, `cfg` items or switch to Edition 2018. I suggest we do not do this yet to avoid conflicts with #761 and work in `getrandom`.