### PR TITLE
Generic distributions: use custom trait

### DIFF
--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -20,4 +20,3 @@ appveyor = { repository = "rust-random/rand" }
 
 [dependencies]
 rand = { path = "..", version = ">=0.5, <=0.7" }
-num-traits = "0.2"

--- a/rand_distr/src/exponential.rs
+++ b/rand_distr/src/exponential.rs
@@ -11,8 +11,7 @@
 
 use rand::Rng;
 use crate::{ziggurat_tables, Distribution};
-use crate::utils::ziggurat;
-use num_traits::Float;
+use crate::utils::{ziggurat, Float};
 
 /// Samples floating-point numbers according to the exponential distribution,
 /// with rate parameter `λ = 1`. This is equivalent to `Exp::new(1.0)` or
@@ -105,10 +104,10 @@ where Exp1: Distribution<N>
     /// `lambda`.
     #[inline]
     pub fn new(lambda: N) -> Result<Exp<N>, Error> {
-        if !(lambda > N::zero()) {
+        if !(lambda > N::from(0.0)) {
             return Err(Error::LambdaTooSmall);
         }
-        Ok(Exp { lambda_inverse: N::one() / lambda })
+        Ok(Exp { lambda_inverse: N::from(1.0) / lambda })
     }
 }
 

--- a/rand_distr/src/gamma.rs
+++ b/rand_distr/src/gamma.rs
@@ -213,8 +213,8 @@ where StandardNormal: Distribution<N>, Open01: Distribution<N>
 /// println!("{} is from a χ²(11) distribution", v)
 /// ```
 #[derive(Clone, Copy, Debug)]
-pub struct ChiSquared {
-    repr: ChiSquaredRepr,
+pub struct ChiSquared<N> {
+    repr: ChiSquaredRepr<N>,
 }
 
 /// Error type returned from `ChiSquared::new` and `StudentT::new`.
@@ -225,35 +225,39 @@ pub enum ChiSquaredError {
 }
 
 #[derive(Clone, Copy, Debug)]
-enum ChiSquaredRepr {
+enum ChiSquaredRepr<N> {
     // k == 1, Gamma(alpha, ..) is particularly slow for alpha < 1,
     // e.g. when alpha = 1/2 as it would be for this case, so special-
     // casing and using the definition of N(0,1)^2 is faster.
     DoFExactlyOne,
-    DoFAnythingElse(Gamma<f64>),
+    DoFAnythingElse(Gamma<N>),
 }
 
-impl ChiSquared {
+impl<N: Float> ChiSquared<N>
+where StandardNormal: Distribution<N>, Exp1: Distribution<N>, Open01: Distribution<N>
+{
     /// Create a new chi-squared distribution with degrees-of-freedom
     /// `k`.
-    pub fn new(k: f64) -> Result<ChiSquared, ChiSquaredError> {
-        let repr = if k == 1.0 {
+    pub fn new(k: N) -> Result<ChiSquared<N>, ChiSquaredError> {
+        let repr = if k == N::from(1.0) {
             DoFExactlyOne
         } else {
-            if !(0.5 * k > 0.0) {
+            if !(N::from(0.5) * k > N::from(0.0)) {
                 return Err(ChiSquaredError::DoFTooSmall);
             }
-            DoFAnythingElse(Gamma::new(0.5 * k, 2.0).unwrap())
+            DoFAnythingElse(Gamma::new(N::from(0.5) * k, N::from(2.0)).unwrap())
         };
         Ok(ChiSquared { repr })
     }
 }
-impl Distribution<f64> for ChiSquared {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
+impl<N: Float> Distribution<N> for ChiSquared<N>
+where StandardNormal: Distribution<N>, Exp1: Distribution<N>, Open01: Distribution<N>
+{
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> N {
         match self.repr {
             DoFExactlyOne => {
                 // k == 1 => N(0,1)^2
-                let norm: f64 = rng.sample(StandardNormal);
+                let norm: N = rng.sample(StandardNormal);
                 norm * norm
             }
             DoFAnythingElse(ref g) => g.sample(rng)
@@ -277,12 +281,12 @@ impl Distribution<f64> for ChiSquared {
 /// println!("{} is from an F(2, 32) distribution", v)
 /// ```
 #[derive(Clone, Copy, Debug)]
-pub struct FisherF {
-    numer: ChiSquared,
-    denom: ChiSquared,
+pub struct FisherF<N> {
+    numer: ChiSquared<N>,
+    denom: ChiSquared<N>,
     // denom_dof / numer_dof so that this can just be a straight
     // multiplication, rather than a division.
-    dof_ratio: f64,
+    dof_ratio: N,
 }
 
 /// Error type returned from `FisherF::new`.
@@ -294,13 +298,15 @@ pub enum FisherFError {
     NTooSmall,
 }
 
-impl FisherF {
+impl<N: Float> FisherF<N>
+where StandardNormal: Distribution<N>, Exp1: Distribution<N>, Open01: Distribution<N>
+{
     /// Create a new `FisherF` distribution, with the given parameter.
-    pub fn new(m: f64, n: f64) -> Result<FisherF, FisherFError> {
-        if !(m > 0.0) {
+    pub fn new(m: N, n: N) -> Result<FisherF<N>, FisherFError> {
+        if !(m > N::from(0.0)) {
             return Err(FisherFError::MTooSmall);
         }
-        if !(n > 0.0) {
+        if !(n > N::from(0.0)) {
             return Err(FisherFError::NTooSmall);
         }
 
@@ -311,8 +317,10 @@ impl FisherF {
         })
     }
 }
-impl Distribution<f64> for FisherF {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
+impl<N: Float> Distribution<N> for FisherF<N>
+where StandardNormal: Distribution<N>, Exp1: Distribution<N>, Open01: Distribution<N>
+{
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> N {
         self.numer.sample(rng) / self.denom.sample(rng) * self.dof_ratio
     }
 }
@@ -330,24 +338,28 @@ impl Distribution<f64> for FisherF {
 /// println!("{} is from a t(11) distribution", v)
 /// ```
 #[derive(Clone, Copy, Debug)]
-pub struct StudentT {
-    chi: ChiSquared,
-    dof: f64
+pub struct StudentT<N> {
+    chi: ChiSquared<N>,
+    dof: N
 }
 
-impl StudentT {
+impl<N: Float> StudentT<N>
+where StandardNormal: Distribution<N>, Exp1: Distribution<N>, Open01: Distribution<N>
+{
     /// Create a new Student t distribution with `n` degrees of
     /// freedom.
-    pub fn new(n: f64) -> Result<StudentT, ChiSquaredError> {
+    pub fn new(n: N) -> Result<StudentT<N>, ChiSquaredError> {
         Ok(StudentT {
             chi: ChiSquared::new(n)?,
             dof: n
         })
     }
 }
-impl Distribution<f64> for StudentT {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
-        let norm: f64 = rng.sample(StandardNormal);
+impl<N: Float> Distribution<N> for StudentT<N>
+where StandardNormal: Distribution<N>, Exp1: Distribution<N>, Open01: Distribution<N>
+{
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> N {
+        let norm: N = rng.sample(StandardNormal);
         norm * (self.dof / self.chi.sample(rng)).sqrt()
     }
 }
@@ -364,9 +376,9 @@ impl Distribution<f64> for StudentT {
 /// println!("{} is from a Beta(2, 5) distribution", v);
 /// ```
 #[derive(Clone, Copy, Debug)]
-pub struct Beta {
-    gamma_a: Gamma<f64>,
-    gamma_b: Gamma<f64>,
+pub struct Beta<N> {
+    gamma_a: Gamma<N>,
+    gamma_b: Gamma<N>,
 }
 
 /// Error type returned from `Beta::new`.
@@ -378,21 +390,25 @@ pub enum BetaError {
     BetaTooSmall,
 }
 
-impl Beta {
+impl<N: Float> Beta<N>
+where StandardNormal: Distribution<N>, Exp1: Distribution<N>, Open01: Distribution<N>
+{
     /// Construct an object representing the `Beta(alpha, beta)`
     /// distribution.
-    pub fn new(alpha: f64, beta: f64) -> Result<Beta, BetaError> {
+    pub fn new(alpha: N, beta: N) -> Result<Beta<N>, BetaError> {
         Ok(Beta {
-            gamma_a: Gamma::new(alpha, 1.)
+            gamma_a: Gamma::new(alpha, N::from(1.))
                          .map_err(|_| BetaError::AlphaTooSmall)?,
-            gamma_b: Gamma::new(beta, 1.)
+            gamma_b: Gamma::new(beta, N::from(1.))
                          .map_err(|_| BetaError::BetaTooSmall)?,
         })
     }
 }
 
-impl Distribution<f64> for Beta {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
+impl<N: Float> Distribution<N> for Beta<N>
+where StandardNormal: Distribution<N>, Exp1: Distribution<N>, Open01: Distribution<N>
+{
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> N {
         let x = self.gamma_a.sample(rng);
         let y = self.gamma_b.sample(rng);
         x / (x + y)

--- a/rand_distr/src/lib.rs
+++ b/rand_distr/src/lib.rs
@@ -59,7 +59,7 @@
 //!   - [`UnitCircle`] distribution
 
 pub use rand::distributions::{Distribution, DistIter, Standard,
-    Alphanumeric, Uniform, OpenClosed01, Open01, Bernoulli, weighted};
+    Alphanumeric, Uniform, OpenClosed01, Open01, Bernoulli, uniform, weighted};
 
 pub use self::unit_sphere::UnitSphereSurface;
 pub use self::unit_circle::UnitCircle;

--- a/rand_distr/src/lib.rs
+++ b/rand_distr/src/lib.rs
@@ -75,6 +75,7 @@ pub use self::cauchy::{Cauchy, Error as CauchyError};
 pub use self::dirichlet::{Dirichlet, Error as DirichletError};
 pub use self::triangular::{Triangular, TriangularError};
 pub use self::weibull::{Weibull, Error as WeibullError};
+pub use self::utils::Float;
 
 mod unit_sphere;
 mod unit_circle;

--- a/rand_distr/src/normal.rs
+++ b/rand_distr/src/normal.rs
@@ -11,8 +11,7 @@
 
 use rand::Rng;
 use crate::{ziggurat_tables, Distribution, Open01};
-use crate::utils::ziggurat;
-use num_traits::Float;
+use crate::utils::{ziggurat, Float};
 
 /// Samples floating-point numbers according to the normal distribution
 /// `N(0, 1)` (a.k.a. a standard normal, or Gaussian). This is equivalent to
@@ -122,7 +121,7 @@ where StandardNormal: Distribution<N>
     /// standard deviation.
     #[inline]
     pub fn new(mean: N, std_dev: N) -> Result<Normal<N>, Error> {
-        if !(std_dev >= N::zero()) {
+        if !(std_dev >= N::from(0.0)) {
             return Err(Error::StdDevTooSmall);
         }
         Ok(Normal {
@@ -169,7 +168,7 @@ where StandardNormal: Distribution<N>
     /// and standard deviation of the logarithm of the distribution.
     #[inline]
     pub fn new(mean: N, std_dev: N) -> Result<LogNormal<N>, Error> {
-        if !(std_dev >= N::zero()) {
+        if !(std_dev >= N::from(0.0)) {
             return Err(Error::StdDevTooSmall);
         }
         Ok(LogNormal { norm: Normal::new(mean, std_dev).unwrap() })

--- a/rand_distr/src/triangular.rs
+++ b/rand_distr/src/triangular.rs
@@ -9,6 +9,7 @@
 
 use rand::Rng;
 use crate::{Distribution, Standard};
+use crate::utils::Float;
 
 /// The triangular distribution.
 /// 
@@ -28,10 +29,10 @@ use crate::{Distribution, Standard};
 /// println!("{} is from a triangular distribution", v);
 /// ```
 #[derive(Clone, Copy, Debug)]
-pub struct Triangular {
-    min: f64,
-    max: f64,
-    mode: f64,
+pub struct Triangular<N> {
+    min: N,
+    max: N,
+    mode: N,
 }
 
 /// Error type returned from [`Triangular::new`].
@@ -43,10 +44,12 @@ pub enum TriangularError {
     ModeRange,
 }
 
-impl Triangular {
+impl<N: Float> Triangular<N>
+where Standard: Distribution<N>
+{
     /// Set up the Triangular distribution with defined `min`, `max` and `mode`.
     #[inline]
-    pub fn new(min: f64, max: f64, mode: f64) -> Result<Triangular, TriangularError> {
+    pub fn new(min: N, max: N, mode: N) -> Result<Triangular<N>, TriangularError> {
         if !(max >= min) {
             return Err(TriangularError::RangeTooSmall);
         }
@@ -57,10 +60,12 @@ impl Triangular {
     }
 }
 
-impl Distribution<f64> for Triangular {
+impl<N: Float> Distribution<N> for Triangular<N>
+where Standard: Distribution<N>
+{
     #[inline]
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
-        let f: f64 = rng.sample(Standard);
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> N {
+        let f: N = rng.sample(Standard);
         let diff_mode_min = self.mode - self.min;
         let range = self.max - self.min;
         let f_range = f * range;

--- a/rand_distr/src/unit_circle.rs
+++ b/rand_distr/src/unit_circle.rs
@@ -20,7 +20,7 @@ use crate::utils::Float;
 /// ```
 /// use rand_distr::{UnitCircle, Distribution};
 ///
-/// let v = UnitCircle.sample(&mut rand::thread_rng());
+/// let v: [f64; 2] = UnitCircle.sample(&mut rand::thread_rng());
 /// println!("{:?} is from the unit circle.", v)
 /// ```
 ///
@@ -76,7 +76,7 @@ mod tests {
     fn norm() {
         let mut rng = crate::test::rng(1);
         for _ in 0..1000 {
-            let x = UnitCircle.sample(&mut rng);
+            let x: [f64; 2] = UnitCircle.sample(&mut rng);
             assert_almost_eq!(x[0]*x[0] + x[1]*x[1], 1., 1e-15);
         }
     }
@@ -84,8 +84,16 @@ mod tests {
     #[test]
     fn value_stability() {
         let mut rng = crate::test::rng(2);
-        assert_eq!(UnitCircle.sample(&mut rng), [-0.8032118336637037, 0.5956935036263119]);
-        assert_eq!(UnitCircle.sample(&mut rng), [-0.4742919588505423, -0.880367615130018]);
-        assert_eq!(UnitCircle.sample(&mut rng), [0.9297328981467168, 0.368234623716601]);
+        let expected = [
+                [-0.8032118336637037, 0.5956935036263119],
+                [-0.4742919588505423, -0.880367615130018],
+                [0.9297328981467168, 0.368234623716601],
+            ];
+        let samples: [[f64; 2]; 3] = [
+                UnitCircle.sample(&mut rng),
+                UnitCircle.sample(&mut rng),
+                UnitCircle.sample(&mut rng),
+            ];
+        assert_eq!(samples, expected);
     }
 }

--- a/rand_distr/src/unit_circle.rs
+++ b/rand_distr/src/unit_circle.rs
@@ -7,7 +7,8 @@
 // except according to those terms.
 
 use rand::Rng;
-use crate::{Distribution, Uniform};
+use crate::{Distribution, Uniform, uniform::SampleUniform};
+use crate::utils::Float;
 
 /// Samples uniformly from the edge of the unit circle in two dimensions.
 ///
@@ -30,10 +31,10 @@ use crate::{Distribution, Uniform};
 #[derive(Clone, Copy, Debug)]
 pub struct UnitCircle;
 
-impl Distribution<[f64; 2]> for UnitCircle {
+impl<N: Float + SampleUniform> Distribution<[N; 2]> for UnitCircle {
     #[inline]
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> [f64; 2] {
-        let uniform = Uniform::new(-1., 1.);
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> [N; 2] {
+        let uniform = Uniform::new(N::from(-1.), N::from(1.));
         let mut x1;
         let mut x2;
         let mut sum;
@@ -41,12 +42,12 @@ impl Distribution<[f64; 2]> for UnitCircle {
             x1 = uniform.sample(rng);
             x2 = uniform.sample(rng);
             sum = x1*x1 + x2*x2;
-            if sum < 1. {
+            if sum < N::from(1.) {
                 break;
             }
         }
         let diff = x1*x1 - x2*x2;
-        [diff / sum, 2.*x1*x2 / sum]
+        [diff / sum, N::from(2.)*x1*x2 / sum]
     }
 }
 

--- a/rand_distr/src/unit_sphere.rs
+++ b/rand_distr/src/unit_sphere.rs
@@ -7,7 +7,8 @@
 // except according to those terms.
 
 use rand::Rng;
-use crate::{Distribution, Uniform};
+use crate::{Distribution, Uniform, uniform::SampleUniform};
+use crate::utils::Float;
 
 /// Samples uniformly from the surface of the unit sphere in three dimensions.
 ///
@@ -29,18 +30,18 @@ use crate::{Distribution, Uniform};
 #[derive(Clone, Copy, Debug)]
 pub struct UnitSphereSurface;
 
-impl Distribution<[f64; 3]> for UnitSphereSurface {
+impl<N: Float + SampleUniform> Distribution<[N; 3]> for UnitSphereSurface {
     #[inline]
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> [f64; 3] {
-        let uniform = Uniform::new(-1., 1.);
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> [N; 3] {
+        let uniform = Uniform::new(N::from(-1.), N::from(1.));
         loop {
             let (x1, x2) = (uniform.sample(rng), uniform.sample(rng));
             let sum = x1*x1 + x2*x2;
-            if sum >= 1. {
+            if sum >= N::from(1.) {
                 continue;
             }
-            let factor = 2. * (1.0_f64 - sum).sqrt();
-            return [x1 * factor, x2 * factor, 1. - 2.*sum];
+            let factor = N::from(2.) * (N::from(1.0) - sum).sqrt();
+            return [x1 * factor, x2 * factor, N::from(1.) - N::from(2.)*sum];
         }
     }
 }

--- a/rand_distr/src/unit_sphere.rs
+++ b/rand_distr/src/unit_sphere.rs
@@ -20,7 +20,7 @@ use crate::utils::Float;
 /// ```
 /// use rand_distr::{UnitSphereSurface, Distribution};
 ///
-/// let v = UnitSphereSurface.sample(&mut rand::thread_rng());
+/// let v: [f64; 3] = UnitSphereSurface.sample(&mut rand::thread_rng());
 /// println!("{:?} is from the unit sphere surface.", v)
 /// ```
 ///
@@ -71,7 +71,7 @@ mod tests {
     fn norm() {
         let mut rng = crate::test::rng(1);
         for _ in 0..1000 {
-            let x = UnitSphereSurface.sample(&mut rng);
+            let x: [f64; 3] = UnitSphereSurface.sample(&mut rng);
             assert_almost_eq!(x[0]*x[0] + x[1]*x[1] + x[2]*x[2], 1., 1e-15);
         }
     }
@@ -79,11 +79,16 @@ mod tests {
     #[test]
     fn value_stability() {
         let mut rng = crate::test::rng(2);
-        assert_eq!(UnitSphereSurface.sample(&mut rng),
-                   [-0.24950027180862533, -0.7552572587896719, 0.6060825747478084]);
-        assert_eq!(UnitSphereSurface.sample(&mut rng),
-                   [0.47604534507233487, -0.797200864987207, -0.3712837328763685]);
-        assert_eq!(UnitSphereSurface.sample(&mut rng),
-                   [0.9795722330927367, 0.18692349236651176, 0.07414747571708524]);
+        let expected = [
+                [-0.24950027180862533, -0.7552572587896719, 0.6060825747478084],
+                [0.47604534507233487, -0.797200864987207, -0.3712837328763685],
+                [0.9795722330927367, 0.18692349236651176, 0.07414747571708524],
+            ];
+        let samples: [[f64; 3]; 3] = [
+                UnitSphereSurface.sample(&mut rng),
+                UnitSphereSurface.sample(&mut rng),
+                UnitSphereSurface.sample(&mut rng),
+            ];
+        assert_eq!(samples, expected);
     }
 }

--- a/rand_distr/src/utils.rs
+++ b/rand_distr/src/utils.rs
@@ -26,6 +26,7 @@ pub trait Float: Copy + Sized + cmp::PartialOrd
     + ops::Sub<Output = Self>
     + ops::Mul<Output = Self>
     + ops::Div<Output = Self>
+    + ops::AddAssign + ops::SubAssign + ops::MulAssign + ops::DivAssign
 {
     /// The constant π
     fn pi() -> Self;

--- a/rand_distr/src/utils.rs
+++ b/rand_distr/src/utils.rs
@@ -27,8 +27,14 @@ pub trait Float: Copy + Sized + cmp::PartialOrd
     + ops::Mul<Output = Self>
     + ops::Div<Output = Self>
 {
+    /// The constant π
+    fn pi() -> Self;
     /// Support approximate representation of a f64 value
     fn from(x: f64) -> Self;
+    
+    /// Take the absolute value of self
+    fn abs(self) -> Self;
+    
     /// Take the exponential of self
     fn exp(self) -> Self;
     /// Take the natural logarithm of self
@@ -37,22 +43,37 @@ pub trait Float: Copy + Sized + cmp::PartialOrd
     fn sqrt(self) -> Self;
     /// Take self to a floating-point power
     fn powf(self, power: Self) -> Self;
+    
+    /// Take the tangent of self
+    fn tan(self) -> Self;
 }
 
 impl Float for f32 {
+    fn pi() -> Self { core::f32::consts::PI }
     fn from(x: f64) -> Self { x as f32 }
+    
+    fn abs(self) -> Self { self.abs() }
+    
     fn exp(self) -> Self { self.exp() }
     fn ln(self) -> Self { self.ln() }
     fn sqrt(self) -> Self { self.sqrt() }
     fn powf(self, power: Self) -> Self { self.powf(power) }
+    
+    fn tan(self) -> Self { self.tan() }
 }
 
 impl Float for f64 {
+    fn pi() -> Self { core::f64::consts::PI }
     fn from(x: f64) -> Self { x }
+    
+    fn abs(self) -> Self { self.abs() }
+    
     fn exp(self) -> Self { self.exp() }
     fn ln(self) -> Self { self.ln() }
     fn sqrt(self) -> Self { self.sqrt() }
     fn powf(self, power: Self) -> Self { self.powf(power) }
+    
+    fn tan(self) -> Self { self.tan() }
 }
 
 /// Calculates ln(gamma(x)) (natural logarithm of the gamma

--- a/rand_distr/src/utils.rs
+++ b/rand_distr/src/utils.rs
@@ -22,6 +22,7 @@ use core::{cmp, ops};
 /// The bounds and methods are based purely on internal
 /// requirements, and will change as needed.
 pub trait Float: Copy + Sized + cmp::PartialOrd
+    + ops::Neg<Output = Self>
     + ops::Add<Output = Self>
     + ops::Sub<Output = Self>
     + ops::Mul<Output = Self>

--- a/rand_distr/src/weibull.rs
+++ b/rand_distr/src/weibull.rs
@@ -10,6 +10,7 @@
 
 use rand::Rng;
 use crate::{Distribution, OpenClosed01};
+use crate::utils::Float;
 
 /// Samples floating-point numbers according to the Weibull distribution
 ///
@@ -22,9 +23,9 @@ use crate::{Distribution, OpenClosed01};
 /// println!("{}", val);
 /// ```
 #[derive(Clone, Copy, Debug)]
-pub struct Weibull {
-    inv_shape: f64,
-    scale: f64,
+pub struct Weibull<N> {
+    inv_shape: N,
+    scale: N,
 }
 
 /// Error type returned from `Weibull::new`.
@@ -36,22 +37,26 @@ pub enum Error {
     ShapeTooSmall,
 }
 
-impl Weibull {
+impl<N: Float> Weibull<N>
+where OpenClosed01: Distribution<N>
+{
     /// Construct a new `Weibull` distribution with given `scale` and `shape`.
-    pub fn new(scale: f64, shape: f64) -> Result<Weibull, Error> {
-        if !(scale > 0.0) {
+    pub fn new(scale: N, shape: N) -> Result<Weibull<N>, Error> {
+        if !(scale > N::from(0.0)) {
             return Err(Error::ScaleTooSmall);
         }
-        if !(shape > 0.0) {
+        if !(shape > N::from(0.0)) {
             return Err(Error::ShapeTooSmall);
         }
-        Ok(Weibull { inv_shape: 1./shape, scale })
+        Ok(Weibull { inv_shape: N::from(1.)/shape, scale })
     }
 }
 
-impl Distribution<f64> for Weibull {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
-        let x: f64 = rng.sample(OpenClosed01);
+impl<N: Float> Distribution<N> for Weibull<N>
+where OpenClosed01: Distribution<N>
+{
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> N {
+        let x: N = rng.sample(OpenClosed01);
         self.scale * (-x.ln()).powf(self.inv_shape)
     }
 }


### PR DESCRIPTION
Continuing from #785, this replaces `num_traits::Float` with a custom version, then also makes `Cauchy` generic.

Closes #100.

Thoughts (@vks)? The implementation of `Float` in the first commit doesn't look bad, but we see in the second it is growing quickly.

One motivation is to avoid a dependency on an unstable lib (there appear to be suggestions the trait should change). Another is to avoid requiring `.unwrap()` on `N::from(..)`, although as implemented here we use `as` which isn't exactly safe (we could instead restrict input precision and use `From<f32>`).