### PR TITLE
better way to ignore tests in Miri

### DIFF
--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -137,7 +137,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_average() {
         const P: f64 = 0.3;
         const NUM: u32 = 3;

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -288,7 +288,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_binomial() {
         let mut rng = crate::test::rng(351);
         test_binomial_mean_and_variance(150, 0.1, &mut rng);

--- a/src/distributions/poisson.rs
+++ b/src/distributions/poisson.rs
@@ -109,7 +109,7 @@ mod test {
     use super::Poisson;
 
     #[test]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_poisson_10() {
         let poisson = Poisson::new(10.0);
         let mut rng = crate::test::rng(123);

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -959,7 +959,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_integers() {
         use core::{i8, i16, i32, i64, isize};
         use core::{u8, u16, u32, u64, usize};
@@ -1044,7 +1044,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_floats() {
         let mut rng = crate::test::rng(252);
         let mut zero_rng = StepRng::new(0, 0);
@@ -1183,7 +1183,7 @@ mod tests {
 
 
     #[test]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_durations() {
         #[cfg(feature = "std")]
         use std::time::Duration;

--- a/src/distributions/weighted/alias_method.rs
+++ b/src/distributions/weighted/alias_method.rs
@@ -370,7 +370,7 @@ mod test {
     use super::*;
 
     #[test]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_weighted_index_f32() {
         test_weighted_index(f32::into);
 
@@ -399,14 +399,14 @@ mod test {
 
     #[cfg(not(target_os = "emscripten"))]
     #[test]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_weighted_index_u128() {
         test_weighted_index(|x: u128| x as f64);
     }
 
     #[cfg(all(rustc_1_26, not(target_os = "emscripten")))]
     #[test]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_weighted_index_i128() {
         test_weighted_index(|x: i128| x as f64);
 
@@ -422,13 +422,13 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_weighted_index_u8() {
         test_weighted_index(u8::into);
     }
 
     #[test]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_weighted_index_i8() {
         test_weighted_index(i8::into);
 

--- a/src/distributions/weighted/mod.rs
+++ b/src/distributions/weighted/mod.rs
@@ -237,7 +237,7 @@ mod test {
     use super::*;
 
     #[test]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_weightedindex() {
         let mut r = crate::test::rng(700);
         const N_REPS: u32 = 5000;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -697,7 +697,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_gen_ratio_average() {
         const NUM: u32 = 3;
         const DENOM: u32 = 10;

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -373,7 +373,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_sample_alg() {
         let seed_rng = crate::test::rng;
 

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -614,7 +614,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_iterator_choose() {
         let r = &mut crate::test::rng(109);
         fn test_iter<R: Rng + ?Sized, Iter: Iterator<Item=usize> + Clone>(r: &mut R, iter: Iter) {
@@ -646,7 +646,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_shuffle() {
         let mut r = crate::test::rng(108);
         let empty: &mut [isize] = &mut [];
@@ -734,7 +734,7 @@ mod test {
     
     #[test]
     #[cfg(feature = "alloc")]
-    #[cfg(not(miri))] // Miri is too slow
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_weighted() {
         let mut r = crate::test::rng(406);
         const N_REPS: u32 = 3000;


### PR DESCRIPTION
This avoids warnings about unused functions and imports.