### PR TITLE
fix no-std

### DIFF
--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -20,9 +20,9 @@ appveyor = { repository = "rust-random/rand" }
 
 [dependencies]
 rand_core = { path = "../rand_core", version = "0.5" }
-c2-chacha = { version = "0.2.2", default-features = false, features = ["simd"] }
+c2-chacha = { version = "0.2.2", default-features = false }
 
 [features]
 default = ["std", "simd"]
 std = ["c2-chacha/std"]
-simd = [] # deprecated
+simd = ["c2-chacha/simd"]


### PR DESCRIPTION
Fixes #868

I am also having issue using `rand` and `rand_chacha` for wasm target.
I haven't figure out the root cause why std feature got pulled in but this change fixes issue for me.