### PR TITLE
Disable default features for getrandom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ nightly = ["simd_support"] # enables all features requiring nightly rust
 serde1 = [] # does nothing, deprecated
 
 # Optional dependencies:
-std = ["rand_core/std", "rand_chacha/std", "alloc", "getrandom"]
+std = ["rand_core/std", "rand_chacha/std", "alloc", "getrandom", "getrandom_package/std"]
 alloc = ["rand_core/alloc"]  # enables Vec and Box support (without std)
 # re-export optional WASM dependencies to avoid breakage:
 wasm-bindgen = ["getrandom_package/wasm-bindgen"]
@@ -57,7 +57,7 @@ members = [
 rand_core = { path = "rand_core", version = "0.5" }
 rand_pcg = { path = "rand_pcg", version = "0.2", optional = true }
 # Do not depend on 'getrandom_package' directly; use the 'getrandom' feature!
-getrandom_package = { version = "0.1.1", package = "getrandom", optional = true }
+getrandom_package = { version = "0.1", package = "getrandom", default-features = false, optional = true }
 log = { version = "0.4", optional = true }
 
 [dependencies.packed_simd]

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -25,4 +25,4 @@ serde1 = ["serde"] # enables serde for BlockRng wrapper
 
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }
-getrandom = { version = "0.1", optional = true }
+getrandom = { version = "0.1", default-features = false, optional = true }

--- a/rand_os/Cargo.toml
+++ b/rand_os/Cargo.toml
@@ -23,4 +23,4 @@ stdweb = ["getrandom/stdweb"]
 
 [dependencies]
 rand_core = { path = "../rand_core", version = "0.5", features = ["getrandom"] }
-getrandom = "0.1.1"
+getrandom = { version = "0.1", default-features = false }


### PR DESCRIPTION
This allows us to safely add default features to `getrandom` without
breaking rand.

See https://github.com/rust-random/getrandom/issues/94