### PR TITLE
Disentangle `nightly` and `simd_support` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Improve treatment of rounding errors in `WeightedIndex::update_weights` (#956)
 - `StdRng`: Switch from ChaCha20 to ChaCha12 for better performance (#1028)
 - `SmallRng`: Replace PCG algorithm with xoshiro{128,256}++ (#1038)
+- The `nightly` feature no longer implies the `simd_support` feature
 
 ## [0.7.3] - 2020-01-10
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Improve treatment of rounding errors in `WeightedIndex::update_weights` (#956)
 - `StdRng`: Switch from ChaCha20 to ChaCha12 for better performance (#1028)
 - `SmallRng`: Replace PCG algorithm with xoshiro{128,256}++ (#1038)
-- The `nightly` feature no longer implies the `simd_support` feature
+- The `nightly` feature no longer implies the `simd_support` feature (#1048)
 
 ## [0.7.3] - 2020-01-10
 ### Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ appveyor = { repository = "rust-random/rand" }
 [features]
 # Meta-features:
 default = ["std", "std_rng"]
-nightly = ["simd_support"] # enables all features requiring nightly rust
+nightly = [] # enables performance optimizations requiring nightly rust
 serde1 = ["serde"]
 
 # Option (enabled by default): without "std" rand uses libcore; this option

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ Additionally, these features configure Rand:
 -   `simd_support` (experimental) enables sampling of SIMD values
     (uniformly random SIMD integers and floats), requiring nightly Rust
 
-Note that the `simd_support` feature (and to a lesser extent the `nightly`
-feature) may be broken on some nightly Rust versions and cause `rand` to not
-compile.
+Note that nightly features are not stable and therefore not all library and
+compiler versions will be compatible. This is especially true of Rand's
+experimental `simd_support` feature.
 
 Rand supports limited functionality in `no_std` mode (enabled via
 `default-features = false`). In this case, `OsRng` and `from_entropy` are

--- a/README.md
+++ b/README.md
@@ -103,9 +103,13 @@ Optionally, the following dependencies can be enabled:
 Additionally, these features configure Rand:
 
 -   `small_rng` enables inclusion of the `SmallRng` PRNG
--   `nightly` enables all experimental features
+-   `nightly` enables some optimizations requiring nightly Rust
 -   `simd_support` (experimental) enables sampling of SIMD values
-    (uniformly random SIMD integers and floats)
+    (uniformly random SIMD integers and floats), requiring nightly Rust
+
+Note that the `simd_support` feature (and to a lesser extent the `nightly`
+feature) may be broken on some nightly Rust versions and cause `rand` to not
+compile.
 
 Rand supports limited functionality in `no_std` mode (enabled via
 `default-features = false`). In this case, `OsRng` and `from_entropy` are

--- a/src/distributions/integer.rs
+++ b/src/distributions/integer.rs
@@ -10,9 +10,10 @@
 
 use crate::distributions::{Distribution, Standard};
 use crate::Rng;
-#[cfg(all(target_arch = "x86", feature = "nightly"))] use core::arch::x86::*;
-#[cfg(all(target_arch = "x86_64", feature = "nightly"))]
-use core::arch::x86_64::*;
+#[cfg(all(target_arch = "x86", feature = "simd_support"))]
+use core::arch::x86::{__m64, __m128i, __m256i};
+#[cfg(all(target_arch = "x86_64", feature = "simd_support"))]
+use core::arch::x86_64::{__m64, __m128i, __m256i};
 #[cfg(not(target_os = "emscripten"))] use core::num::NonZeroU128;
 use core::num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
 #[cfg(feature = "simd_support")] use packed_simd::*;
@@ -155,7 +156,6 @@ simd_impl!(256, u8x32, i8x32, u16x16, i16x16, u32x8, i32x8, u64x4, i64x4,);
 simd_impl!(512, u8x64, i8x64, u16x32, i16x32, u32x16, i32x16, u64x8, i64x8,);
 #[cfg(all(
     feature = "simd_support",
-    feature = "nightly",
     any(target_arch = "x86", target_arch = "x86_64")
 ))]
 simd_impl!((__m64, u8x8), (__m128i, u8x16), (__m256i, u8x32),);

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -561,7 +561,7 @@ uniform_int_impl! { usize, usize, usize }
 #[cfg(not(target_os = "emscripten"))]
 uniform_int_impl! { u128, u128, u128 }
 
-#[cfg(all(feature = "simd_support", feature = "nightly"))]
+#[cfg(feature = "simd_support")]
 macro_rules! uniform_simd_int_impl {
     ($ty:ident, $unsigned:ident, $u_scalar:ident) => {
         // The "pick the largest zone that can fit in an `u32`" optimization
@@ -668,7 +668,7 @@ macro_rules! uniform_simd_int_impl {
     };
 }
 
-#[cfg(all(feature = "simd_support", feature = "nightly"))]
+#[cfg(feature = "simd_support")]
 uniform_simd_int_impl! {
     (u64x2, i64x2),
     (u64x4, i64x4),
@@ -676,7 +676,7 @@ uniform_simd_int_impl! {
     u64
 }
 
-#[cfg(all(feature = "simd_support", feature = "nightly"))]
+#[cfg(feature = "simd_support")]
 uniform_simd_int_impl! {
     (u32x2, i32x2),
     (u32x4, i32x4),
@@ -685,7 +685,7 @@ uniform_simd_int_impl! {
     u32
 }
 
-#[cfg(all(feature = "simd_support", feature = "nightly"))]
+#[cfg(feature = "simd_support")]
 uniform_simd_int_impl! {
     (u16x2, i16x2),
     (u16x4, i16x4),
@@ -695,7 +695,7 @@ uniform_simd_int_impl! {
     u16
 }
 
-#[cfg(all(feature = "simd_support", feature = "nightly"))]
+#[cfg(feature = "simd_support")]
 uniform_simd_int_impl! {
     (u8x2, i8x2),
     (u8x4, i8x4),
@@ -1194,7 +1194,7 @@ mod tests {
         #[cfg(not(target_os = "emscripten"))]
         t!(i128, u128);
 
-        #[cfg(all(feature = "simd_support", feature = "nightly"))]
+        #[cfg(feature = "simd_support")]
         {
             t!(u8x2, u8x4, u8x8, u8x16, u8x32, u8x64 => u8);
             t!(i8x2, i8x4, i8x8, i8x16, i8x32, i8x64 => i8);

--- a/src/distributions/utils.rs
+++ b/src/distributions/utils.rs
@@ -143,7 +143,7 @@ wmul_impl_usize! { u32 }
 #[cfg(target_pointer_width = "64")]
 wmul_impl_usize! { u64 }
 
-#[cfg(all(feature = "simd_support", feature = "nightly"))]
+#[cfg(feature = "simd_support")]
 mod simd_wmul {
     use super::*;
     #[cfg(target_arch = "x86")] use core::arch::x86::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 #![deny(missing_debug_implementations)]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 #![no_std]
-#![cfg_attr(all(feature = "simd_support", feature = "nightly"), feature(stdsimd))]
+#![cfg_attr(feature = "simd_support", feature(stdsimd))]
 #![cfg_attr(feature = "nightly", feature(slice_partition_at_index))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![allow(


### PR DESCRIPTION
Now `nightly` can be used without implying `simd_support`. This
hopefully makes the `nightly` feature more stable and improves
compilation time if `simd_support` is not required.

The documentation and changelog were updated accordingly.

Fixes #1047.