### PR TITLE
`Alphanumeric` samples bytes instead of chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
   is supported (#744, #1003). Note that `a` and `b` can no longer be references or SIMD types.
 - Replace `AsByteSliceMut` with `Fill` (#940)
 - Move alias method for `WeightedIndex` to `rand_distr` (#945)
+- `Alphanumeric` samples bytes instead of chars (#935)
 - Better NaN handling for `WeightedIndex` (#1005)
 - Implement `IntoIterator` for `IndexVec`, replacing the `into_iter` method (#1007)
 - Reduce packaged crate size (#983)

--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -176,7 +176,7 @@ distr_nz_int!(distr_standard_nz64, NonZeroU64, u64, Standard);
 distr_nz_int!(distr_standard_nz128, NonZeroU128, u128, Standard);
 
 distr!(distr_standard_bool, bool, Standard);
-distr!(distr_standard_alphanumeric, char, Alphanumeric);
+distr!(distr_standard_alphanumeric, u8, Alphanumeric);
 distr!(distr_standard_codepoint, char, Standard);
 
 distr_float!(distr_standard_f32, f32, Standard);

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -166,7 +166,7 @@ pub trait Distribution<T> {
     /// let v: Vec<f32> = Standard.sample_iter(rng).take(16).collect();
     ///
     /// // String:
-    /// let s: String = Alphanumeric.sample_iter(rng).take(7).collect();
+    /// let s: String = Alphanumeric.sample_iter(rng).take(7).map(char::from).collect();
     ///
     /// // Dice-rolling:
     /// let die_range = Uniform::new_inclusive(1, 6);

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -19,7 +19,7 @@ use serde::{Serialize, Deserialize};
 
 // ----- Sampling distributions -----
 
-/// Sample a `char` or `u8`, uniformly distributed over ASCII letters and numbers:
+/// Sample a `u8`, uniformly distributed over ASCII letters and numbers:
 /// a-z, A-Z and 0-9.
 ///
 /// # Example
@@ -32,6 +32,7 @@ use serde::{Serialize, Deserialize};
 /// let mut rng = thread_rng();
 /// let chars: String = iter::repeat(())
 ///         .map(|()| rng.sample(Alphanumeric))
+///         .map(char::from)
 ///         .take(7)
 ///         .collect();
 /// println!("Random chars: {}", chars);
@@ -61,13 +62,6 @@ impl Distribution<char> for Standard {
             n -= GAP_SIZE;
         }
         unsafe { char::from_u32_unchecked(n) }
-    }
-}
-
-impl Distribution<char> for Alphanumeric {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> char {
-        let byte: u8 = self.sample(rng);
-        byte as char
     }
 }
 
@@ -228,7 +222,7 @@ mod tests {
         // take the rejection sampling path.
         let mut incorrect = false;
         for _ in 0..100 {
-            let c = rng.sample(Alphanumeric);
+            let c: char = rng.sample(Alphanumeric).into();
             incorrect |= !((c >= '0' && c <= '9') ||
                            (c >= 'A' && c <= 'Z') ||
                            (c >= 'a' && c <= 'z') );
@@ -256,7 +250,7 @@ mod tests {
             '\u{ed692}',
             '\u{35888}',
         ]);
-        test_samples(&Alphanumeric, 'a', &['h', 'm', 'e', '3', 'M']);
+        test_samples(&Alphanumeric, 0, &[104, 109, 101, 51, 77]);
         test_samples(&Standard, false, &[true, true, false, true, false]);
         test_samples(&Standard, None as Option<bool>, &[
             Some(true),

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -19,7 +19,7 @@ use serde::{Serialize, Deserialize};
 
 // ----- Sampling distributions -----
 
-/// Sample a `char`, uniformly distributed over ASCII letters and numbers:
+/// Sample a `char` or `u8`, uniformly distributed over ASCII letters and numbers:
 /// a-z, A-Z and 0-9.
 ///
 /// # Example
@@ -66,6 +66,13 @@ impl Distribution<char> for Standard {
 
 impl Distribution<char> for Alphanumeric {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> char {
+        let byte: u8 = self.sample(rng);
+        byte as char
+    }
+}
+
+impl Distribution<u8> for Alphanumeric {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u8 {
         const RANGE: u32 = 26 + 26 + 10;
         const GEN_ASCII_STR_CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
                 abcdefghijklmnopqrstuvwxyz\
@@ -77,7 +84,7 @@ impl Distribution<char> for Alphanumeric {
         loop {
             let var = rng.next_u32() >> (32 - 6);
             if var < RANGE {
-                return GEN_ASCII_STR_CHARSET[var as usize] as char;
+                return GEN_ASCII_STR_CHARSET[var as usize];
             }
         }
     }

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -171,7 +171,7 @@ pub trait Rng: RngCore {
     /// let v: Vec<f32> = rng.sample_iter(Standard).take(16).collect();
     ///
     /// // String:
-    /// let s: String = rng.sample_iter(Alphanumeric).take(7).collect();
+    /// let s: String = rng.sample_iter(Alphanumeric).take(7).map(char::from).collect();
     ///
     /// // Combined values
     /// println!("{:?}", rng.sample_iter(Standard).take(5)


### PR DESCRIPTION
Includes and thus closes #935.