### PR TITLE
WeightedIndex: Make it possible to update a subset of weights

### DIFF
--- a/benches/weighted.rs
+++ b/benches/weighted.rs
@@ -1,0 +1,38 @@
+// Copyright 2019 Developers of the Rand project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(test)]
+
+extern crate test;
+
+const RAND_BENCH_N: u64 = 1000;
+
+use test::Bencher;
+use rand::Rng;
+use rand::distributions::WeightedIndex;
+
+#[bench]
+fn weighted_index_creation(b: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    b.iter(|| {
+        let weights = [1u32, 2, 4, 0, 5, 1, 7, 1, 2, 3, 4, 5, 6, 7];
+        let distr = WeightedIndex::new(weights.to_vec()).unwrap();
+        rng.sample(distr)
+    })
+}
+
+#[bench]
+fn weighted_index_modification(b: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    let weights = [1u32, 2, 3, 0, 5, 6, 7, 1, 2, 3, 4, 5, 6, 7];
+    let mut distr = WeightedIndex::new(weights.to_vec()).unwrap();
+    b.iter(|| {
+        distr.update_weights(&[(2, &4), (5, &1)]).unwrap();
+        rng.sample(&distr)
+    })
+}

--- a/benches/weighted.rs
+++ b/benches/weighted.rs
@@ -10,8 +10,6 @@
 
 extern crate test;
 
-const RAND_BENCH_N: u64 = 1000;
-
 use test::Bencher;
 use rand::Rng;
 use rand::distributions::WeightedIndex;
@@ -19,8 +17,8 @@ use rand::distributions::WeightedIndex;
 #[bench]
 fn weighted_index_creation(b: &mut Bencher) {
     let mut rng = rand::thread_rng();
+    let weights = [1u32, 2, 4, 0, 5, 1, 7, 1, 2, 3, 4, 5, 6, 7];
     b.iter(|| {
-        let weights = [1u32, 2, 4, 0, 5, 1, 7, 1, 2, 3, 4, 5, 6, 7];
         let distr = WeightedIndex::new(weights.to_vec()).unwrap();
         rng.sample(distr)
     })

--- a/src/distributions/weighted/mod.rs
+++ b/src/distributions/weighted/mod.rs
@@ -206,9 +206,9 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
         let add = |x: &mut X, pos_sign: &mut bool, y: &X| {
             if !*pos_sign {
                 if *x < *y {
-                    let tmp = x.clone();
-                    *x = y.clone();
-                    *x -= &tmp;
+                    let mut tmp = y.clone();
+                    tmp -= x;
+                    std::mem::swap(x, &mut tmp);
                     *pos_sign = !*pos_sign;
                 } else {
                     *x -= y;
@@ -221,9 +221,9 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
         let sub = |x: &mut X, pos_sign: &mut bool, y: &X| {
             if *pos_sign {
                 if *x < *y {
-                    let tmp = x.clone();
-                    *x = y.clone();
-                    *x -= &tmp;
+                    let mut tmp = y.clone();
+                    tmp -= x;
+                    std::mem::swap(x, &mut tmp);
                     *pos_sign = !*pos_sign;
                 } else {
                     *x -= y;

--- a/src/distributions/weighted/mod.rs
+++ b/src/distributions/weighted/mod.rs
@@ -211,7 +211,7 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
                 }
             }
             prev_weight = cumulative_weight.clone();
-            std::mem::swap(&mut prev_weight, &mut self.cumulative_weights[i]);
+            core::mem::swap(&mut prev_weight, &mut self.cumulative_weights[i]);
         }
 
         self.total_weight = total_weight;

--- a/src/distributions/weighted/mod.rs
+++ b/src/distributions/weighted/mod.rs
@@ -134,7 +134,8 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
     /// Update a subset of weights, without changing the number of weights.
     ///
     /// Using this method instead of `new` might be more efficient if only a small number of
-    /// weights is modified. For weights that are `Copy`, no allocations are performed.
+    /// weights is modified. No allocations are performed, unless the weight type `X` uses
+    /// allocation internally.
     ///
     /// In case of error, `self` is not modified.
     pub fn update_weights(&mut self, new_weights: &[(usize, &X)]) -> Result<(), WeightedError>

--- a/src/distributions/weighted/mod.rs
+++ b/src/distributions/weighted/mod.rs
@@ -169,9 +169,6 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
                 return Err(WeightedError::TooMany);
             }
 
-            // Unfortunately, we will have to calculate the non-cumulative
-            // weight a second time, to avoid producing an invalid state of
-            // `self`.
             let mut old_w = if i < self.cumulative_weights.len() {
                 self.cumulative_weights[i].clone()
             } else {
@@ -202,7 +199,6 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
             zero.clone() 
         };
         for i in first_new_index..self.cumulative_weights.len() {
-            //if next_new_weight.is_some() && i == next_new_weight.unwrap().0 {
             match next_new_weight {
                 Some(&(j, w)) if i == j => {
                     cumulative_weight += w;


### PR DESCRIPTION
This could be useful for crates like [droprate](https://github.com/AberrantWolf/droprate).

I had to add an additional field `total_weight` to `WeightedIndex`, which is redundant to the field `weight_distribution`. However, I cannot use the latter without making the information about the end of the sampled range public.