### PR TITLE
Update rand_pcg to 0.2.1

### DIFF
--- a/rand_pcg/CHANGELOG.md
+++ b/rand_pcg/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.2.1] - 2019-10-22
 - Bump `bincode` version to 1.1.4 to fix minimal-dependency builds
+- Removed unused `autocfg` build dependency.
 
 ## [0.2.0] - 2019-06-12
 - Add `Lcg128Xsl64` aka `Pcg64`

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_pcg"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This allows us to publish autocfg removal and bincode bump.