### PR TITLE
Uniform distribution: bias and usize portability

### DIFF
--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -149,6 +149,11 @@ distr_int!(distr_uniform_i16, i16, Uniform::new(-500i16, 2000));
 distr_int!(distr_uniform_i32, i32, Uniform::new(-200_000_000i32, 800_000_000));
 distr_int!(distr_uniform_i64, i64, Uniform::new(3i64, 123_456_789_123));
 distr_int!(distr_uniform_i128, i128, Uniform::new(-123_456_789_123i128, 123_456_789_123_456_789));
+distr_int!(distr_uniform_usize16, usize, Uniform::new(0usize, 0xb9d7));
+distr_int!(distr_uniform_usize32, usize, Uniform::new(0usize, 0x548c0f43));
+#[cfg(target_pointer_width = "64")]
+distr_int!(distr_uniform_usize64, usize, Uniform::new(0usize, 0x3a42714f2bf927a8));
+distr_int!(distr_uniform_isize, isize, Uniform::new(-1060478432isize, 1858574057));
 
 distr_float!(distr_uniform_f32, f32, Uniform::new(2.26f32, 2.319));
 distr_float!(distr_uniform_f64, f64, Uniform::new(2.26f64, 2.319));

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -337,7 +337,7 @@ impl<'a, Borrowed> SampleBorrow<Borrowed> for &'a Borrowed where Borrowed: Sampl
 pub struct UniformInt<X> {
     low: X,
     range: X,
-    ints_to_reject: X,
+    z: X,   // either ints_to_reject or zone depending on implementation
 }
 
 macro_rules! uniform_int_impl {
@@ -391,7 +391,7 @@ macro_rules! uniform_int_impl {
                     low: low,
                     // These are really $unsigned values, but store as $ty:
                     range: range as $ty,
-                    ints_to_reject: ints_to_reject as $unsigned as $ty
+                    z: ints_to_reject as $unsigned as $ty
                 }
             }
 
@@ -399,7 +399,7 @@ macro_rules! uniform_int_impl {
                 let range = self.range as $unsigned as $u_large;
                 if range > 0 {
                     let unsigned_max = ::core::$u_large::MAX;
-                    let zone = unsigned_max - (self.ints_to_reject as $unsigned as $u_large);
+                    let zone = unsigned_max - (self.z as $unsigned as $u_large);
                     loop {
                         let v: $u_large = rng.gen();
                         let (hi, lo) = v.wmul(range);
@@ -524,13 +524,13 @@ macro_rules! uniform_simd_int_impl {
                     low: low,
                     // These are really $unsigned values, but store as $ty:
                     range: range.cast(),
-                    zone: zone.cast(),
+                    z: zone.cast(),
                 }
             }
 
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
                 let range: $unsigned = self.range.cast();
-                let zone: $unsigned = self.zone.cast();
+                let zone: $unsigned = self.z.cast();
 
                 // This might seem very slow, generating a whole new
                 // SIMD vector for every sample rejection. For most uses

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -246,14 +246,11 @@ pub trait UniformSampler: Sized {
     /// Sample a single value uniformly from a range with inclusive lower bound
     /// and exclusive upper bound `[low, high)`.
     ///
-    /// Usually users should not call this directly but instead use
-    /// `Uniform::sample_single`, which asserts that `low < high` before calling
-    /// this.
-    ///
-    /// Via this method, implementations can provide a method optimized for
-    /// sampling only a single value from the specified range. The default
-    /// implementation simply calls `UniformSampler::new` then `sample` on the
-    /// result.
+    /// By default this is implemented using
+    /// `UniformSampler::new(low, high).sample(rng)`. However, for some types
+    /// more optimal implementations for single usage may be provided via this
+    /// method (which is the case for integers and floats).
+    /// Results may not be identical.
     fn sample_single<R: Rng + ?Sized, B1, B2>(low: B1, high: B2, rng: &mut R)
         -> Self::X
         where B1: SampleBorrow<Self::X> + Sized,
@@ -309,31 +306,29 @@ impl<'a, Borrowed> SampleBorrow<Borrowed> for &'a Borrowed where Borrowed: Sampl
 ///
 /// # Implementation notes
 ///
+/// For simplicity, we use the same generic struct `UniformInt<X>` for all
+/// integer types `X`. This gives us only one field type, `X`; to store unsigned
+/// values of this size, we take use the fact that these conversions are no-ops.
+///
 /// For a closed range, the number of possible numbers we should generate is
-/// `range = (high - low + 1)`. It is not possible to end up with a uniform
-/// distribution if we map *all* the random integers that can be generated to
-/// this range. We have to map integers from a `zone` that is a multiple of the
-/// range. The rest of the integers, that cause a bias, are rejected.
+/// `range = (high - low + 1)`. To avoid bias, we must ensure that the size of
+/// our sample space, `zone`, is a multiple of `range`; other values must be
+/// rejected (by replacing with a new random sample).
 ///
-/// The problem with `range` is that to cover the full range of the type, it has
-/// to store `unsigned_max + 1`, which can't be represented. But if the range
-/// covers the full range of the type, no modulus is needed. A range of size 0
-/// can't exist, so we use that to represent this special case. Wrapping
-/// arithmetic even makes representing `unsigned_max + 1` as 0 simple.
+/// As a special case, we use `range = 0` to represent the full range of the
+/// result type (i.e. for `new_inclusive($ty::MIN, $ty::MAX)`).
 ///
-/// We don't calculate `zone` directly, but first calculate the number of
-/// integers to reject. To handle `unsigned_max + 1` not fitting in the type,
-/// we use:
-/// `ints_to_reject = (unsigned_max + 1) % range;`
-/// `ints_to_reject = (unsigned_max - range + 1) % range;`
+/// The optimum `zone` is the largest product of `range` which fits in our
+/// (unsigned) target type. We calculate this by calculating how many numbers we
+/// must reject: `reject = (MAX + 1) % range = (MAX - range + 1) % range`. Any (large)
+/// product of `range` will suffice, thus in `sample_single` we multiply by a
+/// power of 2 via bit-shifting (faster but may cause more rejections).
 ///
-/// The smallest integer PRNGs generate is `u32`. That is why for small integer
-/// sizes (`i8`/`u8` and `i16`/`u16`) there is an optimization: don't pick the
-/// largest zone that can fit in the small type, but pick the largest zone that
-/// can fit in an `u32`. `ints_to_reject` is always less than half the size of
-/// the small integer. This means the first bit of `zone` is always 1, and so
-/// are all the other preceding bits of a larger integer. The easiest way to
-/// grow the `zone` for the larger type is to simply sign extend it.
+/// The smallest integer PRNGs generate is `u32`. For 8- and 16-bit outputs we
+/// use `u32` for our `zone` and samples (because it's not slower and because
+/// it reduces the chance of having to reject a sample). In this case we cannot
+/// store `zone` in the target type since it is too large, however we know
+/// `ints_to_reject < range <= $unsigned::MAX`.
 ///
 /// An alternative to using a modulus is widening multiply: After a widening
 /// multiply by `range`, the result is in the high word. Then comparing the low
@@ -342,12 +337,11 @@ impl<'a, Borrowed> SampleBorrow<Borrowed> for &'a Borrowed where Borrowed: Sampl
 pub struct UniformInt<X> {
     low: X,
     range: X,
-    zone: X,
+    ints_to_reject: X,
 }
 
 macro_rules! uniform_int_impl {
-    ($ty:ty, $signed:ty, $unsigned:ident,
-     $i_large:ident, $u_large:ident) => {
+    ($ty:ty, $unsigned:ident, $u_large:ident) => {
         impl SampleUniform for $ty {
             type Sampler = UniformInt<$ty>;
         }
@@ -382,34 +376,30 @@ macro_rules! uniform_int_impl {
                 let high = *high_b.borrow();
                 assert!(low <= high,
                         "Uniform::new_inclusive called with `low > high`");
-                let unsigned_max = ::core::$unsigned::MAX;
+                let unsigned_max = ::core::$u_large::MAX;
 
                 let range = high.wrapping_sub(low).wrapping_add(1) as $unsigned;
                 let ints_to_reject =
                     if range > 0 {
+                        let range = range as $u_large;
                         (unsigned_max - range + 1) % range
                     } else {
                         0
                     };
-                let zone = unsigned_max - ints_to_reject;
 
                 UniformInt {
                     low: low,
                     // These are really $unsigned values, but store as $ty:
                     range: range as $ty,
-                    zone: zone as $ty
+                    ints_to_reject: ints_to_reject as $unsigned as $ty
                 }
             }
 
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
                 let range = self.range as $unsigned as $u_large;
                 if range > 0 {
-                    // Grow `zone` to fit a type of at least 32 bits, by
-                    // sign-extending it (the first bit is always 1, so are all
-                    // the preceding bits of the larger type).
-                    // For types that already have the right size, all the
-                    // casting is a no-op.
-                    let zone = self.zone as $signed as $i_large as $u_large;
+                    let unsigned_max = ::core::$u_large::MAX;
+                    let zone = unsigned_max - (self.ints_to_reject as $unsigned as $u_large);
                     loop {
                         let v: $u_large = rng.gen();
                         let (hi, lo) = v.wmul(range);
@@ -431,7 +421,7 @@ macro_rules! uniform_int_impl {
                 let low = *low_b.borrow();
                 let high = *high_b.borrow();
                 assert!(low < high,
-                        "Uniform::sample_single called with low >= high");
+                        "UniformSampler::sample_single: low >= high");
                 let range = high.wrapping_sub(low) as $unsigned as $u_large;
                 let zone =
                     if ::core::$unsigned::MAX <= ::core::u16::MAX as $unsigned {
@@ -459,20 +449,20 @@ macro_rules! uniform_int_impl {
     }
 }
 
-uniform_int_impl! { i8, i8, u8, i32, u32 }
-uniform_int_impl! { i16, i16, u16, i32, u32 }
-uniform_int_impl! { i32, i32, u32, i32, u32 }
-uniform_int_impl! { i64, i64, u64, i64, u64 }
+uniform_int_impl! { i8, u8, u32 }
+uniform_int_impl! { i16, u16, u32 }
+uniform_int_impl! { i32, u32, u32 }
+uniform_int_impl! { i64, u64, u64 }
 #[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
-uniform_int_impl! { i128, i128, u128, u128, u128 }
-uniform_int_impl! { isize, isize, usize, isize, usize }
-uniform_int_impl! { u8, i8, u8, i32, u32 }
-uniform_int_impl! { u16, i16, u16, i32, u32 }
-uniform_int_impl! { u32, i32, u32, i32, u32 }
-uniform_int_impl! { u64, i64, u64, i64, u64 }
-uniform_int_impl! { usize, isize, usize, isize, usize }
+uniform_int_impl! { i128, u128, u128 }
+uniform_int_impl! { isize, usize, usize }
+uniform_int_impl! { u8, u8, u32 }
+uniform_int_impl! { u16, u16, u32 }
+uniform_int_impl! { u32, u32, u32 }
+uniform_int_impl! { u64, u64, u64 }
+uniform_int_impl! { usize, usize, usize }
 #[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
-uniform_int_impl! { u128, u128, u128, i128, u128 }
+uniform_int_impl! { u128, u128, u128 }
 
 #[cfg(all(feature = "simd_support", feature = "nightly"))]
 macro_rules! uniform_simd_int_impl {
@@ -736,7 +726,7 @@ macro_rules! uniform_float_impl {
                 let low = *low_b.borrow();
                 let high = *high_b.borrow();
                 assert!(low.all_lt(high),
-                        "Uniform::sample_single called with low >= high");
+                        "UniformSampler::sample_single: low >= high");
                 let mut scale = high - low;
 
                 loop {
@@ -787,7 +777,7 @@ macro_rules! uniform_float_impl {
                     let mask = !scale.finite_mask();
                     if mask.any() {
                         assert!(low.all_finite() && high.all_finite(),
-                                "Uniform::sample_single called with non-finite boundaries");
+                                "Uniform::sample_single: low and high must be finite");
                         scale = scale.decrease_masked(mask);
                     }
                 }

--- a/src/distributions/weighted/alias_method.rs
+++ b/src/distributions/weighted/alias_method.rs
@@ -25,10 +25,10 @@ use Rng;
 /// Given that `n` is the number of items in the vector used to create an
 /// [`WeightedIndex<W>`], [`WeightedIndex<W>`] will require `O(n)` amount of
 /// memory. More specifically it takes up some constant amount of memory plus
-/// the vector used to create it and a [`Vec<usize>`] with capacity `n`.
+/// the vector used to create it and a [`Vec<u32>`] with capacity `n`.
 ///
 /// Time complexity for the creation of a [`WeightedIndex<W>`] is `O(n)`.
-/// Sampling is `O(1)`, it makes a call to [`Uniform<usize>::sample`] and a call
+/// Sampling is `O(1)`, it makes a call to [`Uniform<u32>::sample`] and a call
 /// to [`Uniform<W>::sample`].
 ///
 /// # Example
@@ -56,13 +56,13 @@ use Rng;
 ///
 /// [`WeightedIndex<W>`]: crate::distributions::weighted::alias_method::WeightedIndex
 /// [`Weight`]: crate::distributions::weighted::alias_method::Weight
-/// [`Vec<usize>`]: Vec
-/// [`Uniform<usize>::sample`]: Distribution::sample
+/// [`Vec<u32>`]: Vec
+/// [`Uniform<u32>::sample`]: Distribution::sample
 /// [`Uniform<W>::sample`]: Distribution::sample
 pub struct WeightedIndex<W: Weight> {
-    aliases: Vec<usize>,
+    aliases: Vec<u32>,
     no_alias_odds: Vec<W>,
-    uniform_index: Uniform<usize>,
+    uniform_index: Uniform<u32>,
     uniform_within_weight_sum: Uniform<W>,
 }
 
@@ -71,6 +71,7 @@ impl<W: Weight> WeightedIndex<W> {
     ///
     /// Returns an error if:
     /// - The vector is empty.
+    /// - The vector is longer than `u32::MAX`.
     /// - For any weight `w`: `w < 0` or `w > max` where `max = W::MAX /
     ///   weights.len()`.
     /// - The sum of weights is zero.
@@ -78,9 +79,12 @@ impl<W: Weight> WeightedIndex<W> {
         let n = weights.len();
         if n == 0 {
             return Err(WeightedError::NoItem);
+        } else if n > ::core::u32::MAX as usize {
+            return Err(WeightedError::TooMany);
         }
+        let n = n as u32;
 
-        let max_weight_size = W::try_from_usize_lossy(n)
+        let max_weight_size = W::try_from_u32_lossy(n)
             .map(|n| W::MAX / n)
             .unwrap_or(W::ZERO);
         if !weights
@@ -103,7 +107,7 @@ impl<W: Weight> WeightedIndex<W> {
         }
 
         // `weight_sum` would have been zero if `try_from_lossy` causes an error here.
-        let n_converted = W::try_from_usize_lossy(n).unwrap();
+        let n_converted = W::try_from_u32_lossy(n).unwrap();
 
         let mut no_alias_odds = weights;
         for odds in no_alias_odds.iter_mut() {
@@ -119,52 +123,52 @@ impl<W: Weight> WeightedIndex<W> {
         /// be ensured that a single index is only ever in one of them at the
         /// same time.
         struct Aliases {
-            aliases: Vec<usize>,
-            smalls_head: usize,
-            bigs_head: usize,
+            aliases: Vec<u32>,
+            smalls_head: u32,
+            bigs_head: u32,
         }
 
         impl Aliases {
-            fn new(size: usize) -> Self {
+            fn new(size: u32) -> Self {
                 Aliases {
-                    aliases: vec![0; size],
-                    smalls_head: ::core::usize::MAX,
-                    bigs_head: ::core::usize::MAX,
+                    aliases: vec![0; size as usize],
+                    smalls_head: ::core::u32::MAX,
+                    bigs_head: ::core::u32::MAX,
                 }
             }
 
-            fn push_small(&mut self, idx: usize) {
-                self.aliases[idx] = self.smalls_head;
+            fn push_small(&mut self, idx: u32) {
+                self.aliases[idx as usize] = self.smalls_head;
                 self.smalls_head = idx;
             }
 
-            fn push_big(&mut self, idx: usize) {
-                self.aliases[idx] = self.bigs_head;
+            fn push_big(&mut self, idx: u32) {
+                self.aliases[idx as usize] = self.bigs_head;
                 self.bigs_head = idx;
             }
 
-            fn pop_small(&mut self) -> usize {
+            fn pop_small(&mut self) -> u32 {
                 let popped = self.smalls_head;
-                self.smalls_head = self.aliases[popped];
+                self.smalls_head = self.aliases[popped as usize];
                 popped
             }
 
-            fn pop_big(&mut self) -> usize {
+            fn pop_big(&mut self) -> u32 {
                 let popped = self.bigs_head;
-                self.bigs_head = self.aliases[popped];
+                self.bigs_head = self.aliases[popped as usize];
                 popped
             }
 
             fn smalls_is_empty(&self) -> bool {
-                self.smalls_head == ::core::usize::MAX
+                self.smalls_head == ::core::u32::MAX
             }
 
             fn bigs_is_empty(&self) -> bool {
-                self.bigs_head == ::core::usize::MAX
+                self.bigs_head == ::core::u32::MAX
             }
 
-            fn set_alias(&mut self, idx: usize, alias: usize) {
-                self.aliases[idx] = alias;
+            fn set_alias(&mut self, idx: u32, alias: u32) {
+                self.aliases[idx as usize] = alias;
             }
         }
 
@@ -173,9 +177,9 @@ impl<W: Weight> WeightedIndex<W> {
         // Split indices into those with small weights and those with big weights.
         for (index, &odds) in no_alias_odds.iter().enumerate() {
             if odds < weight_sum {
-                aliases.push_small(index);
+                aliases.push_small(index as u32);
             } else {
-                aliases.push_big(index);
+                aliases.push_big(index as u32);
             }
         }
 
@@ -186,9 +190,11 @@ impl<W: Weight> WeightedIndex<W> {
             let b = aliases.pop_big();
 
             aliases.set_alias(s, b);
-            no_alias_odds[b] = no_alias_odds[b] - weight_sum + no_alias_odds[s];
+            no_alias_odds[b as usize] = no_alias_odds[b as usize]
+                    - weight_sum
+                    + no_alias_odds[s as usize];
 
-            if no_alias_odds[b] < weight_sum {
+            if no_alias_odds[b as usize] < weight_sum {
                 aliases.push_small(b);
             } else {
                 aliases.push_big(b);
@@ -198,10 +204,10 @@ impl<W: Weight> WeightedIndex<W> {
         // The remaining indices should have no alias odds of about 100%. This is due to
         // numeric accuracy. Otherwise they would be exactly 100%.
         while !aliases.smalls_is_empty() {
-            no_alias_odds[aliases.pop_small()] = weight_sum;
+            no_alias_odds[aliases.pop_small() as usize] = weight_sum;
         }
         while !aliases.bigs_is_empty() {
-            no_alias_odds[aliases.pop_big()] = weight_sum;
+            no_alias_odds[aliases.pop_big() as usize] = weight_sum;
         }
 
         // Prepare distributions for sampling. Creating them beforehand improves
@@ -221,10 +227,10 @@ impl<W: Weight> WeightedIndex<W> {
 impl<W: Weight> Distribution<usize> for WeightedIndex<W> {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
         let candidate = rng.sample(self.uniform_index);
-        if rng.sample(&self.uniform_within_weight_sum) < self.no_alias_odds[candidate] {
-            candidate
+        if rng.sample(&self.uniform_within_weight_sum) < self.no_alias_odds[candidate as usize] {
+            candidate as usize
         } else {
-            self.aliases[candidate]
+            self.aliases[candidate as usize] as usize
         }
     }
 }
@@ -282,10 +288,10 @@ pub trait Weight:
     /// Element of `Self` equivalent to 0.
     const ZERO: Self;
 
-    /// Produce an instance of `Self` from a `usize` value, or return `None` if
+    /// Produce an instance of `Self` from a `u32` value, or return `None` if
     /// out of range. Loss of precision (where `Self` is a floating point type)
     /// is acceptable.
-    fn try_from_usize_lossy(n: usize) -> Option<Self>;
+    fn try_from_u32_lossy(n: u32) -> Option<Self>;
 
     /// Sums all values in slice `values`.
     fn sum(values: &[Self]) -> Self {
@@ -299,7 +305,7 @@ macro_rules! impl_weight_for_float {
             const MAX: Self = ::core::$T::MAX;
             const ZERO: Self = 0.0;
 
-            fn try_from_usize_lossy(n: usize) -> Option<Self> {
+            fn try_from_u32_lossy(n: u32) -> Option<Self> {
                 Some(n as $T)
             }
 
@@ -328,9 +334,9 @@ macro_rules! impl_weight_for_int {
             const MAX: Self = ::core::$T::MAX;
             const ZERO: Self = 0;
 
-            fn try_from_usize_lossy(n: usize) -> Option<Self> {
+            fn try_from_u32_lossy(n: u32) -> Option<Self> {
                 let n_converted = n as Self;
-                if n_converted >= Self::ZERO && n_converted as usize == n {
+                if n_converted >= Self::ZERO && n_converted as u32 == n {
                     Some(n_converted)
                 } else {
                     None
@@ -439,21 +445,21 @@ mod test {
     where
         WeightedIndex<W>: fmt::Debug,
     {
-        const NUM_WEIGHTS: usize = 10;
-        const ZERO_WEIGHT_INDEX: usize = 3;
+        const NUM_WEIGHTS: u32 = 10;
+        const ZERO_WEIGHT_INDEX: u32 = 3;
         const NUM_SAMPLES: u32 = 15000;
         let mut rng = ::test::rng(0x9c9fa0b0580a7031);
 
         let weights = {
-            let mut weights = Vec::with_capacity(NUM_WEIGHTS);
+            let mut weights = Vec::with_capacity(NUM_WEIGHTS as usize);
             let random_weight_distribution = ::distributions::Uniform::new_inclusive(
                 W::ZERO,
-                W::MAX / W::try_from_usize_lossy(NUM_WEIGHTS).unwrap(),
+                W::MAX / W::try_from_u32_lossy(NUM_WEIGHTS).unwrap(),
             );
             for _ in 0..NUM_WEIGHTS {
                 weights.push(rng.sample(&random_weight_distribution));
             }
-            weights[ZERO_WEIGHT_INDEX] = W::ZERO;
+            weights[ZERO_WEIGHT_INDEX as usize] = W::ZERO;
             weights
         };
         let weight_sum = weights.iter().map(|w| *w).sum::<W>();
@@ -463,12 +469,12 @@ mod test {
             .collect::<Vec<f64>>();
         let weight_distribution = WeightedIndex::new(weights).unwrap();
 
-        let mut counts = vec![0_usize; NUM_WEIGHTS];
+        let mut counts = vec![0; NUM_WEIGHTS as usize];
         for _ in 0..NUM_SAMPLES {
             counts[rng.sample(&weight_distribution)] += 1;
         }
 
-        assert_eq!(counts[ZERO_WEIGHT_INDEX], 0);
+        assert_eq!(counts[ZERO_WEIGHT_INDEX as usize], 0);
         for (count, expected_count) in counts.into_iter().zip(expected_counts) {
             let difference = (count as f64 - expected_count).abs();
             let max_allowed_difference = NUM_SAMPLES as f64 / NUM_WEIGHTS as f64 * 0.1;

--- a/src/distributions/weighted/mod.rs
+++ b/src/distributions/weighted/mod.rs
@@ -208,6 +208,9 @@ pub enum WeightedError {
 
     /// All items in the provided weight collection are zero.
     AllWeightsZero,
+    
+    /// Too many weights are provided (length greater than `u32::MAX`)
+    TooMany,
 }
 
 impl WeightedError {
@@ -216,6 +219,7 @@ impl WeightedError {
             WeightedError::NoItem => "No weights provided.",
             WeightedError::InvalidWeight => "A weight is invalid.",
             WeightedError::AllWeightsZero => "All weights are zero.",
+            WeightedError::TooMany => "Too many weights (hit u32::MAX)",
         }
     }
 }


### PR DESCRIPTION
## Bias

I noticed that the `zone` produced via signed extension is not a multiple of the `range`. This means that the implementations for 8- and 16-bit types (@pitdicker) were biased. I added a fix for this which does not appear to have any performance impact.

It's worth mentioning however that the bias is *tiny*: the biggest deviation from a multiple of the range I could find was 32579 (for range = 65355); since this is sampling from a `u32` the probability of generating a biased sample is thus ~7.6e-6. With 100 million samples this bias is still lost in the noise.

Note: the included uniformity test is unfinished because it's pretty useless. Included for example but it should probably just be deleted.

## Portability for isize/usize samples

As discussed in #805. Unfortunately this does have a performance hit:
```
# before:
test distr_uniform_isize                   ... bench:       1,628 ns/iter (+/- 198) = 4914 MB/s
test distr_uniform_usize16                 ... bench:       1,617 ns/iter (+/- 121) = 4947 MB/s
test distr_uniform_usize32                 ... bench:       1,612 ns/iter (+/- 146) = 4962 MB/s
test distr_uniform_usize64                 ... bench:       2,473 ns/iter (+/- 79) = 3234 MB/s
# after:
test distr_uniform_isize                   ... bench:       5,818 ns/iter (+/- 121) = 1375 MB/s
test distr_uniform_usize16                 ... bench:       1,721 ns/iter (+/- 21) = 4648 MB/s
test distr_uniform_usize32                 ... bench:       1,803 ns/iter (+/- 20) = 4437 MB/s
test distr_uniform_usize64                 ... bench:       2,426 ns/iter (+/- 15) = 3297 MB/s
```
It also results in quite a bit of redundant, ugly code. As such I'm not happy about adding it (though it would be nice to have).

---

Thoughts? @burdges @vks @pitdicker 