### PR TITLE
Use SplitMix to seed 64-bit generators

### DIFF
--- a/rand_xoshiro/src/xoroshiro64star.rs
+++ b/rand_xoshiro/src/xoroshiro64star.rs
@@ -6,7 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use byteorder::{ByteOrder, LittleEndian};
 use rand_core;
 use rand_core::le::read_u32_into;
 use rand_core::impls::{fill_bytes_via_next, next_u64_via_u32};
@@ -71,9 +70,7 @@ impl SeedableRng for Xoroshiro64Star {
 
     /// Seed a `Xoroshiro64Star` from a `u64` using `SplitMix64`.
     fn seed_from_u64(seed: u64) -> Xoroshiro64Star {
-        let mut s = [0; 8];
-        LittleEndian::write_u64(&mut s, seed);
-        Xoroshiro64Star::from_seed(s)
+        from_splitmix!(seed)
     }
 }
 
@@ -93,5 +90,11 @@ mod tests {
         for &e in &expected {
             assert_eq!(rng.next_u32(), e);
         }
+    }
+
+    #[test]
+    fn zero_seed() {
+        let mut rng = Xoroshiro64Star::seed_from_u64(0);
+        assert_ne!(rng.next_u64(), 0);
     }
 }

--- a/rand_xoshiro/src/xoroshiro64starstar.rs
+++ b/rand_xoshiro/src/xoroshiro64starstar.rs
@@ -6,7 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use byteorder::{ByteOrder, LittleEndian};
 use rand_core;
 use rand_core::le::read_u32_into;
 use rand_core::impls::{fill_bytes_via_next, next_u64_via_u32};
@@ -68,11 +67,9 @@ impl SeedableRng for Xoroshiro64StarStar {
         }
     }
 
-    /// Seed a `Xoroshiro64StarStar` from a `u64`.
+    /// Seed a `Xoroshiro64StarStar` from a `u64` using `SplitMix64`.
     fn seed_from_u64(seed: u64) -> Xoroshiro64StarStar {
-        let mut s = [0; 8];
-        LittleEndian::write_u64(&mut s, seed);
-        Xoroshiro64StarStar::from_seed(s)
+        from_splitmix!(seed)
     }
 }
 
@@ -92,5 +89,11 @@ mod tests {
         for &e in &expected {
             assert_eq!(rng.next_u32(), e);
         }
+    }
+
+    #[test]
+    fn zero_seed() {
+        let mut rng = Xoroshiro64StarStar::seed_from_u64(0);
+        assert_ne!(rng.next_u64(), 0);
     }
 }


### PR DESCRIPTION
This addresses a stack overflow whith `seed_from_u64(0)`. Fixing this
requires value stability. Furthermore, some inconsistencies in the
documentation are fixed.

This is a value-breaking change.

Fixes #787.