### PR TITLE
Remove #![feature(alloc)]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ sudo: false
 # Tests run on rand:
 # - test no_std support, but only the unit tests:
 #   `cargo test --tests --no-default-features`
+# - test no_std support, including the alloc feature:
+#   cargo test --tests --no-default-features --features=alloc
 # - run unit tests and doctests with all features which are available on stable:
 #   `cargo test --features=serde1,log`
 # - test examples:
@@ -44,8 +46,6 @@ sudo: false
 # Additional tests on nightly:
 # - run unit tests and doctests with all features which are available on nightly:
 #   `cargo test --all-features`
-# - test no_std support, including the nightly alloc feature:
-#   cargo test --tests --no-default-features --features=alloc
 # - run benchmarks as tests:
 #   `cargo test --benches --features=nightly`
 # Tests on subcrates:
@@ -137,7 +137,7 @@ matrix:
       before_script:
         - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
       script:
-        # Differs from standard script: alloc feature, all features, doc build
+        # Differs from standard script: all features, doc build
         - cargo test --tests --no-default-features --features=alloc
         - cargo test --all-features
         - cargo test --benches --features=nightly
@@ -167,7 +167,7 @@ matrix:
         - cargo --list | egrep "^\s*deadlinks$" -q || cargo install cargo-deadlinks
         - cargo deadlinks -V
       script:
-        # Differs from standard script: alloc feature, all features, doc build
+        # Differs from standard script: all features, doc build
         - cargo test --tests --no-default-features --features=alloc
         - cargo test --all-features
         - cargo test --benches --features=nightly
@@ -276,11 +276,13 @@ before_install:
 script:
   - cargo test --tests --no-default-features
   - cargo test --tests --no-default-features --features getrandom
+  - cargo test --tests --no-default-features --features=alloc
   # TODO: add simd_support feature:
   - cargo test --features=serde1,log
   - cargo test --examples
   - cargo test --manifest-path rand_core/Cargo.toml
   - cargo test --manifest-path rand_core/Cargo.toml --no-default-features
+  - cargo test --manifest-path rand_core/Cargo.toml --no-default-features --features=alloc
   - cargo test --manifest-path rand_distr/Cargo.toml
   - cargo test --manifest-path rand_isaac/Cargo.toml --features=serde1
   - cargo test --manifest-path rand_pcg/Cargo.toml --features=serde1

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,8 @@ sudo: false
 #
 # TODO: SIMD support on stable releases
 # NOTE: SIMD support is unreliable on nightly; we track the latest release
+# NOTE: Test for alloc feature in no_std is not included here because it depends
+#       on the alloc crate stabilized in Rust 1.36.
 matrix:
   include:
     - rust: 1.32.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 ## [Unreleased]
 - Fix `no_std` behaviour, appropriately enable c2-chacha's `std` feature (#844)
 - Add a `no_std` target to CI to continously evaluate `no_std` status (#844)
+- `alloc` feature in `no_std` is available since Rust 1.36 (#856)
 
 ## [0.7.0] - 2019-06-28
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Rand release if required, but the change must be noted in the changelog.
 Rand is built with these features enabled by default:
 
 -   `std` enables functionality dependent on the `std` lib
--   `alloc` (implied by `std`) enables functionality requiring an allocator
+-   `alloc` (implied by `std`) enables functionality requiring an allocator (when using this feature in `no_std`, Rand requires Rustc version 1.36 or greater)
 -   `getrandom` (implied by `std`) is an optional dependency providing the code
     behind `rngs::OsRng`
 

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- `alloc` feature in `no_std` is available since Rust 1.36 (#856)
+
 ## [0.5.1] - 2019-09-02
 ### Added
 - `OsRng` added to `rand_core` (#863)

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -38,7 +38,6 @@
 #![allow(clippy::unreadable_literal)]
 
 #![cfg_attr(not(feature="std"), no_std)]
-#![cfg_attr(all(feature="alloc", not(feature="std")), feature(alloc))]
 
 
 use core::default::Default;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 
 #![cfg_attr(not(feature="std"), no_std)]
-#![cfg_attr(all(feature="alloc", not(feature="std")), feature(alloc))]
 #![cfg_attr(all(feature="simd_support", feature="nightly"), feature(stdsimd))]
 
 #![allow(clippy::excessive_precision, clippy::unreadable_literal, clippy::float_cmp)]
@@ -438,7 +437,7 @@ macro_rules! impl_as_byte_slice {
                 }
             }
         }
-        
+
         impl AsByteSliceMut for [Wrapping<$t>] {
             fn as_byte_slice_mut(&mut self) -> &mut [u8] {
                 if self.len() == 0 {
@@ -602,7 +601,7 @@ mod test {
         rng.fill(&mut array[..]);
         assert_eq!(array, [x as u32, (x >> 32) as u32]);
         assert_eq!(rng.next_u32(), x as u32);
-        
+
         // Check equivalence using wrapped arrays
         let mut warray = [Wrapping(0u32); 2];
         rng.fill(&mut warray[..]);


### PR DESCRIPTION
The `alloc` crate has been stabilized in 1.36.