### PR TITLE
Reduce packaged crate size by 5kb using `cargo diet -r`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["random", "rng"]
 categories = ["algorithms", "no-std"]
 autobenches = true
 edition = "2018"
-include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
+include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [badges]
 travis-ci = { repository = "rust-random/rand" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ Random number generators and other randomness functionality.
 """
 keywords = ["random", "rng"]
 categories = ["algorithms", "no-std"]
-exclude = ["/utils/*", "/.travis.yml", "/appveyor.yml", ".gitignore"]
 autobenches = true
 edition = "2018"
+include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 
 [badges]
 travis-ci = { repository = "rust-random/rand" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["random", "rng"]
 categories = ["algorithms", "no-std"]
 autobenches = true
 edition = "2018"
-include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
+include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [badges]
 travis-ci = { repository = "rust-random/rand" }

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -13,6 +13,7 @@ Sampling from random number distributions
 keywords = ["random", "rng", "distribution", "probability"]
 categories = ["algorithms"]
 edition = "2018"
+include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [badges]
 travis-ci = { repository = "rust-random/rand" }

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -13,7 +13,7 @@ Sampling from random number distributions
 keywords = ["random", "rng", "distribution", "probability"]
 categories = ["algorithms"]
 edition = "2018"
-include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
+include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [badges]
 travis-ci = { repository = "rust-random/rand" }


### PR DESCRIPTION
It converted excludes into includes, removing the following files
from the package.

Since this solely optimizes for size, I am happy to make the necessary adjustments to add other files back that you want to be part of the package.

```
┌───────────────────────────────────────────┬─────────────┐
│ File                                      │ Size (Byte) │
├───────────────────────────────────────────┼─────────────┤
│ .gitignore                                │          77 │
│ .github/ISSUE_TEMPLATE/other.md           │          80 │
│ .github/ISSUE_TEMPLATE/feature_request.md │         274 │
│ .github/ISSUE_TEMPLATE/compile-issue.md   │         488 │
│ utils/ci/install_cargo_web.sh             │         536 │
│ COPYRIGHT                                 │         569 │
│ utils/ci/miri.sh                          │         815 │
│ rustfmt.toml                              │         863 │
│ benches/weighted.rs                       │        1088 │
│ utils/ci/install.sh                       │        1381 │
│ utils/ci/script.sh                        │        1583 │
│ examples/monte-carlo.rs                   │        1611 │
│ appveyor.yml                              │        2098 │
│ SECURITY.md                               │        2822 │
│ .travis.yml                               │        2952 │
│ utils/ziggurat_tables.py                  │        3929 │
│ examples/monty-hall.rs                    │        4004 │
│ benches/misc.rs                           │        4524 │
│ benches/seq.rs                            │        5410 │
│ benches/generators.rs                     │        5490 │
└───────────────────────────────────────────┴─────────────┘
```