### PR TITLE
Add SliceRandom::choose_multiple_weighted, implementing weighted sampling without replacement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ appveyor = { repository = "rust-random/rand" }
 [features]
 # Meta-features:
 default = ["std", "std_rng"]
-nightly = ["simd_support"] # enables all features requiring nightly rust
+nightly = ["simd_support", "partition_at_index"] # enables all features requiring nightly rust
 serde1 = [] # does nothing, deprecated
 
 # Option (enabled by default): without "std" rand uses libcore; this option
@@ -44,6 +44,9 @@ std_rng = ["rand_chacha", "rand_hc"]
 
 # Option: enable SmallRng
 small_rng = ["rand_pcg"]
+
+# Option (requires nightly): better performance of choose_multiple_weighted
+partition_at_index = []
 
 [workspace]
 members = [

--- a/benches/seq.rs
+++ b/benches/seq.rs
@@ -177,3 +177,24 @@ sample_indices!(misc_sample_indices_100_of_1G, sample, 100, 1000_000_000);
 sample_indices!(misc_sample_indices_200_of_1G, sample, 200, 1000_000_000);
 sample_indices!(misc_sample_indices_400_of_1G, sample, 400, 1000_000_000);
 sample_indices!(misc_sample_indices_600_of_1G, sample, 600, 1000_000_000);
+
+macro_rules! sample_indices_rand_weights {
+    ($name:ident, $amount:expr, $length:expr) => {
+        #[bench]
+        fn $name(b: &mut Bencher) {
+            let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
+            b.iter(|| {
+                index::sample_weighted(&mut rng, $length, |idx| (1 + (idx % 100)) as u32, $amount)
+            })
+        }
+    };
+}
+
+sample_indices_rand_weights!(misc_sample_weighted_indices_1_of_1k, 1, 1000);
+sample_indices_rand_weights!(misc_sample_weighted_indices_10_of_1k, 10, 1000);
+sample_indices_rand_weights!(misc_sample_weighted_indices_100_of_1k, 100, 1000);
+sample_indices_rand_weights!(misc_sample_weighted_indices_100_of_1M, 100, 1000_000);
+sample_indices_rand_weights!(misc_sample_weighted_indices_200_of_1M, 200, 1000_000);
+sample_indices_rand_weights!(misc_sample_weighted_indices_400_of_1M, 400, 1000_000);
+sample_indices_rand_weights!(misc_sample_weighted_indices_600_of_1M, 600, 1000_000);
+sample_indices_rand_weights!(misc_sample_weighted_indices_1k_of_1M, 1000, 1000_000);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(all(feature = "simd_support", feature = "nightly"), feature(stdsimd))]
+#![cfg_attr(all(feature = "partition_at_index", feature = "nightly"), feature(slice_partition_at_index))]
 #![allow(
     clippy::excessive_precision,
     clippy::unreadable_literal,

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -261,14 +261,14 @@ where R: Rng + ?Sized {
 /// sometimes be useful to have the indices themselves so this is provided as
 /// an alternative.
 ///
-/// This implementation uses `O(length)` space and `O(length)` time if the
-/// "partition_at_index" feature is enabled, or `O(length)` space and
-/// `O(length * log amount)` time otherwise.
+/// This implementation uses `O(length + amount)` space and `O(length)` time
+/// if the "partition_at_index" feature is enabled, or `O(length)` space and
+/// `O(length + amount * log length)` time otherwise.
 ///
 /// Panics if `amount > length`.
 pub fn sample_weighted<R, F, X>(
     rng: &mut R, length: usize, weight: F, amount: usize,
-) -> Result<IndexVecIntoIter, WeightedError>
+) -> Result<IndexVec, WeightedError>
 where
     R: Rng + ?Sized,
     F: Fn(usize) -> X,
@@ -307,7 +307,7 @@ where
     #[cfg(feature = "partition_at_index")]
     {
         if length == 0 {
-            return Ok(IndexVecIntoIter::USize(Vec::new().into_iter()));
+            return Ok(IndexVec::USize(Vec::new()));
         }
 
         let mut candidates = Vec::with_capacity(length);
@@ -332,7 +332,7 @@ where
         for element in greater {
             result.push(element.index);
         }
-        Ok(IndexVecIntoIter::USize(result.into_iter()))
+        Ok(IndexVec::USize(result))
     }
 
     #[cfg(not(feature = "partition_at_index"))]
@@ -359,7 +359,7 @@ where
         while result.len() < amount {
             result.push(candidates.pop().unwrap().index);
         }
-        Ok(IndexVecIntoIter::USize(result.into_iter()))
+        Ok(IndexVec::USize(result))
     }
 }
 

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -286,14 +286,14 @@ where
         key: f64,
     }
     impl PartialOrd for Element {
-        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
             self.key
                 .partial_cmp(&other.key)
-                .or(Some(std::cmp::Ordering::Less))
+                .or(Some(core::cmp::Ordering::Less))
         }
     }
     impl Ord for Element {
-        fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        fn cmp(&self, other: &Self) -> core::cmp::Ordering {
             self.partial_cmp(other).unwrap() // partial_cmp will always produce a value
         }
     }
@@ -337,6 +337,9 @@ where
 
     #[cfg(not(feature = "partition_at_index"))]
     {
+        #[cfg(all(feature = "alloc", not(feature = "std")))]
+        use crate::alloc::collections::BinaryHeap;
+        #[cfg(feature = "std")]
         use std::collections::BinaryHeap;
 
         // Partially sort the array such that the `amount` elements with the largest

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -508,7 +508,8 @@ impl<T> SliceRandom for [T] {
                 self.len(),
                 |idx| weight(&self[idx]).into(),
                 amount,
-            )?,
+            )?
+            .into_iter(),
         })
     }
 

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -178,6 +178,46 @@ pub trait SliceRandom {
             + Clone
             + Default;
 
+    /// Similar to [`choose_multiple`], but where the likelihood of each element's
+    /// inclusion in the output may be specified. The elements are returned in an
+    /// arbitrary, unspecified order.
+    ///
+    /// The specified function `weight` maps each item `x` to a relative
+    /// likelihood `weight(x)`. The probability of each item being selected is
+    /// therefore `weight(x) / s`, where `s` is the sum of all `weight(x)`.
+    ///
+    /// If all of the weights are equal, even if they are all zero, each element has
+    /// an equal likelihood of being selected.
+    ///
+    /// The complexity of this method depends on the feature `partition_at_index`.
+    /// If the feature is enabled, then for slices of length `n`, the complexity
+    /// is `O(n)` space and `O(n)` time. Otherwise, the complexity is `O(n)` space and
+    /// `O(n * log amount)` time.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rand::prelude::*;
+    ///
+    /// let choices = [('a', 2), ('b', 1), ('c', 1)];
+    /// let mut rng = thread_rng();
+    /// // First Draw * Second Draw = total odds
+    /// // -----------------------
+    /// // (50% * 50%) + (25% * 67%) = 41.7% chance that the output is `['a', 'b']` in some order.
+    /// // (50% * 50%) + (25% * 67%) = 41.7% chance that the output is `['a', 'c']` in some order.
+    /// // (25% * 33%) + (25% * 33%) = 16.6% chance that the output is `['b', 'c']` in some order.
+    /// println!("{:?}", choices.choose_multiple_weighted(&mut rng, 2, |item| item.1).unwrap().collect::<Vec<_>>());
+    /// ```
+    /// [`choose_multiple`]: SliceRandom::choose_multiple
+    #[cfg(feature = "alloc")]
+    fn choose_multiple_weighted<R, F, X>(
+        &self, rng: &mut R, amount: usize, weight: F,
+    ) -> Result<SliceChooseIter<Self, Self::Item>, WeightedError>
+    where
+        R: Rng + ?Sized,
+        F: Fn(&Self::Item) -> X,
+        X: Into<f64>;
+
     /// Shuffle a mutable slice in place.
     ///
     /// For slices of length `n`, complexity is `O(n)`.
@@ -448,6 +488,28 @@ impl<T> SliceRandom for [T] {
         use crate::distributions::{Distribution, WeightedIndex};
         let distr = WeightedIndex::new(self.iter().map(weight))?;
         Ok(&mut self[distr.sample(rng)])
+    }
+
+    #[cfg(feature = "alloc")]
+    fn choose_multiple_weighted<R, F, X>(
+        &self, rng: &mut R, amount: usize, weight: F,
+    ) -> Result<SliceChooseIter<Self, Self::Item>, WeightedError>
+    where
+        R: Rng + ?Sized,
+        F: Fn(&Self::Item) -> X,
+        X: Into<f64>,
+    {
+        let amount = ::core::cmp::min(amount, self.len());
+        Ok(SliceChooseIter {
+            slice: self,
+            _phantom: Default::default(),
+            indices: index::sample_weighted(
+                rng,
+                self.len(),
+                |idx| weight(&self[idx]).into(),
+                amount,
+            )?,
+        })
     }
 
     fn shuffle<R>(&mut self, rng: &mut R)
@@ -952,5 +1014,123 @@ mod test {
             do_test(0..8, &[0, 1, 2, 3, 4, 5, 6, 7]);
             do_test(0..100, &[58, 78, 80, 92, 43, 8, 96, 7]);
         }
+    }
+
+    #[test]
+    fn test_multiple_weighted_edge_cases() {
+        use super::*;
+
+        let mut rng = crate::test::rng(413);
+
+        // Case 1: One of the weights is 0
+        let choices = [('a', 2), ('b', 1), ('c', 0)];
+        for _ in 0..100 {
+            let result = choices
+                .choose_multiple_weighted(&mut rng, 2, |item| item.1)
+                .unwrap()
+                .collect::<Vec<_>>();
+
+            assert_eq!(result.len(), 2);
+            assert!(!result.iter().any(|val| val.0 == 'c'));
+        }
+
+        // Case 2: All of the weights are 0
+        let choices = [('a', 0), ('b', 0), ('c', 0)];
+        let result = choices
+            .choose_multiple_weighted(&mut rng, 2, |item| item.1)
+            .unwrap()
+            .collect::<Vec<_>>();
+        assert_eq!(result.len(), 2);
+
+        // Case 3: Negative weights
+        let choices = [('a', -1), ('b', 1), ('c', 1)];
+        assert!(matches!(
+            choices.choose_multiple_weighted(&mut rng, 2, |item| item.1),
+            Err(WeightedError::InvalidWeight)
+        ));
+
+        // Case 4: Empty list
+        let choices = [];
+        let result = choices
+            .choose_multiple_weighted(&mut rng, 0, |_: &()| 0)
+            .unwrap()
+            .collect::<Vec<_>>();
+        assert_eq!(result.len(), 0);
+
+        // Case 5: NaN weights
+        let choices = [('a', std::f64::NAN), ('b', 1.0), ('c', 1.0)];
+        assert!(matches!(
+            choices.choose_multiple_weighted(&mut rng, 2, |item| item.1),
+            Err(WeightedError::InvalidWeight)
+        ));
+
+        // Case 6: +infinity weights
+        let choices = [('a', std::f64::INFINITY), ('b', 1.0), ('c', 1.0)];
+        for _ in 0..100 {
+            let result = choices
+                .choose_multiple_weighted(&mut rng, 2, |item| item.1)
+                .unwrap()
+                .collect::<Vec<_>>();
+            assert_eq!(result.len(), 2);
+            assert!(result.iter().any(|val| val.0 == 'a'));
+        }
+
+        // Case 7: -infinity weights
+        let choices = [('a', std::f64::NEG_INFINITY), ('b', 1.0), ('c', 1.0)];
+        assert!(matches!(
+            choices.choose_multiple_weighted(&mut rng, 2, |item| item.1),
+            Err(WeightedError::InvalidWeight)
+        ));
+
+        // Case 8: -0 weights
+        let choices = [('a', -0.0), ('b', 1.0), ('c', 1.0)];
+        assert!(choices
+            .choose_multiple_weighted(&mut rng, 2, |item| item.1)
+            .is_ok());
+    }
+
+    #[test]
+    fn test_multiple_weighted_distributions() {
+        use super::*;
+
+        // The theoretical probabilities of the different outcomes are:
+        // AB: 0.5  * 0.5  = 0.250
+        // AC: 0.5  * 0.5  = 0.250
+        // BA: 0.25 * 0.67 = 0.167
+        // BC: 0.25 * 0.33 = 0.082
+        // CA: 0.25 * 0.67 = 0.167
+        // CB: 0.25 * 0.33 = 0.082
+        let choices = [('a', 2), ('b', 1), ('c', 1)];
+        let mut rng = crate::test::rng(414);
+
+        let mut results = [0i32; 3];
+        let expected_results = [4167, 4167, 1666];
+        for _ in 0..10000 {
+            let result = choices
+                .choose_multiple_weighted(&mut rng, 2, |item| item.1)
+                .unwrap()
+                .collect::<Vec<_>>();
+
+            assert_eq!(result.len(), 2);
+
+            match (result[0].0, result[1].0) {
+                ('a', 'b') | ('b', 'a') => {
+                    results[0] += 1;
+                }
+                ('a', 'c') | ('c', 'a') => {
+                    results[1] += 1;
+                }
+                ('b', 'c') | ('c', 'b') => {
+                    results[2] += 1;
+                }
+                (_, _) => panic!("unexpected result"),
+            }
+        }
+
+        let mut diffs = results
+            .iter()
+            .zip(&expected_results)
+            .map(|(a, b)| (a - b).abs());
+        assert!(!diffs.any(|deviation| deviation > 100));
     }
 }

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -1045,10 +1045,12 @@ mod test {
 
         // Case 3: Negative weights
         let choices = [('a', -1), ('b', 1), ('c', 1)];
-        assert!(matches!(
-            choices.choose_multiple_weighted(&mut rng, 2, |item| item.1),
-            Err(WeightedError::InvalidWeight)
-        ));
+        assert_eq!(
+            choices
+                .choose_multiple_weighted(&mut rng, 2, |item| item.1)
+                .unwrap_err(),
+            WeightedError::InvalidWeight
+        );
 
         // Case 4: Empty list
         let choices = [];
@@ -1060,10 +1062,12 @@ mod test {
 
         // Case 5: NaN weights
         let choices = [('a', core::f64::NAN), ('b', 1.0), ('c', 1.0)];
-        assert!(matches!(
-            choices.choose_multiple_weighted(&mut rng, 2, |item| item.1),
-            Err(WeightedError::InvalidWeight)
-        ));
+        assert_eq!(
+            choices
+                .choose_multiple_weighted(&mut rng, 2, |item| item.1)
+                .unwrap_err(),
+            WeightedError::InvalidWeight
+        );
 
         // Case 6: +infinity weights
         let choices = [('a', core::f64::INFINITY), ('b', 1.0), ('c', 1.0)];
@@ -1078,10 +1082,12 @@ mod test {
 
         // Case 7: -infinity weights
         let choices = [('a', core::f64::NEG_INFINITY), ('b', 1.0), ('c', 1.0)];
-        assert!(matches!(
-            choices.choose_multiple_weighted(&mut rng, 2, |item| item.1),
-            Err(WeightedError::InvalidWeight)
-        ));
+        assert_eq!(
+            choices
+                .choose_multiple_weighted(&mut rng, 2, |item| item.1)
+                .unwrap_err(),
+            WeightedError::InvalidWeight
+        );
 
         // Case 8: -0 weights
         let choices = [('a', -0.0), ('b', 1.0), ('c', 1.0)];

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -1017,6 +1017,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn test_multiple_weighted_edge_cases() {
         use super::*;
 
@@ -1090,6 +1091,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn test_multiple_weighted_distributions() {
         use super::*;
 

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -1059,14 +1059,14 @@ mod test {
         assert_eq!(result.len(), 0);
 
         // Case 5: NaN weights
-        let choices = [('a', std::f64::NAN), ('b', 1.0), ('c', 1.0)];
+        let choices = [('a', core::f64::NAN), ('b', 1.0), ('c', 1.0)];
         assert!(matches!(
             choices.choose_multiple_weighted(&mut rng, 2, |item| item.1),
             Err(WeightedError::InvalidWeight)
         ));
 
         // Case 6: +infinity weights
-        let choices = [('a', std::f64::INFINITY), ('b', 1.0), ('c', 1.0)];
+        let choices = [('a', core::f64::INFINITY), ('b', 1.0), ('c', 1.0)];
         for _ in 0..100 {
             let result = choices
                 .choose_multiple_weighted(&mut rng, 2, |item| item.1)
@@ -1077,7 +1077,7 @@ mod test {
         }
 
         // Case 7: -infinity weights
-        let choices = [('a', std::f64::NEG_INFINITY), ('b', 1.0), ('c', 1.0)];
+        let choices = [('a', core::f64::NEG_INFINITY), ('b', 1.0), ('c', 1.0)];
         assert!(matches!(
             choices.choose_multiple_weighted(&mut rng, 2, |item| item.1),
             Err(WeightedError::InvalidWeight)


### PR DESCRIPTION
This introduces two new methods, intended to close #596 :

`SliceRandom::choose_multiple_weighted` - similar to `SliceRandom::choose_multiple`, but without replacement and with weights.
`index::sample_weighted` - an analogue to `index::sample` which implements the actual logic.

This notably includes two different implementations of `sample_weighted` - one which uses an unstable, nightly-only feature of the standard library, "slice_partition_at_index", and one which uses only stable functionality. By my measurements, the performance improvement of using the unstable feature with very large slices is extremely significant (see below). I'm not sure what the right thing to do here is - the options seem to be:

* Keep things the way they are, and remove the worse implementation if/when the unstable feature is stabilized. I'm not sure how this interacts with `rustc` version requirements.
* Copy the unstable feature's logic into this crate. This has the downside that It's a significant amount of logic that arguably doesn't belong in `rand`, and it involves lots of use of `unsafe`.

Both implementations are based on Algorithm A described by Efraimidis and Spirakis in their paper on Weighted Random Sampling, available [here](http://citeseerx.ist.psu.edu/viewdoc/download;jsessionid=BEB1FE0AB3C0129B822D2CE5EABBFD42?doi=10.1.1.591.4194&rep=rep1&type=pdf). They differ in the way they implement step 2, "select the items with the largest keys".

Finally, one last thing I'm uncertain about is the behavior the algorithm should take when given invalid weights - negative values and `NaN`. The approach I've taken so far is to add a check that the result of the user-specified `weight` function is valid before computing with it, but the alternative is simply documenting that the behavior of the algorithm is not specified if the weights are invalid.

-----

Here are some benchmarking results taken on Windows on a Ryzen 1700X:

```
> cargo +nightly bench -- sample_weighted

test misc_sample_weighted_indices_100_of_1M  ... bench:  86,739,580 ns/iter (+/- 3,530,996)
test misc_sample_weighted_indices_100_of_1k  ... bench:      92,856 ns/iter (+/- 1,179)
test misc_sample_weighted_indices_10_of_1k   ... bench:      84,986 ns/iter (+/- 1,144)
test misc_sample_weighted_indices_1_of_1k    ... bench:      83,997 ns/iter (+/- 1,771)
test misc_sample_weighted_indices_1k_of_1M   ... bench:  87,341,100 ns/iter (+/- 508,386)
test misc_sample_weighted_indices_200_of_1M  ... bench:  87,002,990 ns/iter (+/- 989,274)
test misc_sample_weighted_indices_400_of_1M  ... bench:  87,762,280 ns/iter (+/- 4,247,746)
test misc_sample_weighted_indices_600_of_1M  ... bench:  87,204,490 ns/iter (+/- 3,406,199)

> cargo +nightly bench --features="nightly" -- sample_weighted

test misc_sample_weighted_indices_100_of_1M  ... bench:  50,854,360 ns/iter (+/- 5,298,528)
test misc_sample_weighted_indices_100_of_1k  ... bench:      41,186 ns/iter (+/- 11,823)
test misc_sample_weighted_indices_10_of_1k   ... bench:      40,682 ns/iter (+/- 21,438)
test misc_sample_weighted_indices_1_of_1k    ... bench:      35,714 ns/iter (+/- 527)
test misc_sample_weighted_indices_1k_of_1M   ... bench:  50,370,600 ns/iter (+/- 4,227,278)
test misc_sample_weighted_indices_200_of_1M  ... bench:  49,976,930 ns/iter (+/- 4,569,493)
test misc_sample_weighted_indices_400_of_1M  ... bench:  49,964,680 ns/iter (+/- 5,318,092)
test misc_sample_weighted_indices_600_of_1M  ... bench:  50,865,190 ns/iter (+/- 4,911,017)
```