### PR TITLE
add Miri to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -256,6 +256,12 @@ matrix:
       script:
         - bash utils/ci/script.sh
 
+    - rust: nightly
+      os: linux
+      env: DESCRIPTION="Miri, nightly"
+      script:
+        - sh utils/ci/miri.sh
+
 before_install:
   - set -e
   - rustup self update

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -137,6 +137,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_average() {
         const P: f64 = 0.3;
         const NUM: u32 = 3;

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -287,6 +287,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_binomial() {
         let mut rng = ::test::rng(351);
         test_binomial_mean_and_variance(150, 0.1, &mut rng);

--- a/src/distributions/cauchy.rs
+++ b/src/distributions/cauchy.rs
@@ -67,6 +67,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(miri))] // Miri doesn't support transcendental functions
     fn test_cauchy_median() {
         let cauchy = Cauchy::new(10.0, 5.0);
         let mut rng = ::test::rng(123);
@@ -80,6 +81,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(miri))] // Miri doesn't support transcendental functions
     fn test_cauchy_mean() {
         let cauchy = Cauchy::new(10.0, 5.0);
         let mut rng = ::test::rng(123);

--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -304,11 +304,16 @@ mod test {
     use distributions::Distribution;
     use super::{Beta, ChiSquared, StudentT, FisherF};
 
+    #[cfg(not(miri))] // Miri is too slow
+    const N: u32 = 1000;
+    #[cfg(miri)]
+    const N: u32 = 100;
+
     #[test]
     fn test_chi_squared_one() {
         let chi = ChiSquared::new(1.0);
         let mut rng = ::test::rng(201);
-        for _ in 0..1000 {
+        for _ in 0..N {
             chi.sample(&mut rng);
         }
     }
@@ -316,7 +321,7 @@ mod test {
     fn test_chi_squared_small() {
         let chi = ChiSquared::new(0.5);
         let mut rng = ::test::rng(202);
-        for _ in 0..1000 {
+        for _ in 0..N {
             chi.sample(&mut rng);
         }
     }
@@ -324,7 +329,7 @@ mod test {
     fn test_chi_squared_large() {
         let chi = ChiSquared::new(30.0);
         let mut rng = ::test::rng(203);
-        for _ in 0..1000 {
+        for _ in 0..N {
             chi.sample(&mut rng);
         }
     }
@@ -338,7 +343,7 @@ mod test {
     fn test_f() {
         let f = FisherF::new(2.0, 32.0);
         let mut rng = ::test::rng(204);
-        for _ in 0..1000 {
+        for _ in 0..N {
             f.sample(&mut rng);
         }
     }
@@ -347,7 +352,7 @@ mod test {
     fn test_t() {
         let t = StudentT::new(11.0);
         let mut rng = ::test::rng(205);
-        for _ in 0..1000 {
+        for _ in 0..N {
             t.sample(&mut rng);
         }
     }
@@ -356,7 +361,7 @@ mod test {
     fn test_beta() {
         let beta = Beta::new(1.0, 2.0);
         let mut rng = ::test::rng(201);
-        for _ in 0..1000 {
+        for _ in 0..N {
             beta.sample(&mut rng);
         }
     }

--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -304,9 +304,6 @@ mod test {
     use distributions::Distribution;
     use super::{Beta, ChiSquared, StudentT, FisherF};
 
-    #[cfg(not(miri))] // Miri is too slow
-    const N: u32 = 1000;
-    #[cfg(miri)]
     const N: u32 = 100;
 
     #[test]

--- a/src/distributions/poisson.rs
+++ b/src/distributions/poisson.rs
@@ -108,20 +108,16 @@ mod test {
     use distributions::Distribution;
     use super::Poisson;
 
-    #[cfg(not(miri))] // Miri is too slow
-    const N: u32 = 1000;
-    #[cfg(miri)]
-    const N: u32 = 100;
-
     #[test]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_poisson_10() {
         let poisson = Poisson::new(10.0);
         let mut rng = ::test::rng(123);
         let mut sum = 0;
-        for _ in 0..N {
+        for _ in 0..1000 {
             sum += poisson.sample(&mut rng);
         }
-        let avg = (sum as f64) / (N as f64);
+        let avg = (sum as f64) / 1000.0;
         println!("Poisson average: {}", avg);
         assert!((avg - 10.0).abs() < 0.5); // not 100% certain, but probable enough
     }
@@ -133,10 +129,10 @@ mod test {
         let poisson = Poisson::new(15.0);
         let mut rng = ::test::rng(123);
         let mut sum = 0;
-        for _ in 0..N {
+        for _ in 0..1000 {
             sum += poisson.sample(&mut rng);
         }
-        let avg = (sum as f64) / (N as f64);
+        let avg = (sum as f64) / 1000.0;
         println!("Poisson average: {}", avg);
         assert!((avg - 15.0).abs() < 0.5); // not 100% certain, but probable enough
     }

--- a/src/distributions/poisson.rs
+++ b/src/distributions/poisson.rs
@@ -108,29 +108,35 @@ mod test {
     use distributions::Distribution;
     use super::Poisson;
 
+    #[cfg(not(miri))] // Miri is too slow
+    const N: u32 = 1000;
+    #[cfg(miri)]
+    const N: u32 = 100;
+
     #[test]
     fn test_poisson_10() {
         let poisson = Poisson::new(10.0);
         let mut rng = ::test::rng(123);
         let mut sum = 0;
-        for _ in 0..1000 {
+        for _ in 0..N {
             sum += poisson.sample(&mut rng);
         }
-        let avg = (sum as f64) / 1000.0;
+        let avg = (sum as f64) / (N as f64);
         println!("Poisson average: {}", avg);
         assert!((avg - 10.0).abs() < 0.5); // not 100% certain, but probable enough
     }
 
     #[test]
+    #[cfg(not(miri))] // Miri doesn't support transcendental functions
     fn test_poisson_15() {
         // Take the 'high expected values' path
         let poisson = Poisson::new(15.0);
         let mut rng = ::test::rng(123);
         let mut sum = 0;
-        for _ in 0..1000 {
+        for _ in 0..N {
             sum += poisson.sample(&mut rng);
         }
-        let avg = (sum as f64) / 1000.0;
+        let avg = (sum as f64) / (N as f64);
         println!("Poisson average: {}", avg);
         assert!((avg - 15.0).abs() < 0.5); // not 100% certain, but probable enough
     }

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -972,6 +972,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_integers() {
         use core::{i8, i16, i32, i64, isize};
         use core::{u8, u16, u32, u64, usize};
@@ -1056,6 +1057,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_floats() {
         let mut rng = ::test::rng(252);
         let mut zero_rng = StepRng::new(0, 0);
@@ -1140,6 +1142,7 @@ mod tests {
     #[cfg(all(feature="std",
               not(target_arch = "wasm32"),
               not(target_arch = "asmjs")))]
+    #[cfg(not(miri))] // Miri does not support catching panics
     fn test_float_assertions() {
         use std::panic::catch_unwind;
         use super::SampleUniform;
@@ -1195,6 +1198,7 @@ mod tests {
 
     #[test]
     #[cfg(any(feature = "std", rustc_1_25))]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_durations() {
         #[cfg(feature = "std")]
         use std::time::Duration;

--- a/src/distributions/weighted/alias_method.rs
+++ b/src/distributions/weighted/alias_method.rs
@@ -362,6 +362,7 @@ mod test {
     use super::*;
 
     #[test]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_weighted_index_f32() {
         test_weighted_index(f32::into);
 
@@ -390,12 +391,14 @@ mod test {
 
     #[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
     #[test]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_weighted_index_u128() {
         test_weighted_index(|x: u128| x as f64);
     }
 
     #[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
     #[test]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_weighted_index_i128() {
         test_weighted_index(|x: i128| x as f64);
 
@@ -411,11 +414,13 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_weighted_index_u8() {
         test_weighted_index(u8::into);
     }
 
     #[test]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_weighted_index_i8() {
         test_weighted_index(i8::into);
 

--- a/src/distributions/weighted/mod.rs
+++ b/src/distributions/weighted/mod.rs
@@ -140,6 +140,7 @@ mod test {
     use super::*;
 
     #[test]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_weightedindex() {
         let mut r = ::test::rng(700);
         const N_REPS: u32 = 5000;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -694,6 +694,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_gen_ratio_average() {
         const NUM: u32 = 3;
         const DENOM: u32 = 10;

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -339,6 +339,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_sample_alg() {
         let seed_rng = ::test::rng;
 

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -539,6 +539,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_iterator_choose() {
         let r = &mut ::test::rng(109);
         fn test_iter<R: Rng + ?Sized, Iter: Iterator<Item=usize> + Clone>(r: &mut R, iter: Iter) {
@@ -570,6 +571,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_shuffle() {
         let mut r = ::test::rng(108);
         let empty: &mut [isize] = &mut [];
@@ -655,6 +657,7 @@ mod test {
     
     #[test]
     #[cfg(feature = "alloc")]
+    #[cfg(not(miri))] // Miri is too slow
     fn test_weighted() {
         let mut r = ::test::rng(406);
         const N_REPS: u32 = 3000;

--- a/utils/ci/miri.sh
+++ b/utils/ci/miri.sh
@@ -1,0 +1,19 @@
+set -ex
+
+if rustup component add miri ; then
+    cargo miri setup
+
+    cargo miri test --no-default-features -- -Zmiri-seed=42 -- -Zunstable-options --exclude-should-panic
+    cargo miri test --features=serde1,log -- -Zmiri-seed=42 -- -Zunstable-options --exclude-should-panic
+    cargo miri test --manifest-path rand_core/Cargo.toml
+    cargo miri test --manifest-path rand_core/Cargo.toml --no-default-features
+    #cargo miri test --manifest-path rand_distr/Cargo.toml # no unsafe and lots of slow tests
+    cargo miri test --manifest-path rand_isaac/Cargo.toml --features=serde1
+    cargo miri test --manifest-path rand_pcg/Cargo.toml --features=serde1
+    cargo miri test --manifest-path rand_xorshift/Cargo.toml --features=serde1
+    cargo miri test --manifest-path rand_xoshiro/Cargo.toml
+    cargo miri test --manifest-path rand_chacha/Cargo.toml
+    cargo miri test --manifest-path rand_hc/Cargo.toml
+    cargo miri test --manifest-path rand_jitter/Cargo.toml
+    cargo miri test --manifest-path rand_os/Cargo.toml -- -Zmiri-seed=42
+fi


### PR DESCRIPTION
This adds a CI job running the test suites in Miri -- at least if Miri is available for the current nightly.

Includes https://github.com/rust-random/rand/pull/780.