### PR TITLE
Block RNGs: remove unaligned memory cast

### DIFF
--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -20,8 +20,7 @@ use std::num::{NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128};
 use test::Bencher;
 use std::time::Duration;
 
-use rand::{Rng, FromEntropy};
-use rand::rngs::SmallRng;
+use rand::prelude::*;
 use rand_distr::{*, weighted::WeightedIndex};
 
 macro_rules! distr_int {
@@ -291,3 +290,23 @@ fn dist_iter(b: &mut Bencher) {
     });
     b.bytes = size_of::<f64>() as u64 * ::RAND_BENCH_N;
 }
+
+macro_rules! sample_binomial {
+    ($name:ident, $n:expr, $p:expr) => {
+        #[bench]
+        fn $name(b: &mut Bencher) {
+            let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
+            let (n, p) = ($n, $p);
+            b.iter(|| {
+                let d = Binomial::new(n, p).unwrap();
+                rng.sample(d)
+            })
+        }
+    }
+}
+
+sample_binomial!(misc_binomial_1, 1, 0.9);
+sample_binomial!(misc_binomial_10, 10, 0.9);
+sample_binomial!(misc_binomial_100, 100, 0.99);
+sample_binomial!(misc_binomial_1000, 1000, 0.01);
+sample_binomial!(misc_binomial_1e12, 1000_000_000_000, 0.2);

--- a/benches/generators.rs
+++ b/benches/generators.rs
@@ -70,7 +70,7 @@ gen_bytes!(gen_bytes_isaac, IsaacRng::from_entropy());
 gen_bytes!(gen_bytes_isaac64, Isaac64Rng::from_entropy());
 gen_bytes!(gen_bytes_std, StdRng::from_entropy());
 gen_bytes!(gen_bytes_small, SmallRng::from_entropy());
-gen_bytes!(gen_bytes_os, OsRng::new().unwrap());
+gen_bytes!(gen_bytes_os, OsRng);
 
 macro_rules! gen_uint {
     ($fnn:ident, $ty:ty, $gen:expr) => {
@@ -107,7 +107,7 @@ gen_uint!(gen_u32_isaac, u32, IsaacRng::from_entropy());
 gen_uint!(gen_u32_isaac64, u32, Isaac64Rng::from_entropy());
 gen_uint!(gen_u32_std, u32, StdRng::from_entropy());
 gen_uint!(gen_u32_small, u32, SmallRng::from_entropy());
-gen_uint!(gen_u32_os, u32, OsRng::new().unwrap());
+gen_uint!(gen_u32_os, u32, OsRng);
 
 gen_uint!(gen_u64_xorshift, u64, XorShiftRng::from_entropy());
 gen_uint!(gen_u64_xoshiro256starstar, u64, Xoshiro256StarStar::from_entropy());
@@ -127,7 +127,7 @@ gen_uint!(gen_u64_isaac, u64, IsaacRng::from_entropy());
 gen_uint!(gen_u64_isaac64, u64, Isaac64Rng::from_entropy());
 gen_uint!(gen_u64_std, u64, StdRng::from_entropy());
 gen_uint!(gen_u64_small, u64, SmallRng::from_entropy());
-gen_uint!(gen_u64_os, u64, OsRng::new().unwrap());
+gen_uint!(gen_u64_os, u64, OsRng);
 
 macro_rules! init_gen {
     ($fnn:ident, $gen:ident) => {

--- a/benches/misc.rs
+++ b/benches/misc.rs
@@ -16,6 +16,7 @@ const RAND_BENCH_N: u64 = 1000;
 use test::Bencher;
 
 use rand::prelude::*;
+use rand::distributions::{Distribution, Standard, Bernoulli};
 
 #[bench]
 fn misc_gen_bool_const(b: &mut Bencher) {
@@ -87,33 +88,13 @@ fn misc_bernoulli_var(b: &mut Bencher) {
         let mut accum = true;
         let mut p = 0.18;
         for _ in 0..::RAND_BENCH_N {
-            let d = rand::distributions::Bernoulli::new(p);
+            let d = Bernoulli::new(p);
             accum ^= rng.sample(d);
             p += 0.0001;
         }
         accum
     })
 }
-
-macro_rules! sample_binomial {
-    ($name:ident, $n:expr, $p:expr) => {
-        #[bench]
-        fn $name(b: &mut Bencher) {
-            let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
-            let (n, p) = ($n, $p);
-            b.iter(|| {
-                let d = rand::distributions::Binomial::new(n, p);
-                rng.sample(d)
-            })
-        }
-    }
-}
-
-sample_binomial!(misc_binomial_1, 1, 0.9);
-sample_binomial!(misc_binomial_10, 10, 0.9);
-sample_binomial!(misc_binomial_100, 100, 0.99);
-sample_binomial!(misc_binomial_1000, 1000, 0.01);
-sample_binomial!(misc_binomial_1e12, 1000_000_000_000, 0.2);
 
 #[bench]
 fn gen_1k_iter_repeat(b: &mut Bencher) {
@@ -128,7 +109,6 @@ fn gen_1k_iter_repeat(b: &mut Bencher) {
 
 #[bench]
 fn gen_1k_sample_iter(b: &mut Bencher) {
-    use rand::distributions::{Distribution, Standard};
     let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
         let v: Vec<u64> = Standard.sample_iter(&mut rng).take(128).collect();

--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -210,48 +210,6 @@ where <R as BlockRngCore>::Results: AsRef<[u32]> + AsMut<[u32]>
         }
     }
 
-    // As an optimization we try to write directly into the output buffer.
-    // This is only enabled for little-endian platforms where unaligned writes
-    // are known to be safe and fast.
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        let mut filled = 0;
-
-        // Continue filling from the current set of results
-        if self.index < self.results.as_ref().len() {
-            let (consumed_u32, filled_u8) =
-                fill_via_u32_chunks(&self.results.as_ref()[self.index..],
-                                    dest);
-
-            self.index += consumed_u32;
-            filled += filled_u8;
-        }
-
-        let len_remainder =
-            (dest.len() - filled) % (self.results.as_ref().len() * 4);
-        let end_direct = dest.len() - len_remainder;
-
-        while filled < end_direct {
-            let dest_u32: &mut R::Results = unsafe {
-                &mut *(dest[filled..].as_mut_ptr() as
-                *mut <R as BlockRngCore>::Results)
-            };
-            self.core.generate(dest_u32);
-            filled += self.results.as_ref().len() * 4;
-            self.index = self.results.as_ref().len();
-        }
-
-        if len_remainder > 0 {
-            self.core.generate(&mut self.results);
-            let (consumed_u32, _) =
-                fill_via_u32_chunks(self.results.as_ref(),
-                                    &mut dest[filled..]);
-
-            self.index = consumed_u32;
-        }
-    }
-
-    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         let mut read_len = 0;
         while read_len < dest.len() {
@@ -416,48 +374,6 @@ where <R as BlockRngCore>::Results: AsRef<[u64]> + AsMut<[u64]>
         value
     }
 
-    // As an optimization we try to write directly into the output buffer.
-    // This is only enabled for little-endian platforms where unaligned writes
-    // are known to be safe and fast.
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        let mut filled = 0;
-        self.half_used = false;
-
-        // Continue filling from the current set of results
-        if self.index < self.results.as_ref().len() {
-            let (consumed_u64, filled_u8) =
-                fill_via_u64_chunks(&self.results.as_ref()[self.index..],
-                                    dest);
-
-            self.index += consumed_u64;
-            filled += filled_u8;
-        }
-
-        let len_remainder =
-            (dest.len() - filled) % (self.results.as_ref().len() * 8);
-        let end_direct = dest.len() - len_remainder;
-
-        while filled < end_direct {
-            let dest_u64: &mut R::Results = unsafe {
-                ::core::mem::transmute(dest[filled..].as_mut_ptr())
-            };
-            self.core.generate(dest_u64);
-            filled += self.results.as_ref().len() * 8;
-            self.index = self.results.as_ref().len();
-        }
-
-        if len_remainder > 0 {
-            self.core.generate(&mut self.results);
-            let (consumed_u64, _) =
-                fill_via_u64_chunks(&mut self.results.as_ref(),
-                                    &mut dest[filled..]);
-
-            self.index = consumed_u64;
-        }
-    }
-
-    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         let mut read_len = 0;
         self.half_used = false;


### PR DESCRIPTION
Fix #779. Review please @RalfJung.

The point of the removed specialisations was to avoid one copy. Since the output type may not have the correct alignment and we wish to copy bytes in the same order, we have no choice but to use a buffer anyway. (We could complicate things by checking the alignment at run-time, but I don't think it's worthwhile given the very small performance cost of the extra copy.)

Benchmarking with 10*1024 byte buffer does show a small impact:
```
# before
test gen_bytes_chacha20             ... bench:  17,775,692 ns/iter (+/- 290,563) = 576 MB/s
test gen_bytes_hc128                ... bench:   4,243,890 ns/iter (+/- 69,032) = 2412 MB/s
test gen_bytes_isaac                ... bench:   7,238,757 ns/iter (+/- 123,797) = 1414 MB/s
test gen_bytes_isaac64              ... bench:   3,900,653 ns/iter (+/- 47,162) = 2625 MB/s
# after
test gen_bytes_chacha20             ... bench:  18,007,036 ns/iter (+/- 384,358) = 568 MB/s
test gen_bytes_hc128                ... bench:   4,634,505 ns/iter (+/- 55,119) = 2209 MB/s
test gen_bytes_isaac                ... bench:   7,338,592 ns/iter (+/- 90,396) = 1395 MB/s
test gen_bytes_isaac64              ... bench:   4,066,367 ns/iter (+/- 55,543) = 2518 MB/s
```

The second commit cleans up some warnings in the benches.