### PR TITLE
Try to clarify the documentation of LogNormal::new

### DIFF
--- a/rand_distr/src/normal.rs
+++ b/rand_distr/src/normal.rs
@@ -188,6 +188,14 @@ where F: Float, StandardNormal: Distribution<F>
 {
     /// Construct a new `LogNormal` distribution with the given mean
     /// and standard deviation of the logarithm of the distribution.
+    ///
+    /// Note that the parameters are not the resulting mean and standard 
+    /// deviation of the actual samples returned by the LogNormal 
+    /// distribution. Instead, they are the mean and standard deviation 
+    /// of the *logarithm* of those returned values.
+    ///
+    /// Equivalently, the parameters mean and std_dev are the μ(mu) 
+    /// and σ(sigma) parameters of the LogNormal distribution.
     #[inline]
     pub fn new(mean: F, std_dev: F) -> Result<LogNormal<F>, Error> {
         if !(std_dev >= F::zero()) {


### PR DESCRIPTION
It may be that I am the only one who expected the 'mean' parameter of LogNormal::new() to be the actual mean of the resulting LogNormal distribution :-). Reading up a bit more on the subject, I realize that the definition used is probably reasonable, but I thought maybe we could clarify it a bit?

Feel free to just disregard this PR if you don't think the clarification is necessary (or if it's wrong).