### PR TITLE
rand: Remove serde1 feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ appveyor = { repository = "rust-random/rand" }
 # Meta-features:
 default = ["std"] # without "std" rand uses libcore
 nightly = ["simd_support"] # enables all features requiring nightly rust
+serde1 = [] # does nothing, deprecated
 
 # Optional dependencies:
 std = ["rand_core/std", "alloc", "getrandom"]
 alloc = ["rand_core/alloc"]  # enables Vec and Box support (without std)
-serde1 = ["rand_core/serde1", "rand_isaac/serde1", "rand_xorshift/serde1"] # enables serialization for PRNGs
 # re-export optional WASM dependencies to avoid breakage:
 wasm-bindgen = ["getrandom_package/wasm-bindgen"]
 stdweb = ["getrandom_package/stdweb"]

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ Rand is built with these features enabled by default:
 Optionally, the following dependencies can be enabled:
 
 -   `log` enables logging via the `log` crate
--   `serde1` enables serialization for some types, via Serde version 1
 -   `stdweb` implies `getrandom/stdweb` to enable
     `getrandom` support on `wasm32-unknown-unknown`
 -   `wasm-bindgen` implies `getrandom/wasm-bindgen` to enable

--- a/utils/ci/miri.sh
+++ b/utils/ci/miri.sh
@@ -8,14 +8,15 @@ rustup component add miri
 cargo miri setup
 
 cargo miri test --no-default-features -- -Zmiri-seed=42 -- -Zunstable-options --exclude-should-panic
-cargo miri test --features=serde1,log -- -Zmiri-seed=42 -- -Zunstable-options --exclude-should-panic
+cargo miri test --features=log -- -Zmiri-seed=42 -- -Zunstable-options --exclude-should-panic
 cargo miri test --manifest-path rand_core/Cargo.toml
+cargo miri test --manifest-path rand_core/Cargo.toml --features=serde1
 cargo miri test --manifest-path rand_core/Cargo.toml --no-default-features
 #cargo miri test --manifest-path rand_distr/Cargo.toml # no unsafe and lots of slow tests
 cargo miri test --manifest-path rand_isaac/Cargo.toml --features=serde1
 cargo miri test --manifest-path rand_pcg/Cargo.toml --features=serde1
 cargo miri test --manifest-path rand_xorshift/Cargo.toml --features=serde1
-cargo miri test --manifest-path rand_xoshiro/Cargo.toml
+cargo miri test --manifest-path rand_xoshiro/Cargo.toml --features=serde1
 cargo miri test --manifest-path rand_chacha/Cargo.toml --no-default-features
 cargo miri test --manifest-path rand_hc/Cargo.toml
 cargo miri test --manifest-path rand_jitter/Cargo.toml

--- a/utils/ci/script.sh
+++ b/utils/ci/script.sh
@@ -5,15 +5,16 @@ set -ex
 main() {
     cross test --target $TARGET --tests --no-default-features
   # TODO: add simd_support feature:
-    cross test --target $TARGET --features=serde1,log
+    cross test --target $TARGET --features=log
     cross test --target $TARGET --examples
     cross test --target $TARGET --manifest-path rand_core/Cargo.toml
+    cross test --target $TARGET --manifest-path rand_core/Cargo.toml --features=serde1
     cross test --target $TARGET --manifest-path rand_core/Cargo.toml --no-default-features
     cross test --target $TARGET --manifest-path rand_distr/Cargo.toml
     cross test --target $TARGET --manifest-path rand_isaac/Cargo.toml --features=serde1
     cross test --target $TARGET --manifest-path rand_pcg/Cargo.toml --features=serde1
     cross test --target $TARGET --manifest-path rand_xorshift/Cargo.toml --features=serde1
-    cross test --target $TARGET --manifest-path rand_xoshiro/Cargo.toml
+    cross test --target $TARGET --manifest-path rand_xoshiro/Cargo.toml --features=serde1
     cross test --target $TARGET --manifest-path rand_chacha/Cargo.toml
     cross test --target $TARGET --manifest-path rand_hc/Cargo.toml
     cross test --target $TARGET --manifest-path rand_os/Cargo.toml


### PR DESCRIPTION
This feature does not do anything in the `rand` crate and was forwarded
to `rand_core`, where it was used for `BlockRng` and `BlockRng64`.
However, crates using this feature would use `rand_core` directly
instead, making the feature pointless for `rand`.

It is not expected to use this feature for any of the RNGs in `rand`.

This hopefully makes it possible to build `rand` on docs.rs again.
(See https://github.com/rust-lang/docs.rs/issues/369.)

Now the serde1 feature does not do anything, but it is still available
for backwards compatibility.