### PR TITLE
fix extracting a u64 on little-endian CPUs

### DIFF
--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -181,9 +181,9 @@ where <R as BlockRngCore>::Results: AsRef<[u32]> + AsMut<[u32]>
     #[inline(always)]
     fn next_u64(&mut self) -> u64 {
         let read_u64 = |results: &[u32], index| {
-            if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
-                // requires little-endian CPU supporting unaligned reads:
-                let ptr: *const u64 = results[index..index+1].as_ptr() as *const u64;
+            if cfg!(any(target_endian = "little")) {
+                // requires little-endian CPU
+                let ptr: *const u64 = results[index..=index+1].as_ptr() as *const u64;
                 unsafe { ptr::read_unaligned(ptr) }
             } else {
                 let x = u64::from(results[index]);


### PR DESCRIPTION
The cast-to-raw-ptr-fix was wrong, but unfortunately it takes some rather special circumstances to exhibit that which did not come up in the test suite. (Miri does not do any tracking of raw pointers, so the raw pointer used here to access the second `u32` probably get confused with some other raw pointer created previously. Eventually we will want to do proper tracking of raw pointers as well.)

Also, this code path can now be used on all little-endian CPUs, at the cost of an unaligned read. Is that preferred?