### PR TITLE
miri CI: use latest nightly with Miri

### DIFF
--- a/utils/ci/miri.sh
+++ b/utils/ci/miri.sh
@@ -1,17 +1,22 @@
 set -ex
 
-if rustup component add miri && cargo miri setup ; then
-    cargo miri test --no-default-features -- -Zmiri-seed=42 -- -Zunstable-options --exclude-should-panic
-    cargo miri test --features=serde1,log -- -Zmiri-seed=42 -- -Zunstable-options --exclude-should-panic
-    cargo miri test --manifest-path rand_core/Cargo.toml
-    cargo miri test --manifest-path rand_core/Cargo.toml --no-default-features
-    #cargo miri test --manifest-path rand_distr/Cargo.toml # no unsafe and lots of slow tests
-    cargo miri test --manifest-path rand_isaac/Cargo.toml --features=serde1
-    cargo miri test --manifest-path rand_pcg/Cargo.toml --features=serde1
-    cargo miri test --manifest-path rand_xorshift/Cargo.toml --features=serde1
-    cargo miri test --manifest-path rand_xoshiro/Cargo.toml
-    cargo miri test --manifest-path rand_chacha/Cargo.toml --no-default-features
-    cargo miri test --manifest-path rand_hc/Cargo.toml
-    cargo miri test --manifest-path rand_jitter/Cargo.toml
-    cargo miri test --manifest-path rand_os/Cargo.toml -- -Zmiri-seed=42
-fi
+MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+echo "Installing latest nightly with Miri: $MIRI_NIGHTLY"
+rustup default "$MIRI_NIGHTLY"
+
+rustup component add miri
+cargo miri setup
+
+cargo miri test --no-default-features -- -Zmiri-seed=42 -- -Zunstable-options --exclude-should-panic
+cargo miri test --features=serde1,log -- -Zmiri-seed=42 -- -Zunstable-options --exclude-should-panic
+cargo miri test --manifest-path rand_core/Cargo.toml
+cargo miri test --manifest-path rand_core/Cargo.toml --no-default-features
+#cargo miri test --manifest-path rand_distr/Cargo.toml # no unsafe and lots of slow tests
+cargo miri test --manifest-path rand_isaac/Cargo.toml --features=serde1
+cargo miri test --manifest-path rand_pcg/Cargo.toml --features=serde1
+cargo miri test --manifest-path rand_xorshift/Cargo.toml --features=serde1
+cargo miri test --manifest-path rand_xoshiro/Cargo.toml
+cargo miri test --manifest-path rand_chacha/Cargo.toml --no-default-features
+cargo miri test --manifest-path rand_hc/Cargo.toml
+cargo miri test --manifest-path rand_jitter/Cargo.toml
+cargo miri test --manifest-path rand_os/Cargo.toml -- -Zmiri-seed=42


### PR DESCRIPTION
Use the brand-new files from https://github.com/rust-lang/rustup-components-history/issues/5 to install a nightly that definitely has Miri.

In principle this could still fail though, as we might ship a Miri that does not actually work (see https://github.com/rust-lang/rustup-components-history/issues/5). That does not happen very often though (it happened once so far).