### PR TITLE
fix AsByteSliceMut using raw pointers with bad provenance

### DIFF
--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -51,7 +51,7 @@
 //! [`fill_bytes`]: RngCore::fill_bytes
 
 use core::convert::AsRef;
-use core::fmt;
+use core::{fmt, ptr};
 use {RngCore, CryptoRng, SeedableRng, Error};
 use impls::{fill_via_u32_chunks, fill_via_u64_chunks};
 
@@ -183,7 +183,8 @@ where <R as BlockRngCore>::Results: AsRef<[u32]> + AsMut<[u32]>
         let read_u64 = |results: &[u32], index| {
             if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
                 // requires little-endian CPU supporting unaligned reads:
-                unsafe { *(&results[index] as *const u32 as *const u64) }
+                let ptr: *const u64 = results[index..index+1].as_ptr() as *const u64;
+                unsafe { ptr::read_unaligned(ptr) }
             } else {
                 let x = u64::from(results[index]);
                 let y = u64::from(results[index + 1]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,8 +387,7 @@ macro_rules! impl_as_byte_slice {
                     }
                 } else {
                     unsafe {
-                        slice::from_raw_parts_mut(&mut self[0]
-                            as *mut $t
+                        slice::from_raw_parts_mut(self.as_mut_ptr()
                             as *mut u8,
                             self.len() * mem::size_of::<$t>()
                         )


### PR DESCRIPTION
`&mut slice[0] as *mut _` is a raw pointer that can only be used for the first element.

`slice.as_mut_ptr()` is not only shorter, but also correctly returns a pointer that can be used for the entire slice.

(Found by running the test suite in Miri.)