### PR TITLE
Add 32-bit test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,12 @@ matrix:
         - cargo build --target=thumbv6m-none-eabi --no-default-features
 
     - rust: nightly
+      name: "Linux, nightly (32-bit test)"
+      env: TARGET=i686-unknown-linux-musl
+      install:
+        - rustup target add $TARGET
+
+    - rust: nightly
       os: linux
       name: "Miri, nightly"
       script:

--- a/utils/ci/script.sh
+++ b/utils/ci/script.sh
@@ -7,6 +7,9 @@ set -ex
 # TARGET enables cross-building
 if [ -z $TARGET ]; then
     CARGO=cargo
+elif [ "$TARGET" = "i686-unknown-linux-musl" ]; then
+    CARGO=cargo
+    TARGET="--target $TARGET"
 else
     CARGO=cross
     TARGET="--target $TARGET"


### PR DESCRIPTION
Small addition to #874. It looks like musl is faster to download and install, so I've chose it over the GNU target.