### PR TITLE
avoid into_iter on arrays

### DIFF
--- a/src/distributions/weighted/mod.rs
+++ b/src/distributions/weighted/mod.rs
@@ -303,7 +303,7 @@ mod test {
              &[1u32, 2, 1, 0, 5, 1, 7, 1, 2, 3, 4, 5, 6, 100][..]),
         ];
 
-        for (weights, update, expected_weights) in data.into_iter() {
+        for (weights, update, expected_weights) in data.iter() {
             let total_weight = weights.iter().sum::<u32>();
             let mut distr = WeightedIndex::new(weights.to_vec()).unwrap();
             assert_eq!(distr.total_weight, total_weight);


### PR DESCRIPTION
This fixes the following warning:
```
warning: this method call currently resolves to `<&[T; N] as IntoIterator>::into_iter` (due to autoref coercions), but that might change in the future when `IntoIterator` impls for arrays are added.
   --> src/distributions/weighted/mod.rs:306:57
    |
306 |         for (weights, update, expected_weights) in data.into_iter() {
    |                                                         ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = note: `#[warn(array_into_iter)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
```