### PR TITLE
Fix rand_os

### DIFF
--- a/rand_os/CHANGELOG.md
+++ b/rand_os/CHANGELOG.md
@@ -4,22 +4,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2019-08-08
+### Fixed
+- Fix `no_std` support.
 
 ## [0.2.0] - 2019-06-06
-Replaced implementation with a backwards-compatible shim around
+### Changed
+- Minimum Supported Rust Version has changed to 1.32.
+- Replaced implementation with a backwards-compatible shim around
 [getrandom](https://crates.io/crates/getrandom).
 
 ## [0.1.3] - 2019-03-05
-### Changes
+### Fixed
 - Fix support for Illumos (#730)
 - Fix deprecation warnings from atomic init (#739)
 
 ## [0.1.2] - 2019-01-28
-### Changes
+### Changed
 - Fuchsia: Replaced fuchsia-zircon with fuchsia-cprng
 
 ## [0.1.1] - 2019-01-08
-### Additions
+### Added
 - Add support for x86_64-fortanix-unknown-sgx target (#670)
 
 ## [0.1.0] - 2019-01-04

--- a/rand_os/Cargo.toml
+++ b/rand_os/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_os"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The Rand Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -22,5 +22,5 @@ wasm-bindgen = ["getrandom/wasm-bindgen"]
 stdweb = ["getrandom/stdweb"]
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "0.5", features = ["std"] }
+rand_core = { path = "../rand_core", version = "0.5", features = ["getrandom"] }
 getrandom = "0.1.1"


### PR DESCRIPTION
Right now `rand_os` unconditionally enables `std` feature in `rand_core`. Issue was raised in #854.