### PR TITLE
Make libc dependency optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 ### Fixes
 - The `Bernoulli` distribution constructors now reports an error on NaN and on
   `denominator == 0`. (#925)
+- Use `std::sync::Once` to register fork handler, avoiding possible atomicity violation (#928)
 
 ### Changes
 - Unix: make libc dependency optional; only use fork protection with std feature (#928)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - The `Bernoulli` distribution constructors now reports an error on NaN and on
   `denominator == 0`. (#925)
 
+### Changes
+- Unix: make libc dependency optional; only use fork protection with std feature (#928)
+
 ### Additions
 - Implement `std::error::Error` for `BernoulliError` (#919)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ nightly = ["simd_support"] # enables all features requiring nightly rust
 serde1 = [] # does nothing, deprecated
 
 # Optional dependencies:
-std = ["rand_core/std", "rand_chacha/std", "alloc", "getrandom"]
+std = ["rand_core/std", "rand_chacha/std", "alloc", "getrandom", "libc"]
 alloc = ["rand_core/alloc"]  # enables Vec and Box support (without std)
 # re-export optional WASM dependencies to avoid breakage:
 # Warning: wasm-bindgen and stdweb features will be removed in rand 0.8;
@@ -68,7 +68,7 @@ features = ["into_bits"]
 
 [target.'cfg(unix)'.dependencies]
 # Used for fork protection (reseeding.rs)
-libc = { version = "0.2.22", default-features = false }
+libc = { version = "0.2.22", optional = true, default-features = false }
 
 # Emscripten does not support 128-bit integers, which are used by ChaCha code.
 # We work around this by using a different RNG.

--- a/src/rngs/adapter/reseeding.rs
+++ b/src/rngs/adapter/reseeding.rs
@@ -279,7 +279,7 @@ where
 }
 
 
-#[cfg(all(unix, not(target_os = "emscripten")))]
+#[cfg(all(unix, feature = "std", not(target_os = "emscripten")))]
 mod fork {
     use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[allow(deprecated)] // Required for compatibility with Rust < 1.24.
@@ -321,7 +321,7 @@ mod fork {
     }
 }
 
-#[cfg(not(all(unix, not(target_os = "emscripten"))))]
+#[cfg(not(all(unix, feature = "std", not(target_os = "emscripten"))))]
 mod fork {
     pub fn get_fork_counter() -> usize {
         0

--- a/src/rngs/adapter/reseeding.rs
+++ b/src/rngs/adapter/reseeding.rs
@@ -282,8 +282,6 @@ where
 #[cfg(all(unix, feature = "std", not(target_os = "emscripten")))]
 mod fork {
     use core::sync::atomic::{AtomicUsize, Ordering};
-    #[allow(deprecated)] // Required for compatibility with Rust < 1.24.
-    use core::sync::atomic::{ATOMIC_USIZE_INIT};
     use std::sync::Once;
 
     // Fork protection
@@ -298,8 +296,7 @@ mod fork {
     // don't update `fork_counter`, so a reseed is attempted as soon as
     // possible.
 
-    #[allow(deprecated)]
-    static RESEEDING_RNG_FORK_COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
+    static RESEEDING_RNG_FORK_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
     pub fn get_fork_counter() -> usize {
         RESEEDING_RNG_FORK_COUNTER.load(Ordering::Relaxed)


### PR DESCRIPTION
Fixes #911 and #927.

(Although the plan is still to restrict `ReseedingRng` to `std` for 0.8.)

Review please @Amanieu / @BurtonQin / @bjorn3 (and apologies for the delay).