### PR TITLE
Prepare rand_distr 0.2.2

### DIFF
--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2019-09-10
+- Fix version requirement on rand lib (#847)
+- Clippy fixes & suppression (#840)
+
 ## [0.2.1] - 2019-06-29
 - Update dependency to support Rand 0.7
 - Doc link fixes

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_distr"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
See also #847.

Is it worth yanking other 0.2.x versions? Possibly not since Cargo will normally use the latest version anyway, though I think there shouldn't be any problems in doing so.