### PR TITLE
First attempt at making Pert ser/de

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,6 +42,7 @@ test_script:
   - cargo test --manifest-path rand_core/Cargo.toml --no-default-features
   - cargo test --manifest-path rand_core/Cargo.toml --no-default-features --features=alloc
   - cargo test --manifest-path rand_distr/Cargo.toml
+  - cargo test --manifest-path rand_distr/Cargo.toml --features=serde1
   - cargo test --manifest-path rand_pcg/Cargo.toml --features=serde1
   - cargo test --manifest-path rand_chacha/Cargo.toml
   - cargo test --manifest-path rand_hc/Cargo.toml

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0.103", features = ["derive"], optional = true }
 default = ["std"]
 std = ["alloc", "rand/std"]
 alloc = ["rand/alloc"]
-serde1  = ["serde"]
+serde1  = ["serde", "rand/serde1"]
 
 [dev-dependencies]
 rand_pcg = { version = "0.2", path = "../rand_pcg" }

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1.0.103", features = ["derive"], optional = true }
 default = ["std"]
 std = ["alloc", "rand/std"]
 alloc = ["rand/alloc"]
+serde1  = ["serde"]
 
 [dev-dependencies]
 rand_pcg = { version = "0.2", path = "../rand_pcg" }

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -22,6 +22,7 @@ appveyor = { repository = "rust-random/rand" }
 [dependencies]
 rand = { path = "..", version = "0.7", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
+serde = { version = "1.0.103", features = ["derive"], optional = true }
 
 [features]
 default = ["std"]

--- a/rand_distr/src/exponential.rs
+++ b/rand_distr/src/exponential.rs
@@ -15,7 +15,7 @@ use crate::{ziggurat_tables, Distribution};
 use rand::Rng;
 use core::fmt;
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde1")]
 use serde::{Serialize, Deserialize};
 
 /// Samples floating-point numbers according to the exponential distribution,
@@ -94,7 +94,7 @@ impl Distribution<f64> for Exp1 {
 /// println!("{} is from a Exp(2) distribution", v);
 /// ```
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct Exp<F>
 where F: Float, Exp1: Distribution<F>
 {

--- a/rand_distr/src/exponential.rs
+++ b/rand_distr/src/exponential.rs
@@ -15,6 +15,9 @@ use crate::{ziggurat_tables, Distribution};
 use rand::Rng;
 use core::fmt;
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 /// Samples floating-point numbers according to the exponential distribution,
 /// with rate parameter `λ = 1`. This is equivalent to `Exp::new(1.0)` or
 /// sampling with `-rng.gen::<f64>().ln()`, but faster.
@@ -91,6 +94,7 @@ impl Distribution<f64> for Exp1 {
 /// println!("{} is from a Exp(2) distribution", v);
 /// ```
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Exp<F>
 where F: Float, Exp1: Distribution<F>
 {

--- a/rand_distr/src/gamma.rs
+++ b/rand_distr/src/gamma.rs
@@ -18,7 +18,7 @@ use crate::{Distribution, Exp, Exp1, Open01};
 use rand::Rng;
 use core::fmt;
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde1")]
 use serde::{Serialize, Deserialize};
 
 /// The Gamma distribution `Gamma(shape, scale)` distribution.
@@ -52,7 +52,7 @@ use serde::{Serialize, Deserialize};
 ///       (September 2000), 363-372.
 ///       DOI:[10.1145/358407.358414](https://doi.acm.org/10.1145/358407.358414)
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct Gamma<F>
 where
     F: Float,
@@ -88,7 +88,7 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 enum GammaRepr<F>
 where
     F: Float,
@@ -116,7 +116,7 @@ where
 /// See `Gamma` for sampling from a Gamma distribution with general
 /// shape parameters.
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 struct GammaSmallShape<F>
 where
     F: Float,
@@ -132,7 +132,7 @@ where
 /// See `Gamma` for sampling from a Gamma distribution with general
 /// shape parameters.
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 struct GammaLargeShape<F>
 where
     F: Float,
@@ -514,7 +514,7 @@ where
 /// println!("{} is from a Beta(2, 5) distribution", v);
 /// ```
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct Beta<F>
 where
     F: Float,

--- a/rand_distr/src/gamma.rs
+++ b/rand_distr/src/gamma.rs
@@ -18,6 +18,9 @@ use crate::{Distribution, Exp, Exp1, Open01};
 use rand::Rng;
 use core::fmt;
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 /// The Gamma distribution `Gamma(shape, scale)` distribution.
 ///
 /// The density function of this distribution is
@@ -49,6 +52,7 @@ use core::fmt;
 ///       (September 2000), 363-372.
 ///       DOI:[10.1145/358407.358414](https://doi.acm.org/10.1145/358407.358414)
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Gamma<F>
 where
     F: Float,
@@ -84,6 +88,7 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 enum GammaRepr<F>
 where
     F: Float,
@@ -111,6 +116,7 @@ where
 /// See `Gamma` for sampling from a Gamma distribution with general
 /// shape parameters.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 struct GammaSmallShape<F>
 where
     F: Float,
@@ -126,6 +132,7 @@ where
 /// See `Gamma` for sampling from a Gamma distribution with general
 /// shape parameters.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 struct GammaLargeShape<F>
 where
     F: Float,
@@ -507,6 +514,7 @@ where
 /// println!("{} is from a Beta(2, 5) distribution", v);
 /// ```
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Beta<F>
 where
     F: Float,

--- a/rand_distr/src/pert.rs
+++ b/rand_distr/src/pert.rs
@@ -12,7 +12,7 @@ use crate::{Beta, Distribution, Exp1, Open01, StandardNormal};
 use rand::Rng;
 use core::fmt;
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde1")]
 use serde::{Serialize, Deserialize};
 
 /// The PERT distribution.
@@ -34,7 +34,7 @@ use serde::{Serialize, Deserialize};
 ///
 /// [`Triangular`]: crate::Triangular
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct Pert<F>
 where
     F: Float,

--- a/rand_distr/src/pert.rs
+++ b/rand_distr/src/pert.rs
@@ -12,6 +12,9 @@ use crate::{Beta, Distribution, Exp1, Open01, StandardNormal};
 use rand::Rng;
 use core::fmt;
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 /// The PERT distribution.
 ///
 /// Similar to the [`Triangular`] distribution, the PERT distribution is
@@ -31,6 +34,7 @@ use core::fmt;
 ///
 /// [`Triangular`]: crate::Triangular
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Pert<F>
 where
     F: Float,

--- a/rand_distr/src/weighted_alias.rs
+++ b/rand_distr/src/weighted_alias.rs
@@ -17,6 +17,9 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 use rand::Rng;
 use alloc::{boxed::Box, vec, vec::Vec};
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 /// A distribution using weighted sampling to pick a discretely selected item.
 ///
 /// Sampling a [`WeightedAliasIndex<W>`] distribution returns the index of a randomly
@@ -64,6 +67,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 /// [`Uniform<u32>::sample`]: Distribution::sample
 /// [`Uniform<W>::sample`]: Distribution::sample
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct WeightedAliasIndex<W: AliasableWeight> {
     aliases: Box<[u32]>,
     no_alias_odds: Box<[W]>,

--- a/rand_distr/src/weighted_alias.rs
+++ b/rand_distr/src/weighted_alias.rs
@@ -17,7 +17,7 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 use rand::Rng;
 use alloc::{boxed::Box, vec, vec::Vec};
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde1")]
 use serde::{Serialize, Deserialize};
 
 /// A distribution using weighted sampling to pick a discretely selected item.
@@ -67,7 +67,7 @@ use serde::{Serialize, Deserialize};
 /// [`Uniform<u32>::sample`]: Distribution::sample
 /// [`Uniform<W>::sample`]: Distribution::sample
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct WeightedAliasIndex<W: AliasableWeight> {
     aliases: Box<[u32]>,
     no_alias_odds: Box<[W]>,

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -1405,6 +1405,7 @@ mod tests {
             x: f32,
         }
         #[derive(Clone, Copy, Debug)]
+        #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
         struct UniformMyF32(UniformFloat<f32>);
         impl UniformSampler for UniformMyF32 {
             type X = MyF32;

--- a/utils/ci/script.sh
+++ b/utils/ci/script.sh
@@ -47,6 +47,7 @@ main() {
   $CARGO test $TARGET --manifest-path rand_core/Cargo.toml --no-default-features --features=getrandom
   
   $CARGO test $TARGET --manifest-path rand_distr/Cargo.toml
+  $CARGO test $TARGET --manifest-path rand_distr/Cargo.toml --features=serde1
   $CARGO test $TARGET --manifest-path rand_pcg/Cargo.toml --features=serde1
   $CARGO test $TARGET --manifest-path rand_chacha/Cargo.toml
   $CARGO test $TARGET --manifest-path rand_hc/Cargo.toml


### PR DESCRIPTION
I am having an issue with something being constrained to Copy, but not actually "possible" to be copy. I don't know what to do about this, and I'd love some help.
```
my shell command: rand(rand_distr_serde)> cargo check --package rand_distr --features serde1
```

```rust
    Checking rand_distr v0.2.2 ([redacted]\rand\rand_distr)
error[E0204]: the trait `Copy` may not be implemented for this type
  --> rand_distr\src\gamma.rs:82:17
   |
82 | #[derive(Clone, Copy, Debug)]
   |                 ^^^^
...
86 |     One(Exp<'a, N>),
   |         ---------- this field does not implement `Copy`
   |
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to previous error

For more information about this error, try `rustc --explain E0204`.
error: could not compile `rand_distr`.
```