### PR TITLE
Restrict `rand::rngs::adapter` to `std`

### DIFF
--- a/src/rngs/adapter/mod.rs
+++ b/src/rngs/adapter/mod.rs
@@ -8,8 +8,9 @@
 
 //! Wrappers / adapters forming RNGs
 
-#[cfg(feature = "std")] mod read;
+mod read;
 mod reseeding;
 
-#[cfg(feature = "std")] pub use self::read::{ReadError, ReadRng};
+pub use self::read::{ReadError, ReadRng};
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 pub use self::reseeding::ReseedingRng;

--- a/src/rngs/adapter/reseeding.rs
+++ b/src/rngs/adapter/reseeding.rs
@@ -279,7 +279,7 @@ where
 }
 
 
-#[cfg(all(unix, feature = "std", not(target_os = "emscripten")))]
+#[cfg(all(unix, not(target_os = "emscripten")))]
 mod fork {
     use core::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Once;
@@ -316,7 +316,7 @@ mod fork {
     }
 }
 
-#[cfg(not(all(unix, feature = "std", not(target_os = "emscripten"))))]
+#[cfg(not(all(unix, not(target_os = "emscripten"))))]
 mod fork {
     pub fn get_fork_counter() -> usize {
         0

--- a/src/rngs/mod.rs
+++ b/src/rngs/mod.rs
@@ -96,7 +96,8 @@
 //! [`rand_xoshiro`]: https://crates.io/crates/rand_xoshiro
 //! [`rng` tag]: https://crates.io/keywords/rng
 
-pub mod adapter;
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+#[cfg(feature = "std")] pub mod adapter;
 
 pub mod mock; // Public so we don't export `StepRng` directly, making it a bit
               // more clear it is intended for testing.


### PR DESCRIPTION
See #911.

@dhardy I'm not sure whether more changes were intended?