### PR TITLE
Fix rand_distr bench: extern crate test

### DIFF
--- a/rand_distr/benches/distributions.rs
+++ b/rand_distr/benches/distributions.rs
@@ -8,6 +8,8 @@
 
 #![feature(test)]
 
+extern crate test;
+
 const RAND_BENCH_N: u64 = 1000;
 
 use std::mem::size_of;


### PR DESCRIPTION
Fixes #917 

Thanks for the report @jstrong-tios. In this case you may as well have just opened a PR, but I've done it now.

Yes, `extern crate` is still needed for the built-in crates (`core`, `std`, `alloc`, `test` — except whichever of `std`/`core` is enabled by default).