### PR TITLE
Prepare rand 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
-## [Unreleased]
+## [0.7.1] - 2019-09-13
+### Fixes
 - Fix `no_std` behaviour, appropriately enable c2-chacha's `std` feature (#844)
-- Add a `no_std` target to CI to continously evaluate `no_std` status (#844)
 - `alloc` feature in `no_std` is available since Rust 1.36 (#856)
+- Fix or squelch issues from Clippy lints (#840)
+
+### Additions
+- Add a `no_std` target to CI to continously evaluate `no_std` status (#844)
+- `WeightedIndex`: allow adjusting a sub-set of weights (#866)
 
 ## [0.7.0] - 2019-06-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
There have been a few changes since 0.7.0, most notably a fix for `no_std`, so I believe we should make a release.

I was hoping to fix #849 here, but... see comments.