### PR TITLE
rand_core 0.4.1 (backports)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ sudo: false
 # - test no_std support, but only the unit tests:
 #   `cargo test --lib --no-default-features`
 # - run unit tests and doctests with all features which are available on stable:
-#   `cargo test --features=serde1,log`
+#   `cargo test --features=log`
 # - test examples:
 #   `cargo test --examples`
 # Additional tests on nightly:
@@ -64,7 +64,7 @@ matrix:
         # Differs from standard script: rand_pcg features
         - cargo test --lib --no-default-features
         # TODO: add simd_support feature:
-        - cargo test --features=serde1,log
+        - cargo test --features=log
         - cargo test --examples
         - cargo test --manifest-path rand_core/Cargo.toml
         - cargo test --manifest-path rand_core/Cargo.toml --no-default-features
@@ -86,7 +86,7 @@ matrix:
         # Differs from standard script: includes aarch64-apple-ios cross-build
         - cargo test --lib --no-default-features
         # TODO: add simd_support feature:
-        - cargo test --features=serde1,log
+        - cargo test --features=log
         - cargo test --examples
         - cargo test --manifest-path rand_core/Cargo.toml
         - cargo test --manifest-path rand_core/Cargo.toml --no-default-features
@@ -113,7 +113,8 @@ matrix:
       script:
         # Differs from standard script: alloc feature, all features, doc build
         - cargo test --lib --no-default-features --features=alloc
-        - cargo test --all-features
+        # Excludes serde1:
+        - cargo test --features=nightly,simd_support,log
         - cargo test --benches --features=nightly
         - cargo test --examples
         - cargo test --manifest-path rand_core/Cargo.toml
@@ -207,7 +208,7 @@ before_install:
 script:
   - cargo test --lib --no-default-features
   # TODO: add simd_support feature:
-  - cargo test --features=serde1,log
+  - cargo test --features=log
   - cargo test --examples
   - cargo test --manifest-path rand_core/Cargo.toml
   - cargo test --manifest-path rand_core/Cargo.toml --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand"
+documentation = "https://rust-random.github.io/rand/"
 homepage = "https://crates.io/crates/rand"
 description = """
 Random number generators and other randomness functionality.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ To get started using Rand, see [The Book](https://rust-random.github.io/book).
 
 ## Versions
 
+Rand libs have inter-dependencies and make use of the
+[semver trick](https://github.com/dtolnay/semver-trick/) in order to make traits
+compatible across crate versions. (This is especially important for `RngCore`
+and `SeedableRng`.) A few crate releases are thus compatibility shims,
+depending on the *next* lib version (e.g. `rand_core` versions `0.2.2` and
+`0.3.1`). This means, for example, that `rand_core_0_4_0::SeedableRng` and
+`rand_core_0_3_0::SeedableRng` are distinct, incompatible traits, which can
+cause build errors. Usually, running `cargo update` is enough to fix any issues.
+
 The Rand lib is not yet stable, however we are careful to limit breaking changes
 and warn via deprecation wherever possible. Patch versions never introduce
 breaking changes. The following minor versions are supported:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ build: false
 test_script:
   - cargo test --lib --no-default-features --features alloc
   # TODO: use --all-features once simd_support is sufficiently stable:
-  - cargo test --features=serde1,log
+  - cargo test --features=log
   - cargo test --benches --features=nightly
   - cargo test --examples
   - cargo test --manifest-path rand_core/Cargo.toml

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_chacha"
+documentation = "https://rust-random.github.io/rand/rand_chacha/"
 homepage = "https://crates.io/crates/rand_chacha"
 description = """
 ChaCha random number generator

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2019-07-29
+Back-port non-API changes from version 0.5.0:
+- Enable testing with Miri and fix incorrect pointer usages (#779, #780, #781, #783, #784)
 - Adjust usage of `#[inline]` for `BlockRng` and `BlockRng64`
+
 ## [0.4.0] - 2019-01-24
 - Disable the `std` feature by default (#702)
 

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+- Adjust usage of `#[inline]` for `BlockRng` and `BlockRng64`
 ## [0.4.0] - 2019-01-24
 - Disable the `std` feature by default (#702)
 

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_core"
+documentation = "https://rust-random.github.io/rand/rand_core/"
 homepage = "https://crates.io/crates/rand_core"
 description = """
 Core random number generator traits and tools for implementation.

--- a/rand_core/README.md
+++ b/rand_core/README.md
@@ -40,6 +40,17 @@ The `rand_core` crate provides:
 
 The traits and error types are also available via `rand`.
 
+## Versions
+
+Rand libs have inter-dependencies and make use of the
+[semver trick](https://github.com/dtolnay/semver-trick/) in order to make traits
+compatible across crate versions. (This is especially important for `RngCore`
+and `SeedableRng`.) A few crate releases are thus compatibility shims,
+depending on the *next* lib version (e.g. `rand_core` versions `0.2.2` and
+`0.3.1`). This means, for example, that `rand_core_0_4_0::SeedableRng` and
+`rand_core_0_3_0::SeedableRng` are distinct, incompatible traits, which can
+cause build errors. Usually, running `cargo update` is enough to fix any issues.
+
 ## Crate Features
 
 `rand_core` supports `no_std` and `alloc`-only configurations, as well as full

--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -210,48 +210,6 @@ where <R as BlockRngCore>::Results: AsRef<[u32]> + AsMut<[u32]>
         }
     }
 
-    // As an optimization we try to write directly into the output buffer.
-    // This is only enabled for little-endian platforms where unaligned writes
-    // are known to be safe and fast.
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        let mut filled = 0;
-
-        // Continue filling from the current set of results
-        if self.index < self.results.as_ref().len() {
-            let (consumed_u32, filled_u8) =
-                fill_via_u32_chunks(&self.results.as_ref()[self.index..],
-                                    dest);
-
-            self.index += consumed_u32;
-            filled += filled_u8;
-        }
-
-        let len_remainder =
-            (dest.len() - filled) % (self.results.as_ref().len() * 4);
-        let end_direct = dest.len() - len_remainder;
-
-        while filled < end_direct {
-            let dest_u32: &mut R::Results = unsafe {
-                &mut *(dest[filled..].as_mut_ptr() as
-                *mut <R as BlockRngCore>::Results)
-            };
-            self.core.generate(dest_u32);
-            filled += self.results.as_ref().len() * 4;
-            self.index = self.results.as_ref().len();
-        }
-
-        if len_remainder > 0 {
-            self.core.generate(&mut self.results);
-            let (consumed_u32, _) =
-                fill_via_u32_chunks(self.results.as_ref(),
-                                    &mut dest[filled..]);
-
-            self.index = consumed_u32;
-        }
-    }
-
-    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         let mut read_len = 0;
         while read_len < dest.len() {
@@ -416,48 +374,6 @@ where <R as BlockRngCore>::Results: AsRef<[u64]> + AsMut<[u64]>
         value
     }
 
-    // As an optimization we try to write directly into the output buffer.
-    // This is only enabled for little-endian platforms where unaligned writes
-    // are known to be safe and fast.
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        let mut filled = 0;
-        self.half_used = false;
-
-        // Continue filling from the current set of results
-        if self.index < self.results.as_ref().len() {
-            let (consumed_u64, filled_u8) =
-                fill_via_u64_chunks(&self.results.as_ref()[self.index..],
-                                    dest);
-
-            self.index += consumed_u64;
-            filled += filled_u8;
-        }
-
-        let len_remainder =
-            (dest.len() - filled) % (self.results.as_ref().len() * 8);
-        let end_direct = dest.len() - len_remainder;
-
-        while filled < end_direct {
-            let dest_u64: &mut R::Results = unsafe {
-                ::core::mem::transmute(dest[filled..].as_mut_ptr())
-            };
-            self.core.generate(dest_u64);
-            filled += self.results.as_ref().len() * 8;
-            self.index = self.results.as_ref().len();
-        }
-
-        if len_remainder > 0 {
-            self.core.generate(&mut self.results);
-            let (consumed_u64, _) =
-                fill_via_u64_chunks(&mut self.results.as_ref(),
-                                    &mut dest[filled..]);
-
-            self.index = consumed_u64;
-        }
-    }
-
-    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         let mut read_len = 0;
         self.half_used = false;

--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -51,7 +51,7 @@
 //! [`fill_bytes`]: RngCore::fill_bytes
 
 use core::convert::AsRef;
-use core::fmt;
+use core::{fmt, ptr};
 use {RngCore, CryptoRng, SeedableRng, Error};
 use impls::{fill_via_u32_chunks, fill_via_u64_chunks};
 
@@ -183,7 +183,8 @@ where <R as BlockRngCore>::Results: AsRef<[u32]> + AsMut<[u32]>
         let read_u64 = |results: &[u32], index| {
             if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
                 // requires little-endian CPU supporting unaligned reads:
-                unsafe { *(&results[index] as *const u32 as *const u64) }
+                let ptr: *const u64 = results[index..index+1].as_ptr() as *const u64;
+                unsafe { ptr::read_unaligned(ptr) }
             } else {
                 let x = u64::from(results[index]);
                 let y = u64::from(results[index + 1]);

--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -187,7 +187,7 @@ where <R as BlockRngCore>::Results: AsRef<[u32]> + AsMut<[u32]>
         let read_u64 = |results: &[u32], index| {
             if cfg!(any(target_endian = "little")) {
                 // requires little-endian CPU
-                let ptr: *const u64 = results[index..=index+1].as_ptr() as *const u64;
+                let ptr: *const u64 = results[index..index+2].as_ptr() as *const u64;
                 unsafe { ptr::read_unaligned(ptr) }
             } else {
                 let x = u64::from(results[index]);

--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -181,9 +181,9 @@ where <R as BlockRngCore>::Results: AsRef<[u32]> + AsMut<[u32]>
     #[inline(always)]
     fn next_u64(&mut self) -> u64 {
         let read_u64 = |results: &[u32], index| {
-            if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
-                // requires little-endian CPU supporting unaligned reads:
-                let ptr: *const u64 = results[index..index+1].as_ptr() as *const u64;
+            if cfg!(any(target_endian = "little")) {
+                // requires little-endian CPU
+                let ptr: *const u64 = results[index..=index+1].as_ptr() as *const u64;
                 unsafe { ptr::read_unaligned(ptr) }
             } else {
                 let x = u64::from(results[index]);

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -141,23 +141,23 @@ pub trait RngCore {
     /// RNGs must implement at least one method from this trait directly. In
     /// the case this method is not implemented directly, it can be implemented
     /// using `self.next_u64() as u32` or via
-    /// [`fill_bytes`][impls::next_u32_via_fill].
+    /// [`fill_bytes`](impls::next_u32_via_fill).
     fn next_u32(&mut self) -> u32;
 
     /// Return the next random `u64`.
     ///
     /// RNGs must implement at least one method from this trait directly. In
     /// the case this method is not implemented directly, it can be implemented
-    /// via [`next_u32`][impls::next_u64_via_u32] or via
-    /// [`fill_bytes`][impls::next_u64_via_fill].
+    /// via [`next_u32`](impls::next_u64_via_u32) or via
+    /// [`fill_bytes`](impls::next_u64_via_fill).
     fn next_u64(&mut self) -> u64;
 
     /// Fill `dest` with random data.
     ///
     /// RNGs must implement at least one method from this trait directly. In
     /// the case this method is not implemented directly, it can be implemented
-    /// via [`next_u*`][impls::fill_bytes_via_next] or
-    /// via [`try_fill_bytes`][RngCore::try_fill_bytes]; if this generator can
+    /// via [`next_u*`](impls::fill_bytes_via_next) or
+    /// via [`try_fill_bytes`](RngCore::try_fill_bytes); if this generator can
     /// fail the implementation must choose how best to handle errors here
     /// (e.g. panic with a descriptive message or log a warning and retry a few
     /// times).

--- a/rand_hc/CHANGELOG.md
+++ b/rand_hc/CHANGELOG.md
@@ -4,5 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+- Adjust usage of `#[inline]`
 ## [0.1.0] - 2018-10-17
 - Pulled out of the Rand crate

--- a/rand_hc/Cargo.toml
+++ b/rand_hc/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_hc"
+documentation = "https://rust-random.github.io/rand/rand_hc/"
 homepage = "https://crates.io/crates/rand_hc"
 description = """
 HC128 random number generator

--- a/rand_hc/src/hc128.rs
+++ b/rand_hc/src/hc128.rs
@@ -67,20 +67,22 @@ const SEED_WORDS: usize = 8; // 128 bit key followed by 128 bit iv
 pub struct Hc128Rng(BlockRng<Hc128Core>);
 
 impl RngCore for Hc128Rng {
-    #[inline(always)]
+    #[inline]
     fn next_u32(&mut self) -> u32 {
         self.0.next_u32()
     }
 
-    #[inline(always)]
+    #[inline]
     fn next_u64(&mut self) -> u64 {
         self.0.next_u64()
     }
 
+    #[inline]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.0.fill_bytes(dest)
     }
 
+    #[inline]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill_bytes(dest)
     }
@@ -89,10 +91,12 @@ impl RngCore for Hc128Rng {
 impl SeedableRng for Hc128Rng {
     type Seed = <Hc128Core as SeedableRng>::Seed;
 
+    #[inline]
     fn from_seed(seed: Self::Seed) -> Self {
         Hc128Rng(BlockRng::<Hc128Core>::from_seed(seed))
     }
 
+    #[inline]
     fn from_rng<R: RngCore>(rng: R) -> Result<Self, Error> {
         BlockRng::<Hc128Core>::from_rng(rng).map(Hc128Rng)
     }
@@ -268,6 +272,7 @@ impl Hc128Core {
     // Initialize an HC-128 random number generator. The seed has to be
     // 256 bits in length (`[u32; 8]`), matching the 128 bit `key` followed by
     // 128 bit `iv` when HC-128 where to be used as a stream cipher.
+    #[inline(always)]   // single use: SeedableRng::from_seed
     fn init(seed: [u32; SEED_WORDS]) -> Self {
         #[inline]
         fn f1(x: u32) -> u32 {

--- a/rand_isaac/CHANGELOG.md
+++ b/rand_isaac/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+- Adjust usage of `#[inline]`
 ## [0.1.1] - 2018-11-26
 - Fix `rand_core` version requirement
 - Fix doc links

--- a/rand_isaac/Cargo.toml
+++ b/rand_isaac/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_isaac"
+documentation = "https://rust-random.github.io/rand/rand_isaac/"
 homepage = "https://crates.io/crates/rand_isaac"
 description = """
 ISAAC random number generator

--- a/rand_isaac/src/isaac.rs
+++ b/rand_isaac/src/isaac.rs
@@ -92,20 +92,22 @@ const RAND_SIZE: usize = 1 << RAND_SIZE_LEN;
 pub struct IsaacRng(BlockRng<IsaacCore>);
 
 impl RngCore for IsaacRng {
-    #[inline(always)]
+    #[inline]
     fn next_u32(&mut self) -> u32 {
         self.0.next_u32()
     }
 
-    #[inline(always)]
+    #[inline]
     fn next_u64(&mut self) -> u64 {
         self.0.next_u64()
     }
 
+    #[inline]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.0.fill_bytes(dest)
     }
 
+    #[inline]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill_bytes(dest)
     }
@@ -114,6 +116,7 @@ impl RngCore for IsaacRng {
 impl SeedableRng for IsaacRng {
     type Seed = <IsaacCore as SeedableRng>::Seed;
 
+    #[inline]
     fn from_seed(seed: Self::Seed) -> Self {
         IsaacRng(BlockRng::<IsaacCore>::from_seed(seed))
     }
@@ -121,10 +124,12 @@ impl SeedableRng for IsaacRng {
     /// Create an ISAAC random number generator using an `u64` as seed.
     /// If `seed == 0` this will produce the same stream of random numbers as
     /// the reference implementation when used unseeded.
+    #[inline]
     fn seed_from_u64(seed: u64) -> Self {
         IsaacRng(BlockRng::<IsaacCore>::seed_from_u64(seed))
     }
 
+    #[inline]
     fn from_rng<S: RngCore>(rng: S) -> Result<Self, Error> {
         BlockRng::<IsaacCore>::from_rng(rng).map(|rng| IsaacRng(rng))
     }

--- a/rand_isaac/src/isaac64.rs
+++ b/rand_isaac/src/isaac64.rs
@@ -83,20 +83,22 @@ const RAND_SIZE: usize = 1 << RAND_SIZE_LEN;
 pub struct Isaac64Rng(BlockRng64<Isaac64Core>);
 
 impl RngCore for Isaac64Rng {
-    #[inline(always)]
+    #[inline]
     fn next_u32(&mut self) -> u32 {
         self.0.next_u32()
     }
 
-    #[inline(always)]
+    #[inline]
     fn next_u64(&mut self) -> u64 {
         self.0.next_u64()
     }
 
+    #[inline]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.0.fill_bytes(dest)
     }
 
+    #[inline]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill_bytes(dest)
     }
@@ -105,6 +107,7 @@ impl RngCore for Isaac64Rng {
 impl SeedableRng for Isaac64Rng {
     type Seed = <Isaac64Core as SeedableRng>::Seed;
 
+    #[inline]
     fn from_seed(seed: Self::Seed) -> Self {
         Isaac64Rng(BlockRng64::<Isaac64Core>::from_seed(seed))
     }
@@ -112,10 +115,12 @@ impl SeedableRng for Isaac64Rng {
     /// Create an ISAAC random number generator using an `u64` as seed.
     /// If `seed == 0` this will produce the same stream of random numbers as
     /// the reference implementation when used unseeded.
+    #[inline]
     fn seed_from_u64(seed: u64) -> Self {
         Isaac64Rng(BlockRng64::<Isaac64Core>::seed_from_u64(seed))
     }
 
+    #[inline]
     fn from_rng<S: RngCore>(rng: S) -> Result<Self, Error> {
         BlockRng64::<Isaac64Core>::from_rng(rng).map(|rng| Isaac64Rng(rng))
     }

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_pcg"
+documentation = "https://rust-random.github.io/rand/rand_pcg/"
 homepage = "https://crates.io/crates/rand_pcg"
 description = """
 Selected PCG random number generators

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_xorshift"
+documentation = "https://rust-random.github.io/rand/rand_xorshift/"
 homepage = "https://crates.io/crates/rand_xorshift"
 description = """
 Xorshift random number generator

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -64,7 +64,7 @@ impl Distribution<f64> for Exp1 {
 /// This distribution has density function: `f(x) = lambda * exp(-lambda * x)`
 /// for `x > 0`.
 /// 
-/// Note that [`Exp1`][crate::distributions::Exp1] is an optimised implementation for `lambda = 1`.
+/// Note that [`Exp1`](crate::distributions::Exp1) is an optimised implementation for `lambda = 1`.
 ///
 /// # Example
 ///

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -81,10 +81,12 @@ impl RngCore for SmallRng {
         self.0.next_u64()
     }
 
+    #[inline(always)]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.0.fill_bytes(dest);
     }
 
+    #[inline(always)]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill_bytes(dest)
     }
@@ -93,10 +95,12 @@ impl RngCore for SmallRng {
 impl SeedableRng for SmallRng {
     type Seed = <Rng as SeedableRng>::Seed;
 
+    #[inline(always)]
     fn from_seed(seed: Self::Seed) -> Self {
         SmallRng(Rng::from_seed(seed))
     }
 
+    #[inline(always)]
     fn from_rng<R: RngCore>(rng: R) -> Result<Self, Error> {
         Rng::from_rng(rng).map(SmallRng)
     }

--- a/src/rngs/std.rs
+++ b/src/rngs/std.rs
@@ -39,10 +39,12 @@ impl RngCore for StdRng {
         self.0.next_u64()
     }
 
+    #[inline(always)]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.0.fill_bytes(dest);
     }
 
+    #[inline(always)]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill_bytes(dest)
     }
@@ -51,10 +53,12 @@ impl RngCore for StdRng {
 impl SeedableRng for StdRng {
     type Seed = <Hc128Rng as SeedableRng>::Seed;
 
+    #[inline(always)]
     fn from_seed(seed: Self::Seed) -> Self {
         StdRng(Hc128Rng::from_seed(seed))
     }
 
+    #[inline(always)]
     fn from_rng<R: RngCore>(rng: R) -> Result<Self, Error> {
         Hc128Rng::from_rng(rng).map(StdRng)
     }

--- a/utils/ci/script.sh
+++ b/utils/ci/script.sh
@@ -5,7 +5,7 @@ set -ex
 main() {
     cross test --target $TARGET --lib --no-default-features
   # TODO: add simd_support feature:
-    cross test --target $TARGET --features=serde1,log
+    cross test --target $TARGET --features=log
     cross test --target $TARGET --examples
     cross test --target $TARGET --manifest-path rand_core/Cargo.toml
     cross test --target $TARGET --manifest-path rand_core/Cargo.toml --no-default-features


### PR DESCRIPTION
As requested in #783.

Note @gnzlbg this does not include the `links` attribute we discussed yesterday (#850), because I don't believe this is the best fix.