### PR TITLE
skip miri tests if miri setup fails

### DIFF
--- a/utils/ci/miri.sh
+++ b/utils/ci/miri.sh
@@ -1,8 +1,6 @@
 set -ex
 
-if rustup component add miri ; then
-    cargo miri setup
-
+if rustup component add miri && cargo miri setup ; then
     cargo miri test --no-default-features -- -Zmiri-seed=42 -- -Zunstable-options --exclude-should-panic
     cargo miri test --features=serde1,log -- -Zmiri-seed=42 -- -Zunstable-options --exclude-should-panic
     cargo miri test --manifest-path rand_core/Cargo.toml


### PR DESCRIPTION
If Miri can be installed but not set-up, that's also a problem with the current nightly and unrelated to rand.