### PR TITLE
Fix rand dependency version in rand_distr

### DIFF
--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "rust-random/rand" }
 appveyor = { repository = "rust-random/rand" }
 
 [dependencies]
-rand = { path = "..", version = ">=0.5, <=0.7" }
+rand = { path = "..", version = "0.7" }
 
 [dev-dependencies]
 rand_pcg = { version = "0.2", path = "../rand_pcg" }


### PR DESCRIPTION
`rand_distr` works with neither `rand` `0.5.6` (the latest version of `0.5.*`) nor `0.6.5` (the latest version of `0.6.*`). In other words, if I change the dependency to `rand = "0.5"` or `rand = "0.6"`, then `cargo check` fails.