### PR TITLE
Prepare new releases, from_rng Endianness and inlining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
 
-## Unreleased
+## [0.7.0 Pre-release] - 2019-06-06
+Many changes (TODO)
 - Enable fork protection of ReseedingRng without `std`
 - Remove dependency on `winapi`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.6.5"
+version = "0.7.0-pre.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ members = [
 ]
 
 [dependencies]
-rand_core = { path = "rand_core", version = "0.4" }
+rand_core = { path = "rand_core", version = "0.5" }
 rand_pcg = { path = "rand_pcg", version = "0.1", optional = true }
 # Do not depend on 'getrandom_package' directly; use the 'getrandom' feature!
 getrandom_package = { version = "0.1.1", package = "getrandom", optional = true }
@@ -114,4 +114,4 @@ required-features = ["small_rng"]
 all-features = true
 
 [patch.crates-io]
-rand_core = { path = "rand_core", version = "0.4" }
+rand_core = { path = "rand_core", version = "0.5" }

--- a/rand_chacha/CHANGELOG.md
+++ b/rand_chacha/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2019-06-06
+- Rewrite based on the much faster `c2-chacha` crate (#789)
+
 ## [0.1.1] - 2019-01-04
 - Disable `i128` and `u128` if the `target_os` is `emscripten` (#671: work-around Emscripten limitation)
 - Update readme and doc links

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "rust-random/rand" }
 appveyor = { repository = "rust-random/rand" }
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "0.4" }
+rand_core = { path = "../rand_core", version = "0.5" }
 c2-chacha = { version = "0.2.2", default-features = false }
 
 [build-dependencies]

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_chacha"
-version = "0.2.1"
+version = "0.2.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers", "The CryptoCorrosion Contributors"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/rand_chacha/README.md
+++ b/rand_chacha/README.md
@@ -16,11 +16,14 @@ as an RNG. It is an improved variant of the Salsa20 cipher family, which was
 selected as one of the "stream ciphers suitable for widespread adoption" by
 eSTREAM[^2].
 
+The RNGs provided by this crate are implemented via the fast stream ciphers of
+the [`c2-chacha`](https://crates.io/crates/c2-chacha) crate.
+
 Links:
 
 -   [API documentation (master)](https://rust-random.github.io/rand/rand_chacha)
 -   [API documentation (docs.rs)](https://docs.rs/rand_chacha)
--   [Changelog](CHANGELOG.md)
+-   [Changelog](https://github.com/rust-random/rand/blob/master/rand_chacha/CHANGELOG.md)
 
 [rand]: https://crates.io/crates/rand
 [^1]: D. J. Bernstein, [*ChaCha, a variant of Salsa20*](

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0] - 2019-06-06
 - Enable testing with Miri and fix incorrect pointer usages (#779, #780, #781, #783, #784)
 - Rewrite `Error` type and adjust API (#800)
+- Adjust usage of `#[inline]` for `BlockRng` and `BlockRng64`
 
 ## [0.4.0] - 2019-01-24
 - Disable the `std` feature by default (#702)

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2019-06-06
+- Enable testing with Miri and fix incorrect pointer usages (#779, #780, #781, #783, #784)
+- Rewrite `Error` type and adjust API (#800)
+
 ## [0.4.0] - 2019-01-24
 - Disable the `std` feature by default (#702)
 

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/rand_core/README.md
+++ b/rand_core/README.md
@@ -25,7 +25,7 @@ Links:
 
 -   [API documentation (master)](https://rust-random.github.io/rand/rand_core)
 -   [API documentation (docs.rs)](https://docs.rs/rand_core)
--   [Changelog](CHANGELOG.md)
+-   [Changelog](https://github.com/rust-random/rand/blob/master/rand_core/CHANGELOG.md)
 
 [rand]: https://crates.io/crates/rand
 
@@ -41,6 +41,11 @@ The `rand_core` crate provides:
 The traits and error types are also available via `rand`.
 
 ## Versions
+
+The current version is:
+```
+rand_core = "0.5.0"
+```
 
 Rand libs have inter-dependencies and make use of the
 [semver trick](https://github.com/dtolnay/semver-trick/) in order to make traits

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "rust-random/rand" }
 appveyor = { repository = "rust-random/rand" }
 
 [dependencies]
-rand = { path = "..", version = ">=0.5, <=0.7" }
+rand = { path = "..", version = ">=0.5, <=0.7.0-pre.9" }
 
 [dev-dependencies]
 rand_pcg = { version = "0.1", path = "../rand_pcg" }

--- a/rand_hc/CHANGELOG.md
+++ b/rand_hc/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1] - 2019-06-06
 - Bump `rand_core` version
+- Adjust usage of `#[inline]`
 
 ## [0.1.0] - 2018-10-17
 - Pulled out of the Rand crate

--- a/rand_hc/CHANGELOG.md
+++ b/rand_hc/CHANGELOG.md
@@ -4,5 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2019-06-06
+- Bump `rand_core` version
+
 ## [0.1.0] - 2018-10-17
 - Pulled out of the Rand crate

--- a/rand_hc/Cargo.toml
+++ b/rand_hc/Cargo.toml
@@ -18,4 +18,4 @@ travis-ci = { repository = "rust-random/rand" }
 appveyor = { repository = "rust-random/rand" }
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "0.4" }
+rand_core = { path = "../rand_core", version = "0.5" }

--- a/rand_hc/Cargo.toml
+++ b/rand_hc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_hc"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["The Rand Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/rand_hc/README.md
+++ b/rand_hc/README.md
@@ -19,7 +19,7 @@ Links:
 
 -   [API documentation (master)](https://rust-random.github.io/rand/rand_hc)
 -   [API documentation (docs.rs)](https://docs.rs/rand_hc)
--   [Changelog](CHANGELOG.md)
+-   [Changelog](https://github.com/rust-random/rand/blob/master/rand_hc/CHANGELOG.md)
 
 [rand]: https://crates.io/crates/rand
 [^1]: Hongjun Wu (2008). ["The Stream Cipher HC-128"](

--- a/rand_hc/src/hc128.rs
+++ b/rand_hc/src/hc128.rs
@@ -67,20 +67,22 @@ const SEED_WORDS: usize = 8; // 128 bit key followed by 128 bit iv
 pub struct Hc128Rng(BlockRng<Hc128Core>);
 
 impl RngCore for Hc128Rng {
-    #[inline(always)]
+    #[inline]
     fn next_u32(&mut self) -> u32 {
         self.0.next_u32()
     }
 
-    #[inline(always)]
+    #[inline]
     fn next_u64(&mut self) -> u64 {
         self.0.next_u64()
     }
 
+    #[inline]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.0.fill_bytes(dest)
     }
 
+    #[inline]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill_bytes(dest)
     }
@@ -89,10 +91,12 @@ impl RngCore for Hc128Rng {
 impl SeedableRng for Hc128Rng {
     type Seed = <Hc128Core as SeedableRng>::Seed;
 
+    #[inline]
     fn from_seed(seed: Self::Seed) -> Self {
         Hc128Rng(BlockRng::<Hc128Core>::from_seed(seed))
     }
 
+    #[inline]
     fn from_rng<R: RngCore>(rng: R) -> Result<Self, Error> {
         BlockRng::<Hc128Core>::from_rng(rng).map(Hc128Rng)
     }
@@ -268,6 +272,7 @@ impl Hc128Core {
     // Initialize an HC-128 random number generator. The seed has to be
     // 256 bits in length (`[u32; 8]`), matching the 128 bit `key` followed by
     // 128 bit `iv` when HC-128 where to be used as a stream cipher.
+    #[inline(always)]   // single use: SeedableRng::from_seed
     fn init(seed: [u32; SEED_WORDS]) -> Self {
         #[inline]
         fn f1(x: u32) -> u32 {

--- a/rand_isaac/CHANGELOG.md
+++ b/rand_isaac/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2019-06-06
+- Bump `rand_core` version
+- Remove deprecated code
+
 ## [0.1.1] - 2018-11-26
 - Fix `rand_core` version requirement
 - Fix doc links

--- a/rand_isaac/CHANGELOG.md
+++ b/rand_isaac/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.2] - 2019-06-06
 - Bump `rand_core` version
 - Remove deprecated code
+- Adjust usage of `#[inline]`
 
 ## [0.1.1] - 2018-11-26
 - Fix `rand_core` version requirement

--- a/rand_isaac/Cargo.toml
+++ b/rand_isaac/Cargo.toml
@@ -21,7 +21,7 @@ appveyor = { repository = "rust-random/rand" }
 serde1 = ["serde", "serde_derive", "rand_core/serde1"]
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "0.4" }
+rand_core = { path = "../rand_core", version = "0.5" }
 serde = { version = "1", optional = true }
 serde_derive = { version = "^1.0.38", optional = true }
 

--- a/rand_isaac/Cargo.toml
+++ b/rand_isaac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_isaac"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/rand_isaac/README.md
+++ b/rand_isaac/README.md
@@ -22,7 +22,7 @@ Links:
 
 -   [API documentation (master)](https://rust-random.github.io/rand/rand_isaac)
 -   [API documentation (docs.rs)](https://docs.rs/rand_isaac)
--   [Changelog](CHANGELOG.md)
+-   [Changelog](https://github.com/rust-random/rand/blob/master/rand_isaac/CHANGELOG.md)
 
 [rand]: https://crates.io/crates/rand
 [^1]: Bob Jenkins, [*ISAAC: A fast cryptographic random number generator*](http://burtleburtle.net/bob/rand/isaacafa.html)

--- a/rand_isaac/src/isaac.rs
+++ b/rand_isaac/src/isaac.rs
@@ -92,20 +92,22 @@ const RAND_SIZE: usize = 1 << RAND_SIZE_LEN;
 pub struct IsaacRng(BlockRng<IsaacCore>);
 
 impl RngCore for IsaacRng {
-    #[inline(always)]
+    #[inline]
     fn next_u32(&mut self) -> u32 {
         self.0.next_u32()
     }
 
-    #[inline(always)]
+    #[inline]
     fn next_u64(&mut self) -> u64 {
         self.0.next_u64()
     }
 
+    #[inline]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.0.fill_bytes(dest)
     }
 
+    #[inline]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill_bytes(dest)
     }
@@ -114,6 +116,7 @@ impl RngCore for IsaacRng {
 impl SeedableRng for IsaacRng {
     type Seed = <IsaacCore as SeedableRng>::Seed;
 
+    #[inline]
     fn from_seed(seed: Self::Seed) -> Self {
         IsaacRng(BlockRng::<IsaacCore>::from_seed(seed))
     }
@@ -121,10 +124,12 @@ impl SeedableRng for IsaacRng {
     /// Create an ISAAC random number generator using an `u64` as seed.
     /// If `seed == 0` this will produce the same stream of random numbers as
     /// the reference implementation when used unseeded.
+    #[inline]
     fn seed_from_u64(seed: u64) -> Self {
         IsaacRng(BlockRng::<IsaacCore>::seed_from_u64(seed))
     }
 
+    #[inline]
     fn from_rng<S: RngCore>(rng: S) -> Result<Self, Error> {
         BlockRng::<IsaacCore>::from_rng(rng).map(|rng| IsaacRng(rng))
     }

--- a/rand_isaac/src/isaac64.rs
+++ b/rand_isaac/src/isaac64.rs
@@ -83,20 +83,22 @@ const RAND_SIZE: usize = 1 << RAND_SIZE_LEN;
 pub struct Isaac64Rng(BlockRng64<Isaac64Core>);
 
 impl RngCore for Isaac64Rng {
-    #[inline(always)]
+    #[inline]
     fn next_u32(&mut self) -> u32 {
         self.0.next_u32()
     }
 
-    #[inline(always)]
+    #[inline]
     fn next_u64(&mut self) -> u64 {
         self.0.next_u64()
     }
 
+    #[inline]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.0.fill_bytes(dest)
     }
 
+    #[inline]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill_bytes(dest)
     }
@@ -105,6 +107,7 @@ impl RngCore for Isaac64Rng {
 impl SeedableRng for Isaac64Rng {
     type Seed = <Isaac64Core as SeedableRng>::Seed;
 
+    #[inline]
     fn from_seed(seed: Self::Seed) -> Self {
         Isaac64Rng(BlockRng64::<Isaac64Core>::from_seed(seed))
     }
@@ -112,10 +115,12 @@ impl SeedableRng for Isaac64Rng {
     /// Create an ISAAC random number generator using an `u64` as seed.
     /// If `seed == 0` this will produce the same stream of random numbers as
     /// the reference implementation when used unseeded.
+    #[inline]
     fn seed_from_u64(seed: u64) -> Self {
         Isaac64Rng(BlockRng64::<Isaac64Core>::seed_from_u64(seed))
     }
 
+    #[inline]
     fn from_rng<S: RngCore>(rng: S) -> Result<Self, Error> {
         BlockRng64::<Isaac64Core>::from_rng(rng).map(|rng| Isaac64Rng(rng))
     }

--- a/rand_jitter/CHANGELOG.md
+++ b/rand_jitter/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2019-06-06
+- Bump `rand_core` version
+- Support new `Error` type in `rand_core` 0.5
+- Remove CryptoRng trait bound (#699, #814)
+- Enable doc-testing of README
+
 ## [0.1.4] - 2019-05-02
 - Change error conversion code to partially fix #738
 

--- a/rand_jitter/Cargo.toml
+++ b/rand_jitter/Cargo.toml
@@ -14,7 +14,7 @@ travis-ci = { repository = "rust-random/rand" }
 appveyor = { repository = "rust-random/rand" }
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "0.4" }
+rand_core = { path = "../rand_core", version = "0.5" }
 log = { version = "0.4", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]

--- a/rand_jitter/Cargo.toml
+++ b/rand_jitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_jitter"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_jitter/README.md
+++ b/rand_jitter/README.md
@@ -24,7 +24,7 @@ Links:
 
 -   [API documentation (master)](https://rust-random.github.io/rand/rand_jitter)
 -   [API documentation (docs.rs)](https://docs.rs/rand_jitter)
--   [Changelog](CHANGELOG.md)
+-   [Changelog](https://github.com/rust-random/rand/blob/master/rand_jitter/CHANGELOG.md)
 
 ## Features
 

--- a/rand_os/CHANGELOG.md
+++ b/rand_os/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.2.0] - 2019-04-08
+## [0.2.0] - 2019-06-06
 Replaced implementation with a backwards-compatible shim around
 [getrandom](https://crates.io/crates/getrandom).
 

--- a/rand_os/Cargo.toml
+++ b/rand_os/Cargo.toml
@@ -22,5 +22,5 @@ wasm-bindgen = ["getrandom/wasm-bindgen"]
 stdweb = ["getrandom/stdweb"]
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "0.4", features = ["std"] }
+rand_core = { path = "../rand_core", version = "0.5", features = ["std"] }
 getrandom = "0.1.1"

--- a/rand_os/README.md
+++ b/rand_os/README.md
@@ -22,7 +22,7 @@ Links:
 
 -   [API documentation (master)](https://rust-random.github.io/rand/rand_os)
 -   [API documentation (docs.rs)](https://docs.rs/rand_os)
--   [Changelog](CHANGELOG.md)
+-   [Changelog](https://github.com/rust-random/rand/blob/master/rand_os/CHANGELOG.md)
 
 ## License
 

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -22,7 +22,7 @@ appveyor = { repository = "rust-random/rand" }
 serde1 = ["serde", "serde_derive"]
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "0.4" }
+rand_core = { path = "../rand_core", version = "0.5" }
 serde = { version = "1", optional = true }
 serde_derive = { version = "^1.0.38", optional = true }
 

--- a/rand_pcg/README.md
+++ b/rand_pcg/README.md
@@ -24,7 +24,7 @@ Links:
 
 -   [API documentation (master)](https://rust-random.github.io/rand/rand_pcg)
 -   [API documentation (docs.rs)](https://docs.rs/rand_pcg)
--   [Changelog](CHANGELOG.md)
+-   [Changelog](https://github.com/rust-random/rand/blob/master/rand_pcg/CHANGELOG.md)
 
 
 ## Crate Features

--- a/rand_xorshift/CHANGELOG.md
+++ b/rand_xorshift/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.2] - 2019-06-06
 - Bump `rand_core` version
+- Make XorShiftRng::from_rng portable by enforcing Endianness (#815)
 
 ## [0.1.1] - 2019-01-04
 - Reorganise code and tests; tweak doc

--- a/rand_xorshift/CHANGELOG.md
+++ b/rand_xorshift/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2019-06-06
+- Bump `rand_core` version
+
 ## [0.1.1] - 2019-01-04
 - Reorganise code and tests; tweak doc
 

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -21,7 +21,7 @@ appveyor = { repository = "rust-random/rand" }
 serde1 = ["serde", "serde_derive"]
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "0.4" }
+rand_core = { path = "../rand_core", version = "0.5" }
 serde = { version = "1", optional = true }
 serde_derive = { version = "^1.0.38", optional = true }
 

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_xorshift"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/rand_xorshift/README.md
+++ b/rand_xorshift/README.md
@@ -22,7 +22,7 @@ Links:
 
 -   [API documentation (master)](https://rust-random.github.io/rand/rand_xorshift)
 -   [API documentation (docs.rs)](https://docs.rs/rand_xorshift)
--   [Changelog](CHANGELOG.md)
+-   [Changelog](https://github.com/rust-random/rand/blob/master/rand_xorshift/CHANGELOG.md)
 
 [rand]: https://crates.io/crates/rand
 

--- a/rand_xorshift/src/lib.rs
+++ b/rand_xorshift/src/lib.rs
@@ -110,6 +110,10 @@ impl SeedableRng for XorShiftRng {
                 let slice = slice::from_raw_parts_mut(ptr, 4 * 4);
                 rng.try_fill_bytes(slice)?;
             }
+            for v in seed_u32.iter_mut() {
+                // enforce LE for consistency across platforms
+                *v = v.to_le();
+            }
             if !seed_u32.iter().all(|&x| x == 0) { break; }
         }
 

--- a/rand_xorshift/tests/mod.rs
+++ b/rand_xorshift/tests/mod.rs
@@ -12,9 +12,10 @@ fn test_xorshift_construction() {
     let mut rng1 = XorShiftRng::from_seed(seed);
     assert_eq!(rng1.next_u64(), 4325440999699518727);
 
-    let _rng2 = XorShiftRng::from_rng(rng1).unwrap();
-    // Note: we cannot test the state of _rng2 because from_rng does not
-    // fix Endianness. This is allowed in the trait specification.
+    let mut rng2 = XorShiftRng::from_rng(&mut rng1).unwrap();
+    // Yes, this makes rng2 a clone of rng1!
+    assert_eq!(rng1.next_u64(), 15614385950550801700);
+    assert_eq!(rng2.next_u64(), 15614385950550801700);
 }
 
 #[test]

--- a/rand_xoshiro/CHANGELOG.md
+++ b/rand_xoshiro/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2019-06-06
+- Bump `rand_core` version
+- Document crate features in README
+
 ## [0.2.0] - 2019-05-28
 - Fix `seed_from_u64(0)` for `Xoroshiro64StarStar` and `Xoroshiro64Star`. This
   breaks value stability for these generators if initialized with `seed_from_u64`.

--- a/rand_xoshiro/Cargo.toml
+++ b/rand_xoshiro/Cargo.toml
@@ -21,7 +21,6 @@ serde = { version = "1", optional=true }
 serde_derive = { version = "^1.0.38", optional=true }
 
 [dev-dependencies]
-rand = { path = "..", version = "0.6", default-features=false }  # needed for doctests
 # This is for testing serde, unfortunately we can't specify feature-gated dev
 # deps yet, see: https://github.com/rust-lang/cargo/issues/1596
 bincode = { version = "1" }

--- a/rand_xoshiro/Cargo.toml
+++ b/rand_xoshiro/Cargo.toml
@@ -16,7 +16,7 @@ serde1 = ["serde", "serde_derive"]
 
 [dependencies]
 byteorder = { version = "1", default-features=false }
-rand_core = { path = "../rand_core", version = "0.4" }
+rand_core = { path = "../rand_core", version = "0.5" }
 serde = { version = "1", optional=true }
 serde_derive = { version = "^1.0.38", optional=true }
 

--- a/rand_xoshiro/Cargo.toml
+++ b/rand_xoshiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_xoshiro"
-version = "0.2.0" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.2.1" # NB: When modifying, also modify html_root_url in lib.rs
 authors = ["The Rand Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/rand_xoshiro/README.md
+++ b/rand_xoshiro/README.md
@@ -17,7 +17,7 @@ Links:
 
 -   [API documentation (master)](https://rust-random.github.io/rand/rand_xoshiro)
 -   [API documentation (docs.rs)](https://docs.rs/rand_xoshiro)
--   [Changelog](CHANGELOG.md)
+-   [Changelog](https://github.com/rust-random/rand/blob/master/rand_xoshiro/CHANGELOG.md)
 
 ## Crate Features
 

--- a/rand_xoshiro/src/lib.rs
+++ b/rand_xoshiro/src/lib.rs
@@ -58,7 +58,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand_xoshiro/0.2.0")]
+       html_root_url = "https://docs.rs/rand_xoshiro/0.2.1")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/rand_xoshiro/src/xoroshiro128plus.rs
+++ b/rand_xoshiro/src/xoroshiro128plus.rs
@@ -35,10 +35,9 @@ impl Xoroshiro128Plus {
     /// parallel computations.
     ///
     /// ```
-    /// # extern crate rand;
     /// # extern crate rand_xoshiro;
     /// # fn main() {
-    /// use rand::SeedableRng;
+    /// use rand_xoshiro::rand_core::SeedableRng;
     /// use rand_xoshiro::Xoroshiro128Plus;
     ///
     /// let rng1 = Xoroshiro128Plus::seed_from_u64(0);

--- a/rand_xoshiro/src/xoroshiro128starstar.rs
+++ b/rand_xoshiro/src/xoroshiro128starstar.rs
@@ -34,10 +34,9 @@ impl Xoroshiro128StarStar {
     /// parallel computations.
     ///
     /// ```
-    /// # extern crate rand;
     /// # extern crate rand_xoshiro;
     /// # fn main() {
-    /// use rand::SeedableRng;
+    /// use rand_xoshiro::rand_core::SeedableRng;
     /// use rand_xoshiro::Xoroshiro128StarStar;
     ///
     /// let rng1 = Xoroshiro128StarStar::seed_from_u64(0);

--- a/rand_xoshiro/src/xoshiro128plus.rs
+++ b/rand_xoshiro/src/xoshiro128plus.rs
@@ -32,10 +32,9 @@ impl Xoshiro128Plus {
     /// parallel computations.
     ///
     /// ```
-    /// # extern crate rand;
     /// # extern crate rand_xoshiro;
     /// # fn main() {
-    /// use rand::SeedableRng;
+    /// use rand_xoshiro::rand_core::SeedableRng;
     /// use rand_xoshiro::Xoroshiro128StarStar;
     ///
     /// let rng1 = Xoroshiro128StarStar::seed_from_u64(0);

--- a/rand_xoshiro/src/xoshiro128starstar.rs
+++ b/rand_xoshiro/src/xoshiro128starstar.rs
@@ -31,10 +31,9 @@ impl Xoshiro128StarStar {
     /// parallel computations.
     ///
     /// ```
-    /// # extern crate rand;
     /// # extern crate rand_xoshiro;
     /// # fn main() {
-    /// use rand::SeedableRng;
+    /// use rand_xoshiro::rand_core::SeedableRng;
     /// use rand_xoshiro::Xoroshiro128StarStar;
     ///
     /// let rng1 = Xoroshiro128StarStar::seed_from_u64(0);

--- a/rand_xoshiro/src/xoshiro256plus.rs
+++ b/rand_xoshiro/src/xoshiro256plus.rs
@@ -32,10 +32,9 @@ impl Xoshiro256Plus {
     /// parallel computations.
     ///
     /// ```
-    /// # extern crate rand;
     /// # extern crate rand_xoshiro;
     /// # fn main() {
-    /// use rand::SeedableRng;
+    /// use rand_xoshiro::rand_core::SeedableRng;
     /// use rand_xoshiro::Xoshiro256Plus;
     ///
     /// let rng1 = Xoshiro256Plus::seed_from_u64(0);

--- a/rand_xoshiro/src/xoshiro256starstar.rs
+++ b/rand_xoshiro/src/xoshiro256starstar.rs
@@ -31,10 +31,9 @@ impl Xoshiro256StarStar {
     /// parallel computations.
     ///
     /// ```
-    /// # extern crate rand;
     /// # extern crate rand_xoshiro;
     /// # fn main() {
-    /// use rand::SeedableRng;
+    /// use rand_xoshiro::rand_core::SeedableRng;
     /// use rand_xoshiro::Xoshiro256StarStar;
     ///
     /// let rng1 = Xoshiro256StarStar::seed_from_u64(0);

--- a/rand_xoshiro/src/xoshiro512plus.rs
+++ b/rand_xoshiro/src/xoshiro512plus.rs
@@ -34,10 +34,9 @@ impl Xoshiro512Plus {
     /// parallel computations.
     ///
     /// ```
-    /// # extern crate rand;
     /// # extern crate rand_xoshiro;
     /// # fn main() {
-    /// use rand::SeedableRng;
+    /// use rand_xoshiro::rand_core::SeedableRng;
     /// use rand_xoshiro::Xoshiro512Plus;
     ///
     /// let rng1 = Xoshiro512Plus::seed_from_u64(0);

--- a/rand_xoshiro/src/xoshiro512starstar.rs
+++ b/rand_xoshiro/src/xoshiro512starstar.rs
@@ -33,10 +33,9 @@ impl Xoshiro512StarStar {
     /// parallel computations.
     ///
     /// ```
-    /// # extern crate rand;
     /// # extern crate rand_xoshiro;
     /// # fn main() {
-    /// use rand::SeedableRng;
+    /// use rand_xoshiro::rand_core::SeedableRng;
     /// use rand_xoshiro::Xoshiro512StarStar;
     ///
     /// let rng1 = Xoshiro512StarStar::seed_from_u64(0);

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -89,10 +89,12 @@ impl RngCore for SmallRng {
         self.0.next_u64()
     }
 
+    #[inline(always)]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.0.fill_bytes(dest);
     }
 
+    #[inline(always)]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill_bytes(dest)
     }
@@ -101,10 +103,12 @@ impl RngCore for SmallRng {
 impl SeedableRng for SmallRng {
     type Seed = <Rng as SeedableRng>::Seed;
 
+    #[inline(always)]
     fn from_seed(seed: Self::Seed) -> Self {
         SmallRng(Rng::from_seed(seed))
     }
 
+    #[inline(always)]
     fn from_rng<R: RngCore>(rng: R) -> Result<Self, Error> {
         Rng::from_rng(rng).map(SmallRng)
     }

--- a/src/rngs/std.rs
+++ b/src/rngs/std.rs
@@ -44,10 +44,12 @@ impl RngCore for StdRng {
         self.0.next_u64()
     }
 
+    #[inline(always)]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.0.fill_bytes(dest);
     }
 
+    #[inline(always)]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill_bytes(dest)
     }
@@ -56,10 +58,12 @@ impl RngCore for StdRng {
 impl SeedableRng for StdRng {
     type Seed = <Rng as SeedableRng>::Seed;
 
+    #[inline(always)]
     fn from_seed(seed: Self::Seed) -> Self {
         StdRng(Rng::from_seed(seed))
     }
 
+    #[inline(always)]
     fn from_rng<R: RngCore>(rng: R) -> Result<Self, Error> {
         Rng::from_rng(rng).map(StdRng)
     }


### PR DESCRIPTION
Prepare the 0.7 pre-release and releases of many other crates (the *only* one without changes is PCG, though some are just doc).

Important: this is missing `rand_distr` which I asked @vks to look at.

Also closes #572, most of which was already implemented (probably as part of #800).