### PR TITLE
Use doc(cfg) to annotate feature-gated items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,4 +86,7 @@ rand_hc = { path = "rand_hc", version = "0.2" }
 bincode = "1.2.1"
 
 [package.metadata.docs.rs]
+# To build locally:
+# RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --all-features --no-deps --open
 all-features = true
+rustdoc-args = ["--cfg", "doc_cfg"]

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -28,4 +28,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 getrandom = { version = "0.1", optional = true }
 
 [package.metadata.docs.rs]
+# To build locally:
+# RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --all-features --no-deps --open
 all-features = true
+rustdoc-args = ["--cfg", "doc_cfg"]

--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -57,7 +57,8 @@ use crate::impls::{fill_via_u32_chunks, fill_via_u64_chunks};
 use crate::{CryptoRng, Error, RngCore, SeedableRng};
 use core::convert::AsRef;
 use core::fmt;
-#[cfg(feature = "serde1")] use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde1")]
+use serde::{Deserialize, Serialize};
 
 /// A trait for RNGs which do not generate random numbers individually, but in
 /// blocks (typically `[u32; N]`). This technique is commonly used by
@@ -75,7 +76,6 @@ pub trait BlockRngCore {
     /// Generate a new block of results.
     fn generate(&mut self, results: &mut Self::Results);
 }
-
 
 /// A wrapper type implementing [`RngCore`] for some type implementing
 /// [`BlockRngCore`] with `u32` array buffer; i.e. this can be used to implement
@@ -173,7 +173,8 @@ impl<R: BlockRngCore> BlockRng<R> {
 }
 
 impl<R: BlockRngCore<Item = u32>> RngCore for BlockRng<R>
-where <R as BlockRngCore>::Results: AsRef<[u32]> + AsMut<[u32]>
+where
+    <R as BlockRngCore>::Results: AsRef<[u32]> + AsMut<[u32]>,
 {
     #[inline]
     fn next_u32(&mut self) -> u32 {
@@ -251,7 +252,6 @@ impl<R: BlockRngCore + SeedableRng> SeedableRng for BlockRng<R> {
         Ok(Self::new(R::from_rng(rng)?))
     }
 }
-
 
 /// A wrapper type implementing [`RngCore`] for some type implementing
 /// [`BlockRngCore`] with `u64` array buffer; i.e. this can be used to implement
@@ -341,7 +341,8 @@ impl<R: BlockRngCore> BlockRng64<R> {
 }
 
 impl<R: BlockRngCore<Item = u64>> RngCore for BlockRng64<R>
-where <R as BlockRngCore>::Results: AsRef<[u64]> + AsMut<[u64]>
+where
+    <R as BlockRngCore>::Results: AsRef<[u64]> + AsMut<[u64]>,
 {
     #[inline]
     fn next_u32(&mut self) -> u32 {

--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -21,12 +21,14 @@
 //!
 //! # Example
 //!
-//! ```norun
+//! ```no_run
+//! use rand_core::{RngCore, SeedableRng};
 //! use rand_core::block::{BlockRngCore, BlockRng};
 //!
 //! struct MyRngCore;
 //!
 //! impl BlockRngCore for MyRngCore {
+//!     type Item = u32;
 //!     type Results = [u32; 16];
 //!
 //!     fn generate(&mut self, results: &mut Self::Results) {
@@ -35,7 +37,7 @@
 //! }
 //!
 //! impl SeedableRng for MyRngCore {
-//!     type Seed = unimplemented!();
+//!     type Seed = [u8; 32];
 //!     fn from_seed(seed: Self::Seed) -> Self {
 //!         unimplemented!()
 //!     }
@@ -44,7 +46,8 @@
 //! // optionally, also implement CryptoRng for MyRngCore
 //!
 //! // Final RNG.
-//! type MyRng = BlockRng<u32, MyRngCore>;
+//! let mut rng = BlockRng::<MyRngCore>::seed_from_u64(0);
+//! println!("First value: {}", rng.next_u32());
 //! ```
 //!
 //! [`BlockRngCore`]: crate::block::BlockRngCore

--- a/rand_core/src/error.rs
+++ b/rand_core/src/error.rs
@@ -11,7 +11,6 @@
 use core::fmt;
 use core::num::NonZeroU32;
 
-
 /// Error type of random number generators
 ///
 /// In order to be compatible with `std` and `no_std`, this type has two
@@ -41,7 +40,9 @@ impl Error {
     #[cfg(feature = "std")]
     #[inline]
     pub fn new<E>(err: E) -> Self
-    where E: Into<Box<dyn std::error::Error + Send + Sync + 'static>> {
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
         Error { inner: err.into() }
     }
 

--- a/rand_core/src/error.rs
+++ b/rand_core/src/error.rs
@@ -38,6 +38,7 @@ impl Error {
     ///
     /// See also `From<NonZeroU32>`, which is available with and without `std`.
     #[cfg(feature = "std")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
     #[inline]
     pub fn new<E>(err: E) -> Self
     where
@@ -51,6 +52,7 @@ impl Error {
     /// When configured with `std`, this is a trivial operation and never
     /// panics. Without `std`, this method is simply unavailable.
     #[cfg(feature = "std")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
     #[inline]
     pub fn inner(&self) -> &(dyn std::error::Error + Send + Sync + 'static) {
         &*self.inner
@@ -61,6 +63,7 @@ impl Error {
     /// When configured with `std`, this is a trivial operation and never
     /// panics. Without `std`, this method is simply unavailable.
     #[cfg(feature = "std")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
     #[inline]
     pub fn take_inner(self) -> Box<dyn std::error::Error + Send + Sync + 'static> {
         self.inner

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -23,7 +23,6 @@ use core::mem::size_of;
 use core::ptr::copy_nonoverlapping;
 use core::slice;
 
-
 /// Implement `next_u64` via `next_u32`, little-endian order.
 pub fn next_u64_via_u32<R: RngCore + ?Sized>(rng: &mut R) -> u64 {
     // Use LE; we explicitly generate one value before the next.

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -37,7 +37,7 @@
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 #![allow(clippy::unreadable_literal)]
 #![cfg_attr(not(feature = "std"), no_std)]
-
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
 
 use core::convert::AsMut;
 use core::default::Default;
@@ -364,6 +364,7 @@ pub trait SeedableRng: Sized {
     ///
     /// [`getrandom`]: https://docs.rs/getrandom
     #[cfg(feature = "getrandom")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "getrandom")))]
     fn from_entropy() -> Self {
         let mut seed = Self::Seed::default();
         if let Err(err) = getrandom::getrandom(seed.as_mut()) {

--- a/rand_core/src/os.rs
+++ b/rand_core/src/os.rs
@@ -43,6 +43,7 @@ use getrandom::getrandom;
 /// ```
 ///
 /// [getrandom]: https://crates.io/crates/getrandom
+#[cfg_attr(doc_cfg, doc(cfg(feature = "getrandom")))]
 #[derive(Clone, Copy, Debug, Default)]
 pub struct OsRng;
 

--- a/rand_distr/src/dirichlet.rs
+++ b/rand_distr/src/dirichlet.rs
@@ -31,6 +31,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 /// let samples = dirichlet.sample(&mut rand::thread_rng());
 /// println!("{:?} is from a Dirichlet([1.0, 2.0, 3.0]) distribution", samples);
 /// ```
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Debug)]
 pub struct Dirichlet<F>
 where
@@ -44,6 +45,7 @@ where
 }
 
 /// Error type returned from `Dirchlet::new`.
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Error {
     /// `alpha.len() < 2`.

--- a/rand_distr/src/exponential.rs
+++ b/rand_distr/src/exponential.rs
@@ -124,7 +124,7 @@ where F: Float, Exp1: Distribution<F>
     /// 
     /// # Remarks
     /// 
-    /// For custom types `N` implementing the [`Float`](crate::Float) trait, 
+    /// For custom types `N` implementing the [`Float`] trait,
     /// the case `lambda = 0` is handled as follows: each sample corresponds
     /// to a sample from an `Exp1` multiplied by `1 / 0`. Primitive types 
     /// yield infinity, since `1 / 0 = infinity`.

--- a/rand_distr/src/lib.rs
+++ b/rand_distr/src/lib.rs
@@ -20,6 +20,7 @@
 )]
 #![allow(clippy::neg_cmp_op_on_partial_ord)] // suggested fix too verbose
 #![no_std]
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
 
 //! Generating random samples from probability distributions.
 //!
@@ -107,6 +108,7 @@ pub use self::unit_disc::UnitDisc;
 pub use self::unit_sphere::UnitSphere;
 pub use self::weibull::{Error as WeibullError, Weibull};
 #[cfg(feature = "alloc")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub use rand::distributions::weighted::{WeightedError, WeightedIndex};
 #[cfg(feature = "alloc")]
 pub use weighted_alias::WeightedAliasIndex;
@@ -114,6 +116,7 @@ pub use weighted_alias::WeightedAliasIndex;
 pub use num_traits;
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub mod weighted_alias;
 
 mod binomial;

--- a/rand_distr/src/weighted_alias.rs
+++ b/rand_distr/src/weighted_alias.rs
@@ -63,6 +63,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 /// [`Vec<u32>`]: Vec
 /// [`Uniform<u32>::sample`]: Distribution::sample
 /// [`Uniform<W>::sample`]: Distribution::sample
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub struct WeightedAliasIndex<W: AliasableWeight> {
     aliases: Box<[u32]>,
     no_alias_odds: Box<[W]>,
@@ -269,6 +270,7 @@ where Uniform<W>: Clone
 /// Trait that must be implemented for weights, that are used with
 /// [`WeightedAliasIndex`]. Currently no guarantees on the correctness of
 /// [`WeightedAliasIndex`] are given for custom implementations of this trait.
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub trait AliasableWeight:
     Sized
     + Copy

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -108,7 +108,9 @@ mod bernoulli;
 pub mod uniform;
 
 #[deprecated(since = "0.8.0", note = "use rand::distributions::{WeightedIndex, WeightedError} instead")]
-#[cfg(feature = "alloc")] pub mod weighted;
+#[cfg(feature = "alloc")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+pub mod weighted;
 #[cfg(feature = "alloc")] mod weighted_index;
 
 #[cfg(feature = "serde1")]

--- a/src/distributions/utils.rs
+++ b/src/distributions/utils.rs
@@ -11,7 +11,7 @@
 #[cfg(feature = "simd_support")] use packed_simd::*;
 
 
-pub trait WideningMultiply<RHS = Self> {
+pub(crate) trait WideningMultiply<RHS = Self> {
     type Output;
 
     fn wmul(self, x: RHS) -> Self::Output;

--- a/src/distributions/utils.rs
+++ b/src/distributions/utils.rs
@@ -208,9 +208,6 @@ mod simd_wmul {
     wmul_impl_large! { (u32x16,) u32, 16 }
     wmul_impl_large! { (u64x2, u64x4, u64x8,) u64, 32 }
 }
-#[cfg(all(feature = "simd_support", feature = "nightly"))]
-pub use self::simd_wmul::*;
-
 
 /// Helper trait when dealing with scalar and SIMD floating point types.
 pub(crate) trait FloatSIMDUtils {

--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -77,6 +77,7 @@ use serde::{Serialize, Deserialize};
 /// [`RngCore`]: crate::RngCore
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub struct WeightedIndex<X: SampleUniform + PartialOrd> {
     cumulative_weights: Vec<X>,
     total_weight: X,
@@ -420,6 +421,7 @@ mod test {
 }
 
 /// Error type returned from `WeightedIndex::new`.
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WeightedError {
     /// The provided weight collection contains no items.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(all(feature = "simd_support", feature = "nightly"), feature(stdsimd))]
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![allow(
     clippy::excessive_precision,
     clippy::unreadable_literal,
@@ -177,6 +178,7 @@ use crate::distributions::{Distribution, Standard};
 ///
 /// [`Standard`]: distributions::Standard
 #[cfg(all(feature = "std", feature = "std_rng"))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std_rng")))]
 #[inline]
 pub fn random<T>() -> T
 where Standard: Distribution<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@ use crate::distributions::{Distribution, Standard};
 ///
 /// [`Standard`]: distributions::Standard
 #[cfg(all(feature = "std", feature = "std_rng"))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std_rng")))]
+#[cfg_attr(doc_cfg, doc(cfg(all(feature = "std", feature = "std_rng"))))]
 #[inline]
 pub fn random<T>() -> T
 where Standard: Distribution<T> {

--- a/src/rngs/adapter/read.rs
+++ b/src/rngs/adapter/read.rs
@@ -43,6 +43,7 @@ use rand_core::{impls, Error, RngCore};
 ///
 /// [`OsRng`]: crate::rngs::OsRng
 /// [`try_fill_bytes`]: RngCore::try_fill_bytes
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 #[derive(Debug)]
 pub struct ReadRng<R> {
     reader: R,
@@ -85,6 +86,7 @@ impl<R: Read> RngCore for ReadRng<R> {
 }
 
 /// `ReadRng` error type
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 #[derive(Debug)]
 pub struct ReadError(std::io::Error);
 

--- a/src/rngs/mod.rs
+++ b/src/rngs/mod.rs
@@ -108,4 +108,5 @@ pub mod mock; // Public so we don't export `StepRng` directly, making it a bit
 #[cfg(feature = "std_rng")] pub use self::std::StdRng;
 #[cfg(all(feature = "std", feature = "std_rng"))] pub use self::thread::ThreadRng;
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "getrandom")))]
 #[cfg(feature = "getrandom")] pub use rand_core::OsRng;

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -22,9 +22,6 @@ type Rng = rand_pcg::Pcg32;
 /// It is **not** a good choice when security against prediction or
 /// reproducibility are important.
 ///
-/// This PRNG is **feature-gated**: to use, you must enable the crate feature
-/// `small_rng`.
-///
 /// The algorithm is deterministic but should not be considered reproducible
 /// due to dependence on platform and possible replacement in future
 /// library versions. For a reproducible generator, use a named PRNG from an
@@ -73,6 +70,7 @@ type Rng = rand_pcg::Pcg32;
 /// [`thread_rng`]: crate::thread_rng
 /// [rand_chacha]: https://crates.io/crates/rand_chacha
 /// [rand_pcg]: https://crates.io/crates/rand_pcg
+#[cfg_attr(doc_cfg, doc(cfg(feature = "small_rng")))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SmallRng(Rng);
 

--- a/src/rngs/std.rs
+++ b/src/rngs/std.rs
@@ -32,6 +32,7 @@ pub(crate) use rand_hc::Hc128Core as Core;
 /// the [rand_chacha] crate directly.
 ///
 /// [rand_chacha]: https://crates.io/crates/rand_chacha
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std_rng")))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StdRng(Rng);
 

--- a/src/rngs/thread.rs
+++ b/src/rngs/thread.rs
@@ -53,7 +53,7 @@ const THREAD_RNG_RESEED_THRESHOLD: u64 = 1024 * 64;
 ///
 /// [`ReseedingRng`]: crate::rngs::adapter::ReseedingRng
 /// [`StdRng`]: crate::rngs::StdRng
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std_rng")))]
+#[cfg_attr(doc_cfg, doc(cfg(all(feature = "std", feature = "std_rng"))))]
 #[derive(Copy, Clone, Debug)]
 pub struct ThreadRng {
     // inner raw pointer implies type is neither Send nor Sync
@@ -78,7 +78,7 @@ thread_local!(
 /// `ThreadRng::default()` equivalent.
 ///
 /// For more information see [`ThreadRng`].
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std_rng")))]
+#[cfg_attr(doc_cfg, doc(cfg(all(feature = "std", feature = "std_rng"))))]
 pub fn thread_rng() -> ThreadRng {
     let raw = THREAD_RNG_KEY.with(|t| t.get());
     let nn = NonNull::new(raw).unwrap();

--- a/src/rngs/thread.rs
+++ b/src/rngs/thread.rs
@@ -53,6 +53,7 @@ const THREAD_RNG_RESEED_THRESHOLD: u64 = 1024 * 64;
 ///
 /// [`ReseedingRng`]: crate::rngs::adapter::ReseedingRng
 /// [`StdRng`]: crate::rngs::StdRng
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std_rng")))]
 #[derive(Copy, Clone, Debug)]
 pub struct ThreadRng {
     // inner raw pointer implies type is neither Send nor Sync
@@ -77,6 +78,7 @@ thread_local!(
 /// `ThreadRng::default()` equivalent.
 ///
 /// For more information see [`ThreadRng`].
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std_rng")))]
 pub fn thread_rng() -> ThreadRng {
     let raw = THREAD_RNG_KEY.with(|t| t.get());
     let nn = NonNull::new(raw).unwrap();

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -25,7 +25,9 @@
 //! small performance boost in some cases).
 
 
-#[cfg(feature = "alloc")] pub mod index;
+#[cfg(feature = "alloc")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+pub mod index;
 
 #[cfg(feature = "alloc")] use core::ops::Index;
 
@@ -109,6 +111,7 @@ pub trait SliceRandom {
     /// }
     /// ```
     #[cfg(feature = "alloc")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
     fn choose_multiple<R>(&self, rng: &mut R, amount: usize) -> SliceChooseIter<Self, Self::Item>
     where R: Rng + ?Sized;
 
@@ -136,6 +139,7 @@ pub trait SliceRandom {
     /// [`choose_weighted_mut`]: SliceRandom::choose_weighted_mut
     /// [`distributions::weighted`]: crate::distributions::weighted
     #[cfg(feature = "alloc")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
     fn choose_weighted<R, F, B, X>(
         &self, rng: &mut R, weight: F,
     ) -> Result<&Self::Item, WeightedError>
@@ -163,6 +167,7 @@ pub trait SliceRandom {
     /// [`choose_weighted`]: SliceRandom::choose_weighted
     /// [`distributions::weighted`]: crate::distributions::weighted
     #[cfg(feature = "alloc")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
     fn choose_weighted_mut<R, F, B, X>(
         &mut self, rng: &mut R, weight: F,
     ) -> Result<&mut Self::Item, WeightedError>
@@ -349,6 +354,7 @@ pub trait IteratorRandom: Iterator + Sized {
     /// Complexity is `O(n)` where `n` is the length of the iterator.
     /// For slices, prefer [`SliceRandom::choose_multiple`].
     #[cfg(feature = "alloc")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
     fn choose_multiple<R>(mut self, rng: &mut R, amount: usize) -> Vec<Self::Item>
     where R: Rng + ?Sized {
         let mut reservoir = Vec::with_capacity(amount);
@@ -483,6 +489,7 @@ impl<I> IteratorRandom for I where I: Iterator + Sized {}
 /// This struct is created by
 /// [`SliceRandom::choose_multiple`](trait.SliceRandom.html#tymethod.choose_multiple).
 #[cfg(feature = "alloc")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[derive(Debug)]
 pub struct SliceChooseIter<'a, S: ?Sized + 'a, T: 'a> {
     slice: &'a S,


### PR DESCRIPTION
Starts implementation of #986. @newpavlov / @vks thoughts? I haven't extended this to other crates yet pending feedback.

Note that applying to impls e.g. like this doesn't appear to do anything.
```diff
 // Implement `CryptoRng` for boxed references to an `CryptoRng`.
 #[cfg(feature = "alloc")]
+#[cfg_attr(nightly, doc(cfg(feature = "alloc")))]
 impl<R: CryptoRng + ?Sized> CryptoRng for Box<R> {}
```