### PR TITLE
Minor fixes to remove unnecessary 'cargo doc' warnings

### DIFF
--- a/rand_distr/src/weighted/alias_method.rs
+++ b/rand_distr/src/weighted/alias_method.rs
@@ -58,8 +58,8 @@ use rand::Rng;
 /// }
 /// ```
 ///
-/// [`WeightedIndex<W>`]: crate::distributions::weighted::alias_method::WeightedIndex
-/// [`Weight`]: crate::distributions::weighted::alias_method::Weight
+/// [`WeightedIndex<W>`]: #
+/// [`Weight`]: Weight
 /// [`Vec<u32>`]: Vec
 /// [`Uniform<u32>::sample`]: Distribution::sample
 /// [`Uniform<W>::sample`]: Distribution::sample

--- a/rand_distr/src/weighted/alias_method.rs
+++ b/rand_distr/src/weighted/alias_method.rs
@@ -58,8 +58,7 @@ use rand::Rng;
 /// }
 /// ```
 ///
-/// [`WeightedIndex<W>`]: #
-/// [`Weight`]: Weight
+/// [`WeightedIndex<W>`]: WeightedIndex
 /// [`Vec<u32>`]: Vec
 /// [`Uniform<u32>::sample`]: Distribution::sample
 /// [`Uniform<W>::sample`]: Distribution::sample


### PR DESCRIPTION
Hello 🦀 ,
This PR contains the follwing changes.

* Fix two unresolved links in doc comments.
   The links now work as expected.
   This will remove the warnings that are currently output from `cargo doc`:  

```
warning: `[crate::distributions::weighted::alias_method::WeightedIndex]` cannot be resolved, ignoring it.

  --> rand_distr/src/weighted/alias_method.rs:61:27

   |

61 | /// [`WeightedIndex<W>`]: crate::distributions::weighted::alias_method::WeightedIndex

   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring

   |

   = note: `#[warn(intra_doc_link_resolution_failure)]` on by default

   = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::distributions::weighted::alias_method::WeightedIndex]` cannot be resolved, ignoring it.

  --> rand_distr/src/weighted/alias_method.rs:61:27

   |

61 | /// [`WeightedIndex<W>`]: crate::distributions::weighted::alias_method::WeightedIndex

   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring

   |

   = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::distributions::weighted::alias_method::Weight]` cannot be resolved, ignoring it.

  --> rand_distr/src/weighted/alias_method.rs:62:17

   |

62 | /// [`Weight`]: crate::distributions::weighted::alias_method::Weight

   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring

   |

   = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: 3 warnings emitted
```

Thank you for reviewing this PR 👍 