### PR TITLE
Impl Distribution<u8> for Alphanumeric

### DIFF
--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -16,7 +16,7 @@ use crate::Rng;
 
 // ----- Sampling distributions -----
 
-/// Sample a `char`, uniformly distributed over ASCII letters and numbers:
+/// Sample a `char` or `u8`, uniformly distributed over ASCII letters and numbers:
 /// a-z, A-Z and 0-9.
 ///
 /// # Example
@@ -62,6 +62,13 @@ impl Distribution<char> for Standard {
 
 impl Distribution<char> for Alphanumeric {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> char {
+        let byte: u8 = self.sample(rng);
+        byte as char
+    }
+}
+
+impl Distribution<u8> for Alphanumeric {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u8 {
         const RANGE: u32 = 26 + 26 + 10;
         const GEN_ASCII_STR_CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
                 abcdefghijklmnopqrstuvwxyz\
@@ -73,7 +80,7 @@ impl Distribution<char> for Alphanumeric {
         loop {
             let var = rng.next_u32() >> (32 - 6);
             if var < RANGE {
-                return GEN_ASCII_STR_CHARSET[var as usize] as char;
+                return GEN_ASCII_STR_CHARSET[var as usize];
             }
         }
     }


### PR DESCRIPTION
Sampling a random alphanumeric string by collecting chars (that are known to be ASCII) into a String involves emitting code for re-allocation as String is encoding to UTF-8, via the example:

```rust
let chars: String = iter::repeat(())
        .map(|()| rng.sample(Alphanumeric))
        .take(7)
        .collect();
```

I wanted to get rid of the clearly unnecessary re-allocation branches in my application, so I needed to be able to access to the ASCII characters as simple bytes. It seems like that was already what was going on inside Alphanumeric however, it was just internal.

This PR changes the `Distribution<char>` impl to provide `u8`s (which it generated internally already) instead, and implements the previous `Distribution<char>` using it. One could then for example do:

```rust
let mut rng = thread_rng();
let bytes = (0..7).map(|_| rng.sample(Alphanumeric)).collect();
let chars = unsafe { String::from_utf8_unchecked(bytes) };
```