### PR TITLE
Fix most clippy lints

### DIFF
--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -161,7 +161,7 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
             if *w < zero {
                 return Err(WeightedError::InvalidWeight);
             }
-            if i >= self.cumulative_weights.len() + 1 {
+            if i > self.cumulative_weights.len() {
                 return Err(WeightedError::TooMany);
             }
 

--- a/src/rngs/mock.rs
+++ b/src/rngs/mock.rs
@@ -75,6 +75,8 @@ mod tests {
     #[test]
     #[cfg(feature = "serde1")]
     fn test_serialization_step_rng() {
+        use super::StepRng;
+
         let some_rng = StepRng::new(42, 7);
         let de_some_rng: StepRng =
             bincode::deserialize(&bincode::serialize(&some_rng).unwrap()).unwrap();

--- a/src/rngs/mock.rs
+++ b/src/rngs/mock.rs
@@ -72,13 +72,12 @@ impl RngCore for StepRng {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
     #[cfg(feature = "serde1")]
     fn test_serialization_step_rng() {
         let some_rng = StepRng::new(42, 7);
-        let de_some_rng: StepRng = bincode::deserialize(&bincode::serialize(&some_rng).unwrap()).unwrap();
+        let de_some_rng: StepRng =
+            bincode::deserialize(&bincode::serialize(&some_rng).unwrap()).unwrap();
         assert_eq!(some_rng.v, de_some_rng.v);
         assert_eq!(some_rng.a, de_some_rng.a);
 

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -85,10 +85,15 @@ impl IndexVec {
             IndexVec::USize(ref v) => IndexVecIter::USize(v.iter()),
         }
     }
+}
+
+impl IntoIterator for IndexVec {
+    type Item = usize;
+    type IntoIter = IndexVecIntoIter;
 
     /// Convert into an iterator over the indices as a sequence of `usize` values
     #[inline]
-    pub fn into_iter(self) -> IndexVecIntoIter {
+    fn into_iter(self) -> IndexVecIntoIter {
         match self {
             IndexVec::U32(v) => IndexVecIntoIter::U32(v.into_iter()),
             IndexVec::USize(v) => IndexVecIntoIter::USize(v.into_iter()),

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -44,13 +44,11 @@ use crate::Rng;
 /// ```
 /// use rand::seq::SliceRandom;
 ///
-/// fn main() {
-///     let mut rng = rand::thread_rng();
-///     let mut bytes = "Hello, random!".to_string().into_bytes();
-///     bytes.shuffle(&mut rng);
-///     let str = String::from_utf8(bytes).unwrap();
-///     println!("{}", str);
-/// }
+/// let mut rng = rand::thread_rng();
+/// let mut bytes = "Hello, random!".to_string().into_bytes();
+/// bytes.shuffle(&mut rng);
+/// let str = String::from_utf8(bytes).unwrap();
+/// println!("{}", str);
 /// ```
 /// Example output (non-deterministic):
 /// ```none
@@ -228,12 +226,10 @@ pub trait SliceRandom {
 /// ```
 /// use rand::seq::IteratorRandom;
 ///
-/// fn main() {
-///     let mut rng = rand::thread_rng();
-///     
-///     let faces = "😀😎😐😕😠😢";
-///     println!("I am {}!", faces.chars().choose(&mut rng).unwrap());
-/// }
+/// let mut rng = rand::thread_rng();
+///
+/// let faces = "😀😎😐😕😠😢";
+/// println!("I am {}!", faces.chars().choose(&mut rng).unwrap());
 /// ```
 /// Example output (non-deterministic):
 /// ```none


### PR DESCRIPTION
I did not touch `distributions/uniform.rs`, since the corresponding warnings are addressed in #1003 

This includes one breaking change.