### PR TITLE
Fix chacha performance

### DIFF
--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -20,7 +20,7 @@ appveyor = { repository = "rust-random/rand" }
 
 [dependencies]
 rand_core = { path = "../rand_core", version = "0.5" }
-ppv-lite86 = { version = "0.2.8", default-features = false }
+ppv-lite86 = { version = "0.2.8", default-features = false, features = ["simd"] }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This reverts a change from #979 that introduced a massive performance regression by disabling SIMD for `rand_chacha`.

Likely, the behavior of `ppv-lite86` should rather be fixed (https://github.com/cryptocorrosion/cryptocorrosion/issues/35). This change serves as a workaround until a fixed version is available.

Fixes #1017.

cc @kazcw 