### PR TITLE
0.2.3 rand chacha

### DIFF
--- a/rand_chacha/CHANGELOG.md
+++ b/rand_chacha/CHANGELOG.md
@@ -4,11 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.3] - 2020-03-09
+## [0.2.2] - 2020-03-09
+- Integrate `c2-chacha`, reducing dependency count (#931)
 - Add CryptoRng to ChaChaXCore (#944)
 
-## [0.2.2] - 2020-01-20
-- Integrate `c2-chacha`, reducing dependency count (#931)
 
 ## [0.2.1] - 2019-07-22
 - Force enable the `simd` feature of `c2-chacha` (#845)

--- a/rand_chacha/CHANGELOG.md
+++ b/rand_chacha/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2020-03-09
+- Add CryptoRng to ChaChaXCore (#944)
+
 ## [0.2.2] - 2020-01-20
 - Integrate `c2-chacha`, reducing dependency count (#931)
 

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_chacha"
-version = "0.2.3"
+version = "0.2.2"
 authors = ["The Rand Project Developers", "The Rust Project Developers", "The CryptoCorrosion Contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["The Rand Project Developers", "The Rust Project Developers", "The CryptoCorrosion Contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
@dhardy It turns out that my change was only in rand-chacha so I don't think we need to actually do an 0.7.4 release of rand proper.

Also, I'm not sure 0.2.2 ever actually was published for rand-chacha, but I did bump the version number and do the changelog.

Let me know if I'm incorrect or you need more from me.

Solves #947 