### PR TITLE
License field fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rand"
 version = "0.7.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
 documentation = "https://rust-random.github.io/rand/"

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rand_chacha"
 version = "0.2.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers", "The CryptoCorrosion Contributors"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
 documentation = "https://rust-random.github.io/rand/rand_chacha/"

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rand_core"
 version = "0.5.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
 documentation = "https://rust-random.github.io/rand/rand_core/"

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rand_distr"
 version = "0.2.1"
 authors = ["The Rand Project Developers"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
 documentation = "https://rust-random.github.io/rand/rand_distr/"

--- a/rand_hc/Cargo.toml
+++ b/rand_hc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rand_hc"
 version = "0.2.0"
 authors = ["The Rand Project Developers"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
 documentation = "https://rust-random.github.io/rand/rand_hc/"

--- a/rand_isaac/Cargo.toml
+++ b/rand_isaac/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rand_isaac"
 version = "0.2.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
 documentation = "https://rust-random.github.io/rand/rand_isaac/"

--- a/rand_os/Cargo.toml
+++ b/rand_os/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rand_os"
 version = "0.2.0"
 authors = ["The Rand Project Developers"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
 documentation = "https://docs.rs/rand_os"

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rand_pcg"
 version = "0.2.0"
 authors = ["The Rand Project Developers"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
 documentation = "https://rust-random.github.io/rand/rand_pcg/"

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rand_xorshift"
 version = "0.2.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
 documentation = "https://rust-random.github.io/rand/rand_xorshift/"

--- a/rand_xoshiro/Cargo.toml
+++ b/rand_xoshiro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rand_xoshiro"
 version = "0.3.1" # NB: When modifying, also modify html_root_url in lib.rs
 authors = ["The Rand Project Developers"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
 documentation = "https://docs.rs/rand_xoshiro"

--- a/tests/wasm_bindgen/Cargo.toml
+++ b/tests/wasm_bindgen/Cargo.toml
@@ -4,7 +4,7 @@ description = "Minimal crate to test that rand can be build for web assembly tar
 version = "0.1.0"
 authors = ["The Rand Project Developers"]
 publish = false
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]


### PR DESCRIPTION
This PR replaces `MIT/Apache-2.0` with `MIT OR Apache-2.0`.