### PR TITLE
impl std::error::Error for rand_distr::*Error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## Unreleased
+### Additions
+- Implement `std::error::Error` for `BernoulliError` (#919)
+
 ## [0.7.2] - 2019-09-16
 ### Fixes
 - Fix dependency on `rand_core` 0.5.1 (#890)

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- All error types now implement `std::error::Error` (#919)
+- Re-exported `rand::distributions::BernoulliError` (#919)
+
 ## [0.2.2] - 2019-09-10
 - Fix version requirement on rand lib (#847)
 - Clippy fixes & suppression (#840)

--- a/rand_distr/src/binomial.rs
+++ b/rand_distr/src/binomial.rs
@@ -11,6 +11,7 @@
 
 use rand::Rng;
 use crate::{Distribution, Uniform};
+use std::{error, fmt};
 
 /// The binomial distribution `Binomial(n, p)`.
 ///
@@ -42,6 +43,17 @@ pub enum Error {
     /// `p > 1`.
     ProbabilityTooLarge,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::ProbabilityTooSmall => "p < 0 or is NaN in binomial distribution",
+            Error::ProbabilityTooLarge => "p > 1 in binomial distribution",
+        })
+    }
+}
+
+impl error::Error for Error {}
 
 impl Binomial {
     /// Construct a new `Binomial` with the given shape parameters `n` (number

--- a/rand_distr/src/cauchy.rs
+++ b/rand_distr/src/cauchy.rs
@@ -12,6 +12,7 @@
 use rand::Rng;
 use crate::{Distribution, Standard};
 use crate::utils::Float;
+use std::{error, fmt};
 
 /// The Cauchy distribution `Cauchy(median, scale)`.
 ///
@@ -42,6 +43,16 @@ pub enum Error {
     /// `scale <= 0` or `nan`.
     ScaleTooSmall,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::ScaleTooSmall => "scale is not positive in Cauchy distribution",
+        })
+    }
+}
+
+impl error::Error for Error {}
 
 impl<N: Float> Cauchy<N>
 where Standard: Distribution<N>

--- a/rand_distr/src/dirichlet.rs
+++ b/rand_distr/src/dirichlet.rs
@@ -12,8 +12,9 @@
 use rand::Rng;
 use crate::{Distribution, Gamma, StandardNormal, Exp1, Open01};
 use crate::utils::Float;
+use std::{error, fmt};
 
-/// The dirichelet distribution `Dirichlet(alpha)`.
+/// The Dirichlet distribution `Dirichlet(alpha)`.
 ///
 /// The Dirichlet distribution is a family of continuous multivariate
 /// probability distributions parameterized by a vector alpha of positive reals.
@@ -45,6 +46,19 @@ pub enum Error {
     /// `size < 2`.
     SizeTooSmall,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::AlphaTooShort | Error::SizeTooSmall => {
+                "less than 2 dimensions in Dirichlet distribution"
+            }
+            Error::AlphaTooSmall => "alpha is not positive in Dirichlet distribution",
+        })
+    }
+}
+
+impl error::Error for Error {}
 
 impl<N: Float> Dirichlet<N>
 where StandardNormal: Distribution<N>, Exp1: Distribution<N>, Open01: Distribution<N>

--- a/rand_distr/src/exponential.rs
+++ b/rand_distr/src/exponential.rs
@@ -12,6 +12,7 @@
 use rand::Rng;
 use crate::{ziggurat_tables, Distribution};
 use crate::utils::{ziggurat, Float};
+use std::{error, fmt};
 
 /// Samples floating-point numbers according to the exponential distribution,
 /// with rate parameter `λ = 1`. This is equivalent to `Exp::new(1.0)` or
@@ -96,6 +97,16 @@ pub enum Error {
     /// `lambda <= 0` or `nan`.
     LambdaTooSmall,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::LambdaTooSmall => "lambda is not positive in exponential distribution",
+        })
+    }
+}
+
+impl error::Error for Error {}
 
 impl<N: Float> Exp<N>
 where Exp1: Distribution<N>

--- a/rand_distr/src/gamma.rs
+++ b/rand_distr/src/gamma.rs
@@ -16,6 +16,7 @@ use rand::Rng;
 use crate::normal::StandardNormal;
 use crate::{Distribution, Exp1, Exp, Open01};
 use crate::utils::Float;
+use std::{error, fmt};
 
 /// The Gamma distribution `Gamma(shape, scale)` distribution.
 ///
@@ -62,6 +63,18 @@ pub enum Error {
     /// `1 / scale == 0`.
     ScaleTooLarge,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::ShapeTooSmall => "shape is not positive in gamma distribution",
+            Error::ScaleTooSmall => "scale is not positive in gamma distribution",
+            Error::ScaleTooLarge => "scale is infinity in gamma distribution",
+        })
+    }
+}
+
+impl error::Error for Error {}
 
 #[derive(Clone, Copy, Debug)]
 enum GammaRepr<N> {
@@ -224,6 +237,18 @@ pub enum ChiSquaredError {
     DoFTooSmall,
 }
 
+impl fmt::Display for ChiSquaredError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            ChiSquaredError::DoFTooSmall => {
+                "degrees-of-freedom k is not positive in chi-squared distribution"
+            }
+        })
+    }
+}
+
+impl error::Error for ChiSquaredError {}
+
 #[derive(Clone, Copy, Debug)]
 enum ChiSquaredRepr<N> {
     // k == 1, Gamma(alpha, ..) is particularly slow for alpha < 1,
@@ -297,6 +322,17 @@ pub enum FisherFError {
     /// `n <= 0` or `nan`.
     NTooSmall,
 }
+
+impl fmt::Display for FisherFError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            FisherFError::MTooSmall => "m is not positive in Fisher F distribution",
+            FisherFError::NTooSmall => "n is not positive in Fisher F distribution",
+        })
+    }
+}
+
+impl error::Error for FisherFError {}
 
 impl<N: Float> FisherF<N>
 where StandardNormal: Distribution<N>, Exp1: Distribution<N>, Open01: Distribution<N>
@@ -389,6 +425,17 @@ pub enum BetaError {
     /// `beta <= 0` or `nan`.
     BetaTooSmall,
 }
+
+impl fmt::Display for BetaError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            BetaError::AlphaTooSmall => "alpha is not positive in beta distribution",
+            BetaError::BetaTooSmall => "beta is not positive in beta distribution",
+        })
+    }
+}
+
+impl error::Error for BetaError {}
 
 impl<N: Float> Beta<N>
 where StandardNormal: Distribution<N>, Exp1: Distribution<N>, Open01: Distribution<N>

--- a/rand_distr/src/lib.rs
+++ b/rand_distr/src/lib.rs
@@ -64,7 +64,8 @@
 //!   - [`UnitDisc`] distribution
 
 pub use rand::distributions::{Distribution, DistIter, Standard,
-    Alphanumeric, Uniform, OpenClosed01, Open01, Bernoulli, uniform, weighted};
+    Alphanumeric, Uniform, OpenClosed01, Open01, Bernoulli, BernoulliError,
+    uniform, weighted};
 
 pub use self::unit_sphere::UnitSphere;
 pub use self::unit_ball::UnitBall;

--- a/rand_distr/src/normal.rs
+++ b/rand_distr/src/normal.rs
@@ -12,6 +12,7 @@
 use rand::Rng;
 use crate::{ziggurat_tables, Distribution, Open01};
 use crate::utils::{ziggurat, Float};
+use std::{error, fmt};
 
 /// Samples floating-point numbers according to the normal distribution
 /// `N(0, 1)` (a.k.a. a standard normal, or Gaussian). This is equivalent to
@@ -113,6 +114,16 @@ pub enum Error {
     /// `std_dev < 0` or `nan`.
     StdDevTooSmall,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::StdDevTooSmall => "std_dev < 0 or is NaN in normal distribution",
+        })
+    }
+}
+
+impl error::Error for Error {}
 
 impl<N: Float> Normal<N>
 where StandardNormal: Distribution<N>

--- a/rand_distr/src/pareto.rs
+++ b/rand_distr/src/pareto.rs
@@ -11,6 +11,7 @@
 use rand::Rng;
 use crate::{Distribution, OpenClosed01};
 use crate::utils::Float;
+use std::{error, fmt};
 
 /// Samples floating-point numbers according to the Pareto distribution
 ///
@@ -36,6 +37,17 @@ pub enum Error {
     /// `shape <= 0` or `nan`.
     ShapeTooSmall,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::ScaleTooSmall => "scale is not positive in Pareto distribution",
+            Error::ShapeTooSmall => "shape is not positive in Pareto distribution",
+        })
+    }
+}
+
+impl error::Error for Error {}
 
 impl<N: Float> Pareto<N>
 where OpenClosed01: Distribution<N>

--- a/rand_distr/src/pert.rs
+++ b/rand_distr/src/pert.rs
@@ -51,8 +51,8 @@ pub enum PertError {
 impl fmt::Display for PertError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
-            PertError::RangeTooSmall => "min..=max is not proper range in PERT distribution",
-            PertError::ModeRange => "mode is outside min..=max in PERT distribution",
+            PertError::RangeTooSmall => "requirement min < max is not met in PERT distribution",
+            PertError::ModeRange => "mode is outside [min, max] in PERT distribution",
             PertError::ShapeTooSmall => "shape < 0 or is NaN in PERT distribution",
         })
     }

--- a/rand_distr/src/pert.rs
+++ b/rand_distr/src/pert.rs
@@ -10,6 +10,7 @@
 use rand::Rng;
 use crate::{Distribution, Beta, StandardNormal, Exp1, Open01};
 use crate::utils::Float;
+use std::{error, fmt};
 
 /// The PERT distribution.
 ///
@@ -46,6 +47,18 @@ pub enum PertError {
     /// `shape < 0` or `shape` is NaN
     ShapeTooSmall,
 }
+
+impl fmt::Display for PertError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            PertError::RangeTooSmall => "min..=max is not proper range in PERT distribution",
+            PertError::ModeRange => "mode is outside min..=max in PERT distribution",
+            PertError::ShapeTooSmall => "shape < 0 or is NaN in PERT distribution",
+        })
+    }
+}
+
+impl error::Error for PertError {}
 
 impl<N: Float> Pert<N>
 where StandardNormal: Distribution<N>, Exp1: Distribution<N>, Open01: Distribution<N>

--- a/rand_distr/src/poisson.rs
+++ b/rand_distr/src/poisson.rs
@@ -12,6 +12,7 @@
 use rand::Rng;
 use crate::{Distribution, Cauchy, Standard};
 use crate::utils::Float;
+use std::{error, fmt};
 
 /// The Poisson distribution `Poisson(lambda)`.
 ///
@@ -43,6 +44,16 @@ pub enum Error {
     /// `lambda <= 0` or `nan`.
     ShapeTooSmall,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::ShapeTooSmall => "lambda is not positive in Poisson distribution",
+        })
+    }
+}
+
+impl error::Error for Error {}
 
 impl<N: Float> Poisson<N>
 where Standard: Distribution<N>

--- a/rand_distr/src/triangular.rs
+++ b/rand_distr/src/triangular.rs
@@ -51,9 +51,9 @@ impl fmt::Display for TriangularError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             TriangularError::RangeTooSmall => {
-                "min..=max is not proper range in triangular distribution"
+                "requirement min <= max is not met in triangular distribution"
             }
-            TriangularError::ModeRange => "mode is outside min..=max in triangular distribution",
+            TriangularError::ModeRange => "mode is outside [min, max] in triangular distribution",
         })
     }
 }

--- a/rand_distr/src/triangular.rs
+++ b/rand_distr/src/triangular.rs
@@ -10,6 +10,7 @@
 use rand::Rng;
 use crate::{Distribution, Standard};
 use crate::utils::Float;
+use std::{error, fmt};
 
 /// The triangular distribution.
 /// 
@@ -45,6 +46,19 @@ pub enum TriangularError {
     /// `mode < min` or `mode > max` or `mode` is NaN.
     ModeRange,
 }
+
+impl fmt::Display for TriangularError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            TriangularError::RangeTooSmall => {
+                "min..=max is not proper range in triangular distribution"
+            }
+            TriangularError::ModeRange => "mode is outside min..=max in triangular distribution",
+        })
+    }
+}
+
+impl error::Error for TriangularError {}
 
 impl<N: Float> Triangular<N>
 where Standard: Distribution<N>

--- a/rand_distr/src/weibull.rs
+++ b/rand_distr/src/weibull.rs
@@ -11,6 +11,7 @@
 use rand::Rng;
 use crate::{Distribution, OpenClosed01};
 use crate::utils::Float;
+use std::{error, fmt};
 
 /// Samples floating-point numbers according to the Weibull distribution
 ///
@@ -36,6 +37,17 @@ pub enum Error {
     /// `shape <= 0` or `nan`.
     ShapeTooSmall,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::ScaleTooSmall => "scale is not positive in Weibull distribution",
+            Error::ShapeTooSmall => "shape is not positive in Weibull distribution",
+        })
+    }
+}
+
+impl error::Error for Error {}
 
 impl<N: Float> Weibull<N>
 where OpenClosed01: Distribution<N>

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -10,6 +10,7 @@
 
 use crate::Rng;
 use crate::distributions::Distribution;
+use core::{fmt, u64};
 
 /// The Bernoulli distribution.
 ///
@@ -55,7 +56,7 @@ pub struct Bernoulli {
 // the RNG, and pay the performance price for all uses that *are* reasonable.
 // Luckily, if `new()` and `sample` are close, the compiler can optimize out the
 // extra check.
-const ALWAYS_TRUE: u64 = ::core::u64::MAX;
+const ALWAYS_TRUE: u64 = u64::MAX;
 
 // This is just `2.0.powi(64)`, but written this way because it is not available
 // in `no_std` mode.
@@ -67,6 +68,17 @@ pub enum BernoulliError {
     /// `p < 0` or `p > 1`.
     InvalidProbability,
 }
+
+impl fmt::Display for BernoulliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            BernoulliError::InvalidProbability => "p is outside 0..=1 in Bernoulli distribution",
+        })
+    }
+}
+
+#[cfg(feature = "std")]
+impl ::std::error::Error for BernoulliError {}
 
 impl Bernoulli {
     /// Construct a new `Bernoulli` with the given probability of success `p`.

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -72,7 +72,7 @@ pub enum BernoulliError {
 impl fmt::Display for BernoulliError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
-            BernoulliError::InvalidProbability => "p is outside 0..=1 in Bernoulli distribution",
+            BernoulliError::InvalidProbability => "p is outside [0, 1] in Bernoulli distribution",
         })
     }
 }

--- a/src/distributions/weighted/mod.rs
+++ b/src/distributions/weighted/mod.rs
@@ -380,9 +380,6 @@ impl ::std::error::Error for WeightedError {
     fn description(&self) -> &str {
         self.msg()
     }
-    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
-        None
-    }
 }
 
 impl fmt::Display for WeightedError {


### PR DESCRIPTION
Also re-exported `BernoulliError` into `rand_distr`.