### PR TITLE
Update dependency on `average`

### DIFF
--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -24,6 +24,4 @@ rand = { path = "..", version = "0.7" }
 [dev-dependencies]
 rand_pcg = { version = "0.2", path = "../rand_pcg" }
 # Histogram implementation for testing uniformity
-average = "0.10.0"
-# Not a direct dependency but required to boost the minimum version:
-conv = "0.3.2"
+average = "0.10.3"


### PR DESCRIPTION
The new version of `average` builds with minimal dep versions, so we no longer
need to depend on `conv 0.3.2` directly.