### PR TITLE
Allow lambda zero for parametrization in Exp distribution.

### DIFF
--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 - All error types now implement `std::error::Error` (#919)
 - Re-exported `rand::distributions::BernoulliError` (#919)
+- Add case `lambda = 0` in the parametrixation of `Exp` (#972)
 
 ## [0.2.2] - 2019-09-10
 - Fix version requirement on rand lib (#847)

--- a/rand_distr/src/exponential.rs
+++ b/rand_distr/src/exponential.rs
@@ -105,7 +105,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
-            Error::LambdaTooSmall => "lambda is negative in exponential distribution",
+            Error::LambdaTooSmall => "lambda is negative or NaN in exponential distribution",
         })
     }
 }


### PR DESCRIPTION
This allows the parameter `lambda = 0` in the distribution `Exp`.

# Implementation
Taking advantage that `1 / 0 = infinity`, we change nothing in the implementation, i.e. a sample from `Exp(lambda)` is the result of a sample from `Exp1` multiplied by `1 / lambda`.

# Performance
This makes the sampling from `Exp(lambda = 0)` lose time sampling from `Exp1` when there is no need since the result is always infinity. This is okay since it is not the common case.

# Documentation
The error `LambdaTooSmall` accounts now only for negative or NaN parameters `lambda`. 
Also, In the documentation for `Exp`, there are two changes: the explanation of density and constructor `new`. *Please check the style of this.*

In the explanation of the density, we included the case `lambda = 0`, assuming that the user is using primitives (most of the cases).

In the constructor `new`, a remark was added. It seems a bit overly complicated, but this is because of the trait `N: Float`. Since `Float` has no `infinity` method, we rely on the behaviour of `1 / 0` of the custom type `N`. I made this explicit by explaining the implementation itself! I did not come up with a better explanation. 