### PR TITLE
Depend on libc version required for `pthread_atfork`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ features = ["into_bits"]
 
 [target.'cfg(unix)'.dependencies]
 # Used for fork protection (reseeding.rs)
-libc = { version = "0.2", default-features = false }
+libc = { version = "0.2.22", default-features = false }
 
 [dev-dependencies]
 # This has a histogram implementation used for testing uniformity.


### PR DESCRIPTION
Fixes #47.