### PR TITLE
Fix no-std support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -255,6 +255,13 @@ matrix:
         - source ~/.cargo/env || true
       script:
         - bash utils/ci/script.sh
+    - rust: nightly
+      env: DESCRIPTION="no_std platform test"
+      install:
+        - rustup target add thumbv6m-none-eabi
+      script:
+        # Test the top-level crate with all features:
+        - cargo build --target=thumbv6m-none-eabi --no-default-features
 
     - rust: nightly
       os: linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [Unreleased]
+- Fix `no_std` behaviour, appropriately enable c2-chacha's `std` feature (#844)
+- Add a `no_std` target to CI to continously evaluate `no_std` status (#844)
 
 ## [0.7.0] - 2019-06-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ nightly = ["simd_support"] # enables all features requiring nightly rust
 serde1 = [] # does nothing, deprecated
 
 # Optional dependencies:
-std = ["rand_core/std", "alloc", "getrandom"]
+std = ["rand_core/std", "rand_chacha/std", "alloc", "getrandom"]
 alloc = ["rand_core/alloc"]  # enables Vec and Box support (without std)
 # re-export optional WASM dependencies to avoid breakage:
 wasm-bindgen = ["getrandom_package/wasm-bindgen"]
@@ -74,7 +74,7 @@ libc = { version = "0.2.22", default-features = false }
 # Emscripten does not support 128-bit integers, which are used by ChaCha code.
 # We work around this by using a different RNG.
 [target.'cfg(not(target_os = "emscripten"))'.dependencies]
-rand_chacha = { path = "rand_chacha", version = "0.2" }
+rand_chacha = { path = "rand_chacha", version = "0.2", default-features = false }
 [target.'cfg(target_os = "emscripten")'.dependencies]
 rand_hc = { path = "rand_hc", version = "0.2" }
 


### PR DESCRIPTION
`rand_chacha` used `c2-chacha` without trickling through features.
This disables default options in `rand_chacha`, enabling simd and std
when the option is selected at the root.