### PR TITLE
ChaCha: fix behavior on block count wrap

### DIFF
--- a/rand_chacha/CHANGELOG.md
+++ b/rand_chacha/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Fix panic on block counter wrap that was occurring in debug builds
+
 ## [0.2.2] - 2020-03-09
 - Integrate `c2-chacha`, reducing dependency count (#931)
 - Add CryptoRng to ChaChaXCore (#944)

--- a/rand_chacha/src/guts.rs
+++ b/rand_chacha/src/guts.rs
@@ -100,11 +100,11 @@ fn refill_wide_impl<Mach: Machine>(
     let k = m.vec([0x6170_7865, 0x3320_646e, 0x7962_2d32, 0x6b20_6574]);
     let mut pos = state.pos64(m);
     let d0: Mach::u32x4 = m.unpack(state.d);
-    pos += 1;
+    pos = pos.wrapping_add(1);
     let d1 = d0.insert((pos >> 32) as u32, 1).insert(pos as u32, 0);
-    pos += 1;
+    pos = pos.wrapping_add(1);
     let d2 = d0.insert((pos >> 32) as u32, 1).insert(pos as u32, 0);
-    pos += 1;
+    pos = pos.wrapping_add(1);
     let d3 = d0.insert((pos >> 32) as u32, 1).insert(pos as u32, 0);
 
     let b = m.unpack(state.b);
@@ -121,13 +121,13 @@ fn refill_wide_impl<Mach: Machine>(
     }
     let mut pos = state.pos64(m);
     let d0: Mach::u32x4 = m.unpack(state.d);
-    pos += 1;
+    pos = pos.wrapping_add(1);
     let d1 = d0.insert((pos >> 32) as u32, 1).insert(pos as u32, 0);
-    pos += 1;
+    pos = pos.wrapping_add(1);
     let d2 = d0.insert((pos >> 32) as u32, 1).insert(pos as u32, 0);
-    pos += 1;
+    pos = pos.wrapping_add(1);
     let d3 = d0.insert((pos >> 32) as u32, 1).insert(pos as u32, 0);
-    pos += 1;
+    pos = pos.wrapping_add(1);
     let d4 = d0.insert((pos >> 32) as u32, 1).insert(pos as u32, 0);
 
     let (a, b, c, d) = (


### PR DESCRIPTION
Documented behavior is to allow the counter to wrap around, but
implementation was panicking on that event in debug-mode builds.

Also fix `get_word_pos` handling of counter-wrapping, add some tests,
and make math easier to read.