### PR TITLE
Update getrandom to 0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Implement weighted sampling without replacement (#976, #1013)
 
 ### Changes
+- `getrandom` updated to v0.2
 - `ThreadRng` is no longer `Copy` to enable safe usage within thread-local destructors (see #968)
 - `gen_range(a, b)` was replaced with `gen_range(a..b)`, and `gen_range(a..=b)`
   is supported (#744, #1003). Note that `a` and `b` can no longer be references or SIMD types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Implement weighted sampling without replacement (#976, #1013)
 
 ### Changes
-- `getrandom` updated to v0.2
+- `getrandom` updated to v0.2 (#1041)
 - `ThreadRng` is no longer `Copy` to enable safe usage within thread-local destructors (see #968)
 - `gen_range(a, b)` was replaced with `gen_range(a..b)`, and `gen_range(a..=b)`
   is supported (#744, #1003). Note that `a` and `b` can no longer be references or SIMD types.

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -25,7 +25,7 @@ serde1 = ["serde"] # enables serde for BlockRng wrapper
 
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }
-getrandom = { version = "0.1", optional = true }
+getrandom = { version = "0.2", optional = true }
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/rand_core/src/error.rs
+++ b/rand_core/src/error.rs
@@ -29,13 +29,13 @@ impl Error {
     /// Codes at or above this point can be used by users to define their own
     /// custom errors.
     ///
-    /// This is identical to `getrandom::Error::CUSTOM_START`.
+    /// This is identical to [`getrandom::Error::CUSTOM_START`](https://docs.rs/getrandom/latest/getrandom/struct.Error.html#associatedconstant.CUSTOM_START).
     pub const CUSTOM_START: u32 = (1 << 31) + (1 << 30);
     /// Codes below this point represent OS Errors (i.e. positive i32 values).
     /// Codes at or above this point, but below [`Error::CUSTOM_START`] are
     /// reserved for use by the `rand` and `getrandom` crates.
     ///
-    /// This is identical to `getrandom::Error::INTERNAL_START`.
+    /// This is identical to [`getrandom::Error::INTERNAL_START`](https://docs.rs/getrandom/latest/getrandom/struct.Error.html#associatedconstant.INTERNAL_START).
     pub const INTERNAL_START: u32 = 1 << 31;
 
     /// Construct from any type supporting `std::error::Error`

--- a/rand_core/src/error.rs
+++ b/rand_core/src/error.rs
@@ -28,10 +28,14 @@ pub struct Error {
 impl Error {
     /// Codes at or above this point can be used by users to define their own
     /// custom errors.
+    ///
+    /// This is identical to `getrandom::Error::CUSTOM_START`.
     pub const CUSTOM_START: u32 = (1 << 31) + (1 << 30);
     /// Codes below this point represent OS Errors (i.e. positive i32 values).
     /// Codes at or above this point, but below [`Error::CUSTOM_START`] are
     /// reserved for use by the `rand` and `getrandom` crates.
+    ///
+    /// This is identical to `getrandom::Error::INTERNAL_START`.
     pub const INTERNAL_START: u32 = 1 << 31;
 
     /// Construct from any type supporting `std::error::Error`
@@ -208,3 +212,14 @@ impl fmt::Display for ErrorCode {
 
 #[cfg(feature = "std")]
 impl std::error::Error for ErrorCode {}
+
+#[cfg(test)]
+mod test {
+    #[cfg(feature = "getrandom")]
+    #[test]
+    fn test_error_codes() {
+        // Make sure the values are the same as in `getrandom`.
+        assert_eq!(super::Error::CUSTOM_START, getrandom::Error::CUSTOM_START);
+        assert_eq!(super::Error::INTERNAL_START, getrandom::Error::INTERNAL_START);
+    }
+}


### PR DESCRIPTION
Per discussion in #889, we are keeping getrandom optional. Users can now specify custom RNG handlers for `getrandom` on any target. However, not all users will want `OsRng`, so `getrandom` needs to be optional.

Signed-off-by: Joe Richey <joerichey@google.com>