### PR TITLE
Documentation fix in Triangular distribution.

### DIFF
--- a/src/distributions/triangular.rs
+++ b/src/distributions/triangular.rs
@@ -27,7 +27,7 @@ impl Triangular {
     ///
     /// # Panics
     ///
-    /// If `max < mode`, `mode < max` or `max == min`.
+    /// If `max < mode`, `mode < min` or `max == min`.
     ///
     #[inline]
     pub fn new(min: f64, max: f64, mode: f64) -> Triangular {


### PR DESCRIPTION
The conditions, in which the new() function panics, were wrong.