### PR TITLE
Remove `{UnitSphereSurface, UnitCircle}::new`

### DIFF
--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -207,8 +207,8 @@ distr_int!(distr_binomial, u64, Binomial::new(20, 0.7));
 distr_int!(distr_binomial_small, u64, Binomial::new(1000000, 1e-30));
 distr_int!(distr_poisson, u64, Poisson::new(4.0));
 distr!(distr_bernoulli, bool, Bernoulli::new(0.18));
-distr_arr!(distr_circle, [f64; 2], UnitCircle::new());
-distr_arr!(distr_sphere_surface, [f64; 3], UnitSphereSurface::new());
+distr_arr!(distr_circle, [f64; 2], UnitCircle);
+distr_arr!(distr_sphere_surface, [f64; 3], UnitSphereSurface);
 
 // Weighted
 distr_int!(distr_weighted_i8, usize, WeightedIndex::new(&[1i8, 2, 3, 4, 12, 0, 2, 1]).unwrap());

--- a/rand_distr/src/unit_circle.rs
+++ b/rand_distr/src/unit_circle.rs
@@ -19,8 +19,7 @@ use crate::{Distribution, Uniform};
 /// ```
 /// use rand_distr::{UnitCircle, Distribution};
 ///
-/// let circle = UnitCircle::new();
-/// let v = circle.sample(&mut rand::thread_rng());
+/// let v = UnitCircle.sample(&mut rand::thread_rng());
 /// println!("{:?} is from the unit circle.", v)
 /// ```
 ///
@@ -30,14 +29,6 @@ use crate::{Distribution, Uniform};
 ///       Office, pp. 36-38.
 #[derive(Clone, Copy, Debug)]
 pub struct UnitCircle;
-
-impl UnitCircle {
-    /// Construct a new `UnitCircle` distribution.
-    #[inline]
-    pub fn new() -> UnitCircle {
-        UnitCircle
-    }
-}
 
 impl Distribution<[f64; 2]> for UnitCircle {
     #[inline]
@@ -83,9 +74,8 @@ mod tests {
     #[test]
     fn norm() {
         let mut rng = crate::test::rng(1);
-        let dist = UnitCircle::new();
         for _ in 0..1000 {
-            let x = dist.sample(&mut rng);
+            let x = UnitCircle.sample(&mut rng);
             assert_almost_eq!(x[0]*x[0] + x[1]*x[1], 1., 1e-15);
         }
     }
@@ -93,9 +83,8 @@ mod tests {
     #[test]
     fn value_stability() {
         let mut rng = crate::test::rng(2);
-        let dist = UnitCircle::new();
-        assert_eq!(dist.sample(&mut rng), [-0.8032118336637037, 0.5956935036263119]);
-        assert_eq!(dist.sample(&mut rng), [-0.4742919588505423, -0.880367615130018]);
-        assert_eq!(dist.sample(&mut rng), [0.9297328981467168, 0.368234623716601]);
+        assert_eq!(UnitCircle.sample(&mut rng), [-0.8032118336637037, 0.5956935036263119]);
+        assert_eq!(UnitCircle.sample(&mut rng), [-0.4742919588505423, -0.880367615130018]);
+        assert_eq!(UnitCircle.sample(&mut rng), [0.9297328981467168, 0.368234623716601]);
     }
 }

--- a/rand_distr/src/unit_sphere.rs
+++ b/rand_distr/src/unit_sphere.rs
@@ -19,8 +19,7 @@ use crate::{Distribution, Uniform};
 /// ```
 /// use rand_distr::{UnitSphereSurface, Distribution};
 ///
-/// let sphere = UnitSphereSurface::new();
-/// let v = sphere.sample(&mut rand::thread_rng());
+/// let v = UnitSphereSurface.sample(&mut rand::thread_rng());
 /// println!("{:?} is from the unit sphere surface.", v)
 /// ```
 ///
@@ -29,14 +28,6 @@ use crate::{Distribution, Uniform};
 ///       Ann. Math. Statist. 43, no. 2, 645--646.
 #[derive(Clone, Copy, Debug)]
 pub struct UnitSphereSurface;
-
-impl UnitSphereSurface {
-    /// Construct a new `UnitSphereSurface` distribution.
-    #[inline]
-    pub fn new() -> UnitSphereSurface {
-        UnitSphereSurface
-    }
-}
 
 impl Distribution<[f64; 3]> for UnitSphereSurface {
     #[inline]
@@ -78,9 +69,8 @@ mod tests {
     #[test]
     fn norm() {
         let mut rng = crate::test::rng(1);
-        let dist = UnitSphereSurface::new();
         for _ in 0..1000 {
-            let x = dist.sample(&mut rng);
+            let x = UnitSphereSurface.sample(&mut rng);
             assert_almost_eq!(x[0]*x[0] + x[1]*x[1] + x[2]*x[2], 1., 1e-15);
         }
     }
@@ -88,12 +78,11 @@ mod tests {
     #[test]
     fn value_stability() {
         let mut rng = crate::test::rng(2);
-        let dist = UnitSphereSurface::new();
-        assert_eq!(dist.sample(&mut rng),
+        assert_eq!(UnitSphereSurface.sample(&mut rng),
                    [-0.24950027180862533, -0.7552572587896719, 0.6060825747478084]);
-        assert_eq!(dist.sample(&mut rng),
+        assert_eq!(UnitSphereSurface.sample(&mut rng),
                    [0.47604534507233487, -0.797200864987207, -0.3712837328763685]);
-        assert_eq!(dist.sample(&mut rng),
+        assert_eq!(UnitSphereSurface.sample(&mut rng),
                    [0.9795722330927367, 0.18692349236651176, 0.07414747571708524]);
     }
 }


### PR DESCRIPTION
It is not required for zero-sized types.

Given that #770 makes breaking changes to most constructors, I think we can just remove those instead of deprecating them.