### PR TITLE
`gen_range(a, b)` -> `gen_range(a..b)` and `gen_range(a..=b)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - impl PartialEq+Eq for StdRng, SmallRng, and StepRng (#975)
 - Added a `serde1` feature and added Serialize/Deserialize to `UniformInt` and `WeightedIndex` (#974)
 
+### Changes
+- `gen_range(a, b)` was replaced with `gen_range(a..b)`, and `gen_range(a..=b)`
+  is supported (#744, #1003). Note that `a` and `b` can no longer be references.
+
 ## [0.7.3] - 2020-01-10
 ### Fixes
 - The `Bernoulli` distribution constructors now reports an error on NaN and on

--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -197,7 +197,7 @@ macro_rules! gen_range_int {
                 let mut high = $high;
                 let mut accum: $ty = 0;
                 for _ in 0..RAND_BENCH_N {
-                    accum = accum.wrapping_add(rng.gen_range($low, high));
+                    accum = accum.wrapping_add(rng.gen_range($low..high));
                     // force recalculation of range each time
                     high = high.wrapping_add(1) & std::$ty::MAX;
                 }
@@ -237,7 +237,7 @@ macro_rules! gen_range_float {
                 let mut low = $low;
                 let mut accum: $ty = 0.0;
                 for _ in 0..RAND_BENCH_N {
-                    accum += rng.gen_range(low, high);
+                    accum += rng.gen_range(low..high);
                     // force recalculation of range each time
                     low += 0.9;
                     high += 1.1;

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -11,8 +11,8 @@
 //!
 //! This module is the home of the [`Distribution`] trait and several of its
 //! implementations. It is the workhorse behind some of the convenient
-//! functionality of the [`Rng`] trait, e.g. [`Rng::gen`], [`Rng::gen_range`] and
-//! of course [`Rng::sample`].
+//! functionality of the [`Rng`] trait, e.g. [`Rng::gen`] and of course
+//! [`Rng::sample`].
 //!
 //! Abstractly, a [probability distribution] describes the probability of
 //! occurrence of each value in its sample space.
@@ -54,16 +54,16 @@
 //! space to be specified as an arbitrary range within its target type `T`.
 //! Both [`Standard`] and [`Uniform`] are in some sense uniform distributions.
 //!
-//! Values may be sampled from this distribution using [`Rng::gen_range`] or
+//! Values may be sampled from this distribution using [`Rng::sample(Range)`] or
 //! by creating a distribution object with [`Uniform::new`],
 //! [`Uniform::new_inclusive`] or `From<Range>`. When the range limits are not
 //! known at compile time it is typically faster to reuse an existing
-//! distribution object than to call [`Rng::gen_range`].
+//! `Uniform` object than to call [`Rng::sample(Range)`].
 //!
 //! User types `T` may also implement `Distribution<T>` for [`Uniform`],
 //! although this is less straightforward than for [`Standard`] (see the
-//! documentation in the [`uniform`] module. Doing so enables generation of
-//! values of type `T` with  [`Rng::gen_range`].
+//! documentation in the [`uniform`] module). Doing so enables generation of
+//! values of type `T` with  [`Rng::sample(Range)`].
 //!
 //! ## Open and half-open ranges
 //!
@@ -315,11 +315,10 @@ where
 /// multiplicative method: `(rng.gen::<$uty>() >> N) as $ty * (ε/2)`.
 ///
 /// See also: [`Open01`] which samples from `(0, 1)`, [`OpenClosed01`] which
-/// samples from `(0, 1]` and `Rng::gen_range(0, 1)` which also samples from
-/// `[0, 1)`. Note that `Open01` and `gen_range` (which uses [`Uniform`]) use
-/// transmute-based methods which yield 1 bit less precision but may perform
-/// faster on some architectures (on modern Intel CPUs all methods have
-/// approximately equal performance).
+/// samples from `(0, 1]` and `Rng::gen_range(0..1)` which also samples from
+/// `[0, 1)`. Note that `Open01` uses transmute-based methods which yield 1 bit
+/// less precision but may perform faster on some architectures (on modern Intel
+/// CPUs all methods have approximately equal performance).
 ///
 /// [`Uniform`]: uniform::Uniform
 #[derive(Clone, Copy, Debug)]

--- a/src/rngs/thread.rs
+++ b/src/rngs/thread.rs
@@ -119,6 +119,6 @@ mod test {
         use crate::Rng;
         let mut r = crate::thread_rng();
         r.gen::<i32>();
-        assert_eq!(r.gen_range(0, 1), 0);
+        assert_eq!(r.gen_range(0..1), 0);
     }
 }

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -274,7 +274,7 @@ where R: Rng + ?Sized {
     debug_assert!(amount <= length);
     let mut indices = Vec::with_capacity(amount as usize);
     for j in length - amount..length {
-        let t = rng.gen_range(0, j + 1);
+        let t = rng.gen_range(0..=j);
         if floyd_shuffle {
             if let Some(pos) = indices.iter().position(|&x| x == t) {
                 indices.insert(pos, j);
@@ -290,7 +290,7 @@ where R: Rng + ?Sized {
         // Reimplement SliceRandom::shuffle with smaller indices
         for i in (1..amount).rev() {
             // invariant: elements with index > i have been locked in place.
-            indices.swap(i as usize, rng.gen_range(0, i + 1) as usize);
+            indices.swap(i as usize, rng.gen_range(0..=i) as usize);
         }
     }
     IndexVec::from(indices)
@@ -314,7 +314,7 @@ where R: Rng + ?Sized {
     let mut indices: Vec<u32> = Vec::with_capacity(length as usize);
     indices.extend(0..length);
     for i in 0..amount {
-        let j: u32 = rng.gen_range(i, length);
+        let j: u32 = rng.gen_range(i..length);
         indices.swap(i as usize, j as usize);
     }
     indices.truncate(amount as usize);

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -520,9 +520,9 @@ impl<'a, S: Index<usize, Output = T> + ?Sized + 'a, T: 'a> ExactSizeIterator
 #[inline]
 fn gen_index<R: Rng + ?Sized>(rng: &mut R, ubound: usize) -> usize {
     if ubound <= (core::u32::MAX as usize) {
-        rng.gen_range(0, ubound as u32) as usize
+        rng.gen_range(0..ubound as u32) as usize
     } else {
-        rng.gen_range(0, ubound)
+        rng.gen_range(0..ubound)
     }
 }
 


### PR DESCRIPTION
Replaces and closes #821.