### PR TITLE
Rounding error fix on WeightedIndex::update_weights()

### DIFF
--- a/src/distributions/weighted/mod.rs
+++ b/src/distributions/weighted/mod.rs
@@ -183,7 +183,7 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
             total_weight += w;
             prev_i = Some(i);
         }
-        if total_weight == zero {
+        if total_weight <= zero {
             return Err(WeightedError::AllWeightsZero);
         }
 


### PR DESCRIPTION
WeightedIndex::update_weights() uses subtraction on old_w. Rounding errors, particularly on f32, may bring total_weight to below 0. This PR makes sure a negative total_weight results in an error.
