### PR TITLE
Drop unsafe code from SeedableRng::seed_from_u64

### DIFF
--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -314,11 +314,7 @@ pub trait SeedableRng: Sized {
             let xorshifted = (((state >> 18) ^ state) >> 27) as u32;
             let rot = (state >> 59) as u32;
             let x = xorshifted.rotate_right(rot).to_le();
-
-            unsafe {
-                let p = &x as *const u32 as *const u8;
-                copy_nonoverlapping(p, chunk.as_mut_ptr(), chunk.len());
-            }
+            chunk.copy_from_slice(&x.to_ne_bytes());
         }
 
         Self::from_seed(seed)

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -41,7 +41,6 @@
 
 use core::convert::AsMut;
 use core::default::Default;
-use core::ptr::copy_nonoverlapping;
 
 #[cfg(all(feature = "alloc", not(feature = "std")))] extern crate alloc;
 #[cfg(all(feature = "alloc", not(feature = "std")))] use alloc::boxed::Box;
@@ -313,8 +312,8 @@ pub trait SeedableRng: Sized {
             // Use PCG output function with to_le to generate x:
             let xorshifted = (((state >> 18) ^ state) >> 27) as u32;
             let rot = (state >> 59) as u32;
-            let x = xorshifted.rotate_right(rot).to_le();
-            chunk.copy_from_slice(&x.to_ne_bytes());
+            let x = xorshifted.rotate_right(rot);
+            chunk.copy_from_slice(&x.to_le_bytes());
         }
 
         Self::from_seed(seed)


### PR DESCRIPTION
`u32::to_ne_bytes()` has been stabilized in Rust 1.32, so this does not bump MSRV.

I haven't benchmarked it this change, but since seed generation is done once per RNG, it's not going to be a performance bottleneck either way.