### PR TITLE
Add Iterator::choose_stable()

### DIFF
--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -292,10 +292,11 @@ pub trait IteratorRandom: Iterator + Sized {
     /// available, complexity is `O(n)` where `n` is the iterator length.
     /// Partial hints (where `lower > 0`) also improve performance.
     ///
-    /// Note that the output values and the the number of RNG samples used
+    /// Note that the output values and the number of RNG samples used
     /// depends on size hints. In particular, `Iterator` combinators that don't
     /// change the values yielded but change the size hints may result in
-    /// `choose` returning different elements.
+    /// `choose` returning different elements. If you want consistent results
+    /// and RNG usage consider using [`choose_stable`].
     fn choose<R>(mut self, rng: &mut R) -> Option<Self::Item>
     where R: Rng + ?Sized {
         let (mut lower, mut upper) = self.size_hint();


### PR DESCRIPTION
This function is similar to Iterator::choose() except that given a PRNG and any iterator of the same length it will always select the same element and make the same calls to the PRNG.

Closes https://github.com/rust-random/rand/issues/1051