### PR TITLE
Remove byteorder-dependency

### DIFF
--- a/rand_xoshiro/CHANGELOG.md
+++ b/rand_xoshiro/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2019-08-06
+- Drop `byteorder`-dependency in favor of `stdlib`-implementation.
+
 ## [0.3.0] - 2019-06-12
 - Bump minor crate version since rand_core bump is a breaking change
 - Switch to Edition 2018

--- a/rand_xoshiro/Cargo.toml
+++ b/rand_xoshiro/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2018"
 serde1 = ["serde"]
 
 [dependencies]
-byteorder = { version = "1", default-features=false }
 rand_core = { path = "../rand_core", version = "0.5" }
 serde = { version = "1", features = ["derive"], optional=true }
 

--- a/rand_xoshiro/Cargo.toml
+++ b/rand_xoshiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_xoshiro"
-version = "0.3.0" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.3.1" # NB: When modifying, also modify html_root_url in lib.rs
 authors = ["The Rand Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/rand_xoshiro/src/lib.rs
+++ b/rand_xoshiro/src/lib.rs
@@ -58,7 +58,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand_xoshiro/0.3.0")]
+       html_root_url = "https://docs.rs/rand_xoshiro/0.3.1")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/rand_xoshiro/src/splitmix64.rs
+++ b/rand_xoshiro/src/splitmix64.rs
@@ -7,7 +7,6 @@
 // except according to those terms.
 
 #[cfg(feature="serde1")] use serde::{Serialize, Deserialize};
-use byteorder::{ByteOrder, LittleEndian};
 use rand_core::le::read_u64_into;
 use rand_core::impls::fill_bytes_via_next;
 use rand_core::{RngCore, SeedableRng, Error};
@@ -79,9 +78,7 @@ impl SeedableRng for SplitMix64 {
 
     /// Seed a `SplitMix64` from a `u64`.
     fn seed_from_u64(seed: u64) -> SplitMix64 {
-        let mut x = [0; 8];
-        LittleEndian::write_u64(&mut x, seed);
-        SplitMix64::from_seed(x)
+        SplitMix64::from_seed(seed.to_le_bytes())
     }
 }
 


### PR DESCRIPTION
This removes the `byteorder`-dependency, which is not needed since 1.32 is stable. Dropping the dependency is worth the change IMHO.