### PR TITLE
Remove deprecated Error::description and Error::cause

### DIFF
--- a/src/distributions/weighted/mod.rs
+++ b/src/distributions/weighted/mod.rs
@@ -364,29 +364,16 @@ pub enum WeightedError {
     TooMany,
 }
 
-impl WeightedError {
-    fn msg(&self) -> &str {
-        match *self {
-            WeightedError::NoItem => "No weights provided.",
-            WeightedError::InvalidWeight => "A weight is invalid.",
-            WeightedError::AllWeightsZero => "All weights are zero.",
-            WeightedError::TooMany => "Too many weights (hit u32::MAX)",
-        }
-    }
-}
-
 #[cfg(feature="std")]
-impl ::std::error::Error for WeightedError {
-    fn description(&self) -> &str {
-        self.msg()
-    }
-    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
-        None
-    }
-}
+impl ::std::error::Error for WeightedError {}
 
 impl fmt::Display for WeightedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.msg())
+        match *self {
+            WeightedError::NoItem => write!(f, "No weights provided."),
+            WeightedError::InvalidWeight => write!(f, "A weight is invalid."),
+            WeightedError::AllWeightsZero => write!(f, "All weights are zero."),
+            WeightedError::TooMany => write!(f, "Too many weights (hit u32::MAX)"),
+        }
     }
 }


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon. Error::cause has been documented as deprecated from Error::cause has already been deprecated since 1.33.0.

This PR:
-  Removes an implementation of `description` and `cause` in `WeightedError`
-  Moves `msg ` implementation into `Display::fmt`

Related PR: https://github.com/rust-lang/rust/pull/66919