### PR TITLE
Implement Distribution for Range(Inclusive)

### DIFF
--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -259,6 +259,23 @@ pub trait UniformSampler: Sized {
         let uniform: Self = UniformSampler::new(low, high);
         uniform.sample(rng)
     }
+
+    /// Sample a single value uniformly from a range with inclusive lower bound
+    /// and inclusive upper bound `[low, high]`.
+    ///
+    /// By default this is implemented using
+    /// `UniformSampler::new_inclusive(low, high).sample(rng)`. However, for
+    /// some types more optimal implementations for single usage may be provided
+    /// via this method.
+    /// Results may not be identical.
+    fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(low: B1, high: B2, rng: &mut R)
+        -> Self::X
+        where B1: SampleBorrow<Self::X> + Sized,
+              B2: SampleBorrow<Self::X> + Sized
+    {
+        let uniform: Self = UniformSampler::new_inclusive(low, high);
+        uniform.sample(rng)
+    }
 }
 
 impl<X: SampleUniform> From<::core::ops::Range<X>> for Uniform<X> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,9 +227,10 @@ pub trait Rng: RngCore {
     /// use rand::distributions::Uniform;
     ///
     /// let mut rng = thread_rng();
-    /// let x = rng.sample(Uniform::new(10u32, 15));
+    /// let x = rng.sample(10u32..15);
     /// // Type annotation requires two types, the type and distribution; the
-    /// // distribution can be inferred.
+    /// // distribution can be inferred. `Uniform` is more efficient than the
+    /// // above range syntax if multiple samples are taken.
     /// let y = rng.sample::<u16, _>(Uniform::new(10, 15));
     /// ```
     fn sample<T, D: Distribution<T>>(&mut self, distr: D) -> T {


### PR DESCRIPTION
This enables the convenient syntax of `rng.sample(0..10)`, and hence provides a non-disruptive fix to #744. If people think this is a good idea I should update the documentation to mention `sample_single_inclusive` more, but I figured I'd get feedback first.