### PR TITLE
Add tests for rand_jitter README file

### DIFF
--- a/rand_jitter/Cargo.toml
+++ b/rand_jitter/Cargo.toml
@@ -25,5 +25,8 @@ libc = { version = "0.2", default_features = false }
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["profileapi"] }
 
+[dev-dependencies]
+doc-comment = "0.3"
+
 [features]
 std = ["rand_core/std"]

--- a/rand_jitter/Cargo.toml
+++ b/rand_jitter/Cargo.toml
@@ -25,8 +25,5 @@ libc = { version = "0.2", default_features = false }
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["profileapi"] }
 
-[dev-dependencies]
-doc-comment = "0.3"
-
 [features]
 std = ["rand_core/std"]

--- a/rand_jitter/README.md
+++ b/rand_jitter/README.md
@@ -38,15 +38,26 @@ recommend to run the much more stringent
 
 Use the following code using `timer_stats` to collect the data:
 
-```rust
+```rust,no_run
 use rand_jitter::JitterRng;
 
 use std::error::Error;
 use std::fs::File;
 use std::io::Write;
 
+fn get_nstime() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let dur = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+    // The correct way to calculate the current time is
+    // `dur.as_secs() * 1_000_000_000 + dur.subsec_nanos() as u64`
+    // But this is faster, and the difference in terms of entropy is
+    // negligible (log2(10^9) == 29.9).
+    dur.as_secs() << 30 | dur.subsec_nanos() as u64
+}
+
 fn main() -> Result<(), Box<Error>> {
-    let mut rng = JitterRng::new()?;
+    let mut rng = JitterRng::new_with_timer(get_nstime);
 
     // 1_000_000 results are required for the
     // NIST SP 800-90B Entropy Estimation Suite

--- a/rand_jitter/src/lib.rs
+++ b/rand_jitter/src/lib.rs
@@ -63,12 +63,17 @@ extern crate libc;
 #[cfg(target_os = "windows")]
 extern crate winapi;
 
+// Coming from https://crates.io/crates/doc-comment
 #[cfg(test)]
-#[macro_use]
-extern crate doc_comment;
+macro_rules! doc_comment {
+    ($x:expr) => {
+        #[doc = $x]
+        extern {}
+    };
+}
 
 #[cfg(test)]
-doctest!("../README.md");
+doc_comment!(include_str!("../README.md"));
 
 #[cfg(not(feature = "log"))]
 #[macro_use] mod dummy_log;

--- a/rand_jitter/src/lib.rs
+++ b/rand_jitter/src/lib.rs
@@ -63,6 +63,12 @@ extern crate libc;
 #[cfg(target_os = "windows")]
 extern crate winapi;
 
+#[cfg(test)]
+#[macro_use]
+extern crate doc_comment;
+
+#[cfg(test)]
+doctest!("../README.md");
 
 #[cfg(not(feature = "log"))]
 #[macro_use] mod dummy_log;


### PR DESCRIPTION
It allows to test code examples in the `README.md` file.