### PR TITLE
rand_distr: Prepare 0.1 and 0.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ rand_hc = { path = "rand_hc", version = "0.1" }
 rand_xoshiro = { path = "rand_xoshiro", version = "0.2" }
 rand_isaac = { path = "rand_isaac", version = "0.1" }
 rand_xorshift = { path = "rand_xorshift", version = "0.1" }
-rand_distr = { path = "rand_distr", version = "0.1" }
+rand_distr = { path = "rand_distr", version = "0.2" }
 
 [build-dependencies]
 autocfg = "0.1"

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -4,5 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - ??
-Initial release.
+## [0.2.0] - 2019-06-06
+- Remove `new` constructors for zero-sized types
+- Add Pert distribution
+- Fix undefined behavior in `Poisson`
+- Make all distributions return `Result`s instead of panicking
+- Implement `f32` support for most distributions
+- Rename `UnitSphereSurface` to `UnitSphere`
+- Implement `UnitBall` and `UnitDisc`
+
+## [0.1.0] - 2019-06-06
+Initial release. This is equivalent to the code in `rand` 0.6.5.

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_distr"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The Rand Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -20,7 +20,6 @@ appveyor = { repository = "rust-random/rand" }
 
 [dependencies]
 rand = { path = "..", version = ">=0.5, <=0.7" }
-
 
 [dev-dependencies]
 rand_pcg = { version = "0.1", path = "../rand_pcg" }


### PR DESCRIPTION
For the 0.1, I suggest to branch off b21713a7826a38458c2b82951908313262b1c7b8, update the changelog and publish it on crates.io.