### PR TITLE
Backward-compatible fix for #968

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [0.7.4] - 2020-04-28
+### Security fix
+- Prevent potential use-after-free when using `thread_rng` from a thread-local
+  destructor on some platforms (OSX; #968)
+
 ## [0.7.3] - 2020-01-10
 ### Fixes
 - The `Bernoulli` distribution constructors now reports an error on NaN and on

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This is @josephlr's fix (3) from #968.

Personally I see 2-5% performance penalty vs Joseph's ~16% (same benchmarks; in my case using Xeon E3-1231 aka Haswell with Fedora 31). Either way, real-world impact will usually be much lower due to the tight loops in the benchmarks.

CC @nathdobson @burdges @bjorn3.