### PR TITLE
Always inline the cast_from_int in the non-SIMD impl

### DIFF
--- a/src/distributions/utils.rs
+++ b/src/distributions/utils.rs
@@ -321,6 +321,7 @@ macro_rules! scalar_float_impl {
                 <$ty>::from_bits(self.to_bits() - 1)
             }
             type UInt = $uty;
+            #[inline(always)]
             fn cast_from_int(i: Self::UInt) -> Self { i as $ty }
         }
 

--- a/src/distributions/utils.rs
+++ b/src/distributions/utils.rs
@@ -321,7 +321,7 @@ macro_rules! scalar_float_impl {
                 <$ty>::from_bits(self.to_bits() - 1)
             }
             type UInt = $uty;
-            #[inline(always)]
+            #[inline]
             fn cast_from_int(i: Self::UInt) -> Self { i as $ty }
         }
 


### PR DESCRIPTION
This makes it more consistent with the SIMD implementation, and it usually requires very few machine instructions to convert from an unsigned integer to a floating-point value.