### PR TITLE
Add geometric and hypergeometric distributions

### DIFF
--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- New `Geo`metric and `Hypergeometric` distributions (#1062)
+- New `Geometric`, `StandardGeometric` and `Hypergeometric` distributions (#1062)
 - New `Beta` sampling algorithm for improved performance and accuracy (#1000)
 - `Normal` and `LogNormal` now support `from_mean_cv` and `from_zscore` (#1044)
 - Variants of `NormalError` changed (#1044)

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- New `Geo`metric and `Hypergeometric` distributions (#1062)
 - New `Beta` sampling algorithm for improved performance and accuracy (#1000)
 - `Normal` and `LogNormal` now support `from_mean_cv` and `from_zscore` (#1044)
 - Variants of `NormalError` changed (#1044)

--- a/rand_distr/benches/distributions.rs
+++ b/rand_distr/benches/distributions.rs
@@ -136,6 +136,8 @@ distr_int!(distr_weighted_alias_method_u32, usize, WeightedAliasIndex::new(vec![
 distr_int!(distr_weighted_alias_method_f64, usize, WeightedAliasIndex::new(vec![1.0f64, 0.001, 1.0/3.0, 4.01, 0.0, 3.3, 22.0, 0.001]).unwrap());
 distr_int!(distr_weighted_alias_method_large_set, usize, WeightedAliasIndex::new((0..10000).rev().chain(1..10001).collect()).unwrap());
 
+distr_int!(distr_geometric, u64, Geometric::new(0.5).unwrap());
+distr_int!(distr_standard_geometric, u64, StandardGeometric);
 
 #[bench]
 fn dist_iter(b: &mut Bencher) {

--- a/rand_distr/src/geometric.rs
+++ b/rand_distr/src/geometric.rs
@@ -75,7 +75,7 @@ impl Distribution<u64> for Geometric
             return failures;
         }
         
-        if self.p == 0.0 { return u64::MAX; }
+        if self.p == 0.0 { return core::u64::MAX; }
 
         // Based on the algorithm presented in section 3 of
         // Karl Bringmann and Tobias Friedrich (July 2013) - Exact and Efficient
@@ -106,7 +106,7 @@ impl Distribution<u64> for Geometric
         // choose M uniformly from [0, 2^k), but reject with probability (1 - p)^M
         let m = loop {
             let m = rng.gen::<u64>() & ((1 << k) - 1);
-            let p_reject = if m <= i32::MAX as u64 {
+            let p_reject = if m <= core::i32::MAX as u64 {
                 (1.0 - self.p).powi(m as i32)
             } else {
                 (1.0 - self.p).powf(m as f64)
@@ -128,7 +128,7 @@ impl Distribution<u64> for Geometric
 /// 
 /// See [`Geometric`](crate::Geometric) for the general geometric distribution.
 /// 
-/// Implemented via iterated [Rng::gen::<u64>().leading_ones()].
+/// Implemented via iterated [Rng::gen::<u64>().leading_zeros()].
 /// 
 /// # Example
 /// ```
@@ -145,7 +145,7 @@ impl Distribution<u64> for StandardGeometric {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u64 {
         let mut result = 0;
         loop {
-            let x = rng.gen::<u64>().leading_ones() as u64;
+            let x = rng.gen::<u64>().leading_zeros() as u64;
             result += x;
             if x < 64 { break; }
         }
@@ -201,7 +201,7 @@ mod test {
 
     #[test]
     fn test_standard_geometric() {
-        let mut rng = crate::test::rng(54321);
+        let mut rng = crate::test::rng(654321);
 
         let distr = StandardGeometric;
         let expected_mean = 1.0;

--- a/rand_distr/src/geometric.rs
+++ b/rand_distr/src/geometric.rs
@@ -5,7 +5,7 @@ use num_traits::Float;
 use rand::Rng;
 use core::fmt;
 
-/// The geometric distribution `Geo(p)`.
+/// The geometric distribution `Geometric(p)`.
 /// 
 /// This is the probability distribution of the number of failures before the
 /// first success in a series of Bernoulli trials. It has the density function
@@ -17,20 +17,20 @@ use core::fmt;
 /// # Example
 ///
 /// ```
-/// use rand_distr::{Geo, Distribution};
+/// use rand_distr::{Geometric, Distribution};
 ///
-/// let geo = Geo::new(0.5).unwrap();
-/// let x = geo.sample(&mut rand::thread_rng());
-/// println!("{} is from a Geo(0.5) distribution", x);
+/// let geo = Geometric::new(0.5).unwrap();
+/// let v = geo.sample(&mut rand::thread_rng());
+/// println!("{} is from a Geometric(0.5) distribution", v);
 /// ```
 #[derive(Copy, Clone, Debug)]
-pub struct Geo<F>
+pub struct Geometric<F>
 where F: Float, Exp1: Distribution<F>
 {
     exp: Exp<F>
 }
 
-/// Error type returned from `Geo::new`.
+/// Error type returned from `Geometric::new`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Error {
     /// `p < 0 || p > 1` or `nan`
@@ -48,7 +48,7 @@ impl fmt::Display for Error {
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
-impl<F> Geo<F>
+impl<F> Geometric<F>
 where F: Float, Exp1: Distribution<F>
 {
     /// Construct a new `Geo` with the given shape parameter `p`
@@ -56,13 +56,13 @@ where F: Float, Exp1: Distribution<F>
     pub fn new(p: F) -> Result<Self, Error> {
         let lambda = -F::ln(F::one() - p);
         match Exp::new(lambda) {
-            Ok(exp) => Ok(Geo { exp }),
+            Ok(exp) => Ok(Geometric { exp }),
             Err(_) => Err(Error::InvalidProbability)
         }
     }
 }
 
-impl<F> Distribution<u64> for Geo<F>
+impl<F> Distribution<u64> for Geometric<F>
 where F: Float, Exp1: Distribution<F>
 {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u64 {
@@ -77,18 +77,18 @@ mod test {
 
     #[test]
     fn test_geo_invalid_p() {
-        assert!(Geo::new(core::f64::NAN).is_err());
-        assert!(Geo::new(core::f64::INFINITY).is_err());
-        assert!(Geo::new(core::f64::NEG_INFINITY).is_err());
+        assert!(Geometric::new(core::f64::NAN).is_err());
+        assert!(Geometric::new(core::f64::INFINITY).is_err());
+        assert!(Geometric::new(core::f64::NEG_INFINITY).is_err());
 
-        assert!(Geo::new(-0.5).is_err());
-        assert!(Geo::new(0.0).is_ok());
-        assert!(Geo::new(1.0).is_ok());
-        assert!(Geo::new(2.0).is_err());
+        assert!(Geometric::new(-0.5).is_err());
+        assert!(Geometric::new(0.0).is_ok());
+        assert!(Geometric::new(1.0).is_ok());
+        assert!(Geometric::new(2.0).is_err());
     }
 
     fn test_geo_mean_and_variance<R: Rng>(p: f64, rng: &mut R) {
-        let distr = Geo::new(p).unwrap();
+        let distr = Geometric::new(p).unwrap();
 
         let expected_mean = (1.0 - p) / p;
         let expected_variance = (1.0 - p) / (p * p);

--- a/rand_distr/src/geometric.rs
+++ b/rand_distr/src/geometric.rs
@@ -1,0 +1,119 @@
+//! The geometric distribution.
+
+use crate::{Distribution, Exp, Exp1};
+use num_traits::Float;
+use rand::Rng;
+use std::fmt;
+
+/// The geometric distribution `Geo(p)`.
+/// 
+/// This is the probability distribution of the number of failures before the
+/// first success in a series of Bernoulli trials. It has the density function
+/// `f(k) = (1 - p)^k p` for `k >= 0`, where `p` is the probability of success
+/// on each trial.
+/// 
+/// This is the discrete analogue of the [exponential distribution](crate::Exp).
+///
+/// # Example
+///
+/// ```
+/// use rand_distr::{Geo, Distribution};
+///
+/// let geo = Geo::new(0.5).unwrap();
+/// let x = geo.sample(&mut rand::thread_rng());
+/// println!("{} is from a Geo(0.5) distribution", x);
+/// ```
+#[derive(Copy, Clone, Debug)]
+pub struct Geo<F>
+where F: Float, Exp1: Distribution<F>
+{
+    exp: Exp<F>
+}
+
+/// Error type returned from `Geo::new`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Error {
+    /// `p < 0 || p > 1` or `nan`
+    InvalidProbability,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::InvalidProbability => "p is NaN or outside the interval [0, 1] in geometric distribution",
+        })
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+impl<F> Geo<F>
+where F: Float, Exp1: Distribution<F>
+{
+    /// Construct a new `Geo` with the given shape parameter `p`
+    /// (probablity of success on each trial).
+    pub fn new(p: F) -> Result<Self, Error> {
+        let lambda = -F::ln(F::one() - p);
+        match Exp::new(lambda) {
+            Ok(exp) => Ok(Geo { exp }),
+            Err(_) => Err(Error::InvalidProbability)
+        }
+    }
+}
+
+impl<F> Distribution<u64> for Geo<F>
+where F: Float, Exp1: Distribution<F>
+{
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u64 {
+        let f = self.exp.sample(rng).floor();
+        num_traits::NumCast::from(f).unwrap_or(u64::max_value())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_geo_invalid_p() {
+        assert!(Geo::new(f64::NAN).is_err());
+        assert!(Geo::new(f64::INFINITY).is_err());
+        assert!(Geo::new(f64::NEG_INFINITY).is_err());
+
+        assert!(Geo::new(-0.5).is_err());
+        assert!(Geo::new(0.0).is_ok());
+        assert!(Geo::new(1.0).is_ok());
+        assert!(Geo::new(2.0).is_err());
+    }
+
+    fn test_geo_mean_and_variance<R: Rng>(p: f64, rng: &mut R) {
+        let distr = Geo::new(p).unwrap();
+
+        let expected_mean = (1.0 - p) / p;
+        let expected_variance = (1.0 - p) / (p * p);
+
+        let mut results = [0.0; 1000];
+        for i in results.iter_mut() {
+            *i = distr.sample(rng) as f64;
+        }
+
+        let mean = results.iter().sum::<f64>() / results.len() as f64;
+        assert!((mean as f64 - expected_mean).abs() < expected_mean / 20.0);
+
+        let variance =
+            results.iter().map(|x| (x - mean) * (x - mean)).sum::<f64>() / results.len() as f64;
+        assert!((variance - expected_variance).abs() < expected_variance / 5.0);
+    }
+
+    #[test]
+    fn test_geometric() {
+        let mut rng = crate::test::rng(12345);
+
+        test_geo_mean_and_variance(0.10, &mut rng);
+        test_geo_mean_and_variance(0.25, &mut rng);
+        test_geo_mean_and_variance(0.50, &mut rng);
+        test_geo_mean_and_variance(0.75, &mut rng);
+        test_geo_mean_and_variance(0.90, &mut rng);
+    }
+}

--- a/rand_distr/src/geometric.rs
+++ b/rand_distr/src/geometric.rs
@@ -3,7 +3,7 @@
 use crate::{Distribution, Exp, Exp1};
 use num_traits::Float;
 use rand::Rng;
-use std::fmt;
+use core::fmt;
 
 /// The geometric distribution `Geo(p)`.
 /// 

--- a/rand_distr/src/geometric.rs
+++ b/rand_distr/src/geometric.rs
@@ -77,9 +77,9 @@ mod test {
 
     #[test]
     fn test_geo_invalid_p() {
-        assert!(Geo::new(f64::NAN).is_err());
-        assert!(Geo::new(f64::INFINITY).is_err());
-        assert!(Geo::new(f64::NEG_INFINITY).is_err());
+        assert!(Geo::new(core::f64::NAN).is_err());
+        assert!(Geo::new(core::f64::INFINITY).is_err());
+        assert!(Geo::new(core::f64::NEG_INFINITY).is_err());
 
         assert!(Geo::new(-0.5).is_err());
         assert!(Geo::new(0.0).is_ok());

--- a/rand_distr/src/hypergeometric.rs
+++ b/rand_distr/src/hypergeometric.rs
@@ -4,6 +4,22 @@ use crate::Distribution;
 use rand::Rng;
 use core::fmt;
 
+#[derive(Clone, Copy, Debug)]
+enum SamplingMethod {
+    InverseTransform{ initial_p: f64, initial_x: i64 },
+    RejectionAcceptance{
+        m: f64,
+        a: f64,
+        lambda_l: f64,
+        lambda_r: f64,
+        x_l: f64,
+        x_r: f64,
+        p1: f64,
+        p2: f64,
+        p3: f64
+    },
+}
+
 /// The hypergeometric distribution `Hypergeometric(N, K, n)`.
 /// 
 /// This is the distribution of successes in samples of size `n` drawn without
@@ -27,14 +43,19 @@ use core::fmt;
 /// ```
 #[derive(Copy, Clone, Debug)]
 pub struct Hypergeometric {
-    total_population_size: u64,
-    population_with_feature: u64,
-    sample_size: u64,
+    n1: u64,
+    n2: u64,
+    k: u64,
+    offset_x: i64,
+    sign_x: i64,
+    sampling_method: SamplingMethod,
 }
 
 /// Error type returned from `Hypergeometric::new`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Error {
+    /// `total_population_size` is too large, causing floating point underflow.
+    PopulationTooLarge,
     /// `population_with_feature > total_population_size`.
     ProbabilityTooLarge,
     /// `sample_size > total_population_size`.
@@ -44,24 +65,10 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
+            Error::PopulationTooLarge => "total_population_size is too large causing underflow in geometric distribution",
             Error::ProbabilityTooLarge => "population_with_feature > total_population_size in geometric distribution",
             Error::SampleSizeTooLarge => "sample_size > total_population_size in geometric distribution",
         })
-    }
-}
-
-impl Hypergeometric {
-    /// Constructs a new `Hypergeometric` with the given shape parameters.
-    pub fn new(total_population_size: u64, population_with_feature: u64, sample_size: u64) -> Result<Self, Error> {
-        if population_with_feature > total_population_size {
-            return Err(Error::ProbabilityTooLarge);
-        }
-
-        if sample_size > total_population_size {
-            return Err(Error::SampleSizeTooLarge);
-        }
-
-        Ok(Hypergeometric { total_population_size, population_with_feature, sample_size })
     }
 }
 
@@ -99,34 +106,45 @@ fn fraction_of_products_of_factorials(numerator: (u64, u64), denominator: (u64, 
 }
 
 fn ln_of_factorial(v: f64) -> f64 {
+    // the paper calls for ln(v!), but also wants to pass in fractions,
+    // so we need to use Stirling's approximation to fill in the gaps:
     v * v.ln() - v
 }
 
-impl Distribution<u64> for Hypergeometric {
+impl Hypergeometric {
+    /// Constructs a new `Hypergeometric` with the given shape parameters.
     #[allow(clippy::many_single_char_names)] // Same names as in the reference.
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u64 {
+    pub fn new(total_population_size: u64, population_with_feature: u64, sample_size: u64) -> Result<Self, Error> {
+        if population_with_feature > total_population_size {
+            return Err(Error::ProbabilityTooLarge);
+        }
+
+        if sample_size > total_population_size {
+            return Err(Error::SampleSizeTooLarge);
+        }
+
         // set-up constants as function of original parameters
-        let n = self.total_population_size;
+        let n = total_population_size;
         let (mut sign_x, mut offset_x) = (1, 0);
         let (n1, n2) = {
             // switch around success and failure states if necessary to ensure n1 <= n2
-            let population_without_feature = n - self.population_with_feature;
-            if self.population_with_feature > population_without_feature {
+            let population_without_feature = n - population_with_feature;
+            if population_with_feature > population_without_feature {
                 sign_x = -1;
-                offset_x = self.sample_size as i64;
-                (population_without_feature, self.population_with_feature)
+                offset_x = sample_size as i64;
+                (population_without_feature, population_with_feature)
             } else {
-                (self.population_with_feature, population_without_feature)
+                (population_with_feature, population_without_feature)
             }
         };
         // when sampling more than half the total population, take the smaller
         // group as sampled instead (we can then return n1-x instead):
-        let k = if self.sample_size <= n / 2 {
-            self.sample_size
+        let k = if sample_size <= n / 2 {
+            sample_size
         } else {
             offset_x += n1 as i64 * sign_x;
             sign_x *= -1;
-            n - self.sample_size
+            n - sample_size
         };
 
         // Algorithm H2PE has bounded runtime only if `M - max(0, k-n2) >= 10`,
@@ -139,44 +157,37 @@ impl Distribution<u64> for Hypergeometric {
         // https://www.researchgate.net/publication/233212638
         const HIN_THRESHOLD: f64 = 10.0;
         let m = ((k + 1) as f64 * (n1 + 1) as f64 / (n + 2) as f64).floor();
-        if m - f64::max(0.0, k as f64 - n2 as f64) < HIN_THRESHOLD {
-            let (mut p, mut x) = if k < n2 {
+        let sampling_method = if m - f64::max(0.0, k as f64 - n2 as f64) < HIN_THRESHOLD {
+            let (initial_p, initial_x) = if k < n2 {
                 (fraction_of_products_of_factorials((n2, n - k), (n, n2 - k)), 0)
             } else {
-                (fraction_of_products_of_factorials((n1, k), (n, k - n2)), k - n2)
+                (fraction_of_products_of_factorials((n1, k), (n, k - n2)), (k - n2) as i64)
             };
 
-            let mut u = rng.gen::<f64>();
-            while u > p && x < k { // the paper erroneously uses `until n < p`, which doesn't make any sense
-                u -= p;
-                p *= ((n1 as i64 - x as i64) * (k as i64 - x as i64)) as f64;
-                p /= ((x as i64 + 1) * (n2 as i64 - k as i64 + 1 + x as i64)) as f64;
-                x += 1;
+            if initial_p <= 0.0 || !initial_p.is_finite() {
+                return Err(Error::PopulationTooLarge);
             }
 
-            return (offset_x + sign_x * x as i64) as u64;
-        }
+            SamplingMethod::InverseTransform { initial_p, initial_x }
+        } else {
+            let a = ln_of_factorial(m) +
+                ln_of_factorial(n1 as f64 - m) +
+                ln_of_factorial(k as f64 - m) +
+                ln_of_factorial((n2 - k) as f64 + m);
 
-        // setup constants used only for H2PE
-        let a = ln_of_factorial(m) +
-            ln_of_factorial(n1 as f64 - m) +
-            ln_of_factorial(k as f64 - m) +
-            ln_of_factorial((n2 - k) as f64 + m);
-        let (k_l, k_r, lambda_l, lambda_r, x_l, x_r, p1, p2, p3);
-        {
             let numerator = (n - k) as f64 * k as f64 * n1 as f64 * n2 as f64;
             let denominator = (n - 1) as f64 * n as f64 * n as f64;
             let d = 1.5 * (numerator / denominator).sqrt() + 0.5;
 
-            x_l = m - d + 0.5;
-            x_r = m + d + 0.5;
+            let x_l = m - d + 0.5;
+            let x_r = m + d + 0.5;
 
-            k_l = f64::exp(a -
+            let k_l = f64::exp(a -
                 ln_of_factorial(x_l) -
                 ln_of_factorial(n1 as f64 - x_l) -
                 ln_of_factorial(k as f64 - x_l) -
                 ln_of_factorial((n2 - k) as f64 + x_l));
-            k_r = f64::exp(a -
+            let k_r = f64::exp(a -
                 ln_of_factorial(x_r - 1.0) -
                 ln_of_factorial(n1 as f64 - x_r + 1.0) -
                 ln_of_factorial(k as f64 - x_r + 1.0) -
@@ -184,131 +195,158 @@ impl Distribution<u64> for Hypergeometric {
             
             let numerator = x_l * ((n2 - k) as f64 + x_l);
             let denominator = (n1 as f64 - x_l + 1.0) * (k as f64 - x_l + 1.0);
-            lambda_l = -ln_of_factorial(numerator / denominator);
+            let lambda_l = -ln_of_factorial(numerator / denominator);
 
             let numerator = (n1 as f64 - x_r + 1.0) * (k as f64 - x_r + 1.0);
             let denominator = x_r * ((n2 - k) as f64 + x_r);
-            lambda_r = -ln_of_factorial(numerator / denominator);
+            let lambda_r = -ln_of_factorial(numerator / denominator);
 
             // the paper literally gives `p2 + kL/lambdaL` where it (probably)
             // should have been `p2 <- p1 + kL/lambdaL`; another print error?!
-            p1 = 2.0 * d;
-            p2 = p1 + k_l / lambda_l;
-            p3 = p2 + k_r / lambda_r;
-        }
+            let p1 = 2.0 * d;
+            let p2 = p1 + k_l / lambda_l;
+            let p3 = p2 + k_r / lambda_r;
 
-        // begin rejection sampling
-        let x = loop {
-            let (y, v) = loop {
-                let u = rng.gen::<f64>() * p3; // for selecting the region
-                let v = rng.gen::<f64>(); // for the accept/reject decision
-    
-                if u <= p1 {
-                    // Region 1, centrel bell
-                    let y = (x_l + u).floor();
-                    break (y, v);
-                } else if u <= p2 {
-                    // Region 2, left exponential tail
-                    let y = (x_l + v.ln() / lambda_l).floor(); // TODO: use an `Exp` instead
-                    if y as i64 >= i64::max(0, k as i64 - n2 as i64) {
-                        let v = v * (u - p1) * lambda_l;
-                        break (y, v);
-                    }
-                } else {
-                    // Region 3, right exponential tail
-                    let y = (x_r - v.ln() / lambda_r).floor(); // TODO: use an `Exp` instead
-                    if y as u64 >= u64::min(n1, k) {
-                        let v = v * (u - p2) * lambda_r;
-                        break (y, v);
-                    }
+            SamplingMethod::RejectionAcceptance {
+                m, a, lambda_l, lambda_r, x_l, x_r, p1, p2, p3
+            }
+        };
+
+        Ok(Hypergeometric { n1, n2, k, sign_x, offset_x, sampling_method })
+    }
+}
+
+impl Distribution<u64> for Hypergeometric {
+    #[allow(clippy::many_single_char_names)] // Same names as in the reference.
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u64 {
+        use SamplingMethod::*;
+
+        let Hypergeometric { n1, n2, k, sign_x, offset_x, sampling_method } = *self;
+        let x = match sampling_method {
+            InverseTransform { initial_p: mut p, initial_x: mut x } => {
+                let mut u = rng.gen::<f64>();
+                while u > p && x < k as i64 { // the paper erroneously uses `until n < p`, which doesn't make any sense
+                    u -= p;
+                    p *= ((n1 as i64 - x as i64) * (k as i64 - x as i64)) as f64;
+                    p /= ((x as i64 + 1) * (n2 as i64 - k as i64 + 1 + x as i64)) as f64;
+                    x += 1;
                 }
-            };
-
-            // Step 4: Acceptance/Rejection Comparison
-            if m < 100.0 || y <= 50.0 {
-                // Step 4.1: evaluate f(y) via recursive relationship
-                let mut f = 1.0;
-                if m < y {
-                    for i in (m as u64 + 1)..=(y as u64) {
-                        f *= (n1 - i + 1) as f64 * (k - i + 1) as f64;
-                        f /= i as f64 * (n2 - k + i) as f64;
+                x
+            },
+            RejectionAcceptance { m, a, lambda_l, lambda_r, x_l, x_r, p1, p2, p3 } => {
+                loop {
+                    let (y, v) = loop {
+                        let u = rng.gen::<f64>() * p3; // for selecting the region
+                        let v = rng.gen::<f64>(); // for the accept/reject decision
+            
+                        if u <= p1 {
+                            // Region 1, centrel bell
+                            let y = (x_l + u).floor();
+                            break (y, v);
+                        } else if u <= p2 {
+                            // Region 2, left exponential tail
+                            let y = (x_l + v.ln() / lambda_l).floor(); // TODO: use an `Exp` instead
+                            if y as i64 >= i64::max(0, k as i64 - n2 as i64) {
+                                let v = v * (u - p1) * lambda_l;
+                                break (y, v);
+                            }
+                        } else {
+                            // Region 3, right exponential tail
+                            let y = (x_r - v.ln() / lambda_r).floor(); // TODO: use an `Exp` instead
+                            if y as u64 >= u64::min(n1, k) {
+                                let v = v * (u - p2) * lambda_r;
+                                break (y, v);
+                            }
+                        }
+                    };
+        
+                    // Step 4: Acceptance/Rejection Comparison
+                    if m < 100.0 || y <= 50.0 {
+                        // Step 4.1: evaluate f(y) via recursive relationship
+                        let mut f = 1.0;
+                        if m < y {
+                            for i in (m as u64 + 1)..=(y as u64) {
+                                f *= (n1 - i + 1) as f64 * (k - i + 1) as f64;
+                                f /= i as f64 * (n2 - k + i) as f64;
+                            }
+                        } else {
+                            for i in (y as u64 + 1)..=(m as u64) {
+                                f *= i as f64 * (n2 - k + i) as f64;
+                                f /= (n1 - i) as f64 * (k - i) as f64;
+                            }
+                        }
+        
+                        if v < f { break y as i64; }
+                    } else {
+                        // Step 4.2: Squeezing
+                        let y1 = y + 1.0;
+                        let ym = y - m;
+                        let yn = n1 as f64 - y + 1.0;
+                        let yk = k as f64 - y + 1.0;
+                        let nk = n2 as f64 - k as f64 + y1;
+                        let r = -ym / y1;
+                        let s = ym / yn;
+                        let t = ym / yk;
+                        let e = -ym / nk;
+                        let g = yn * yk / (y1 * nk) - 1.0;
+                        let dg = if g < 0.0 {
+                            1.0 + g
+                        } else {
+                            g
+                        };
+                        let gu = g * (1.0 + g * (-0.5 + g / 3.0));
+                        let gl = gu - g.powi(4) / (4.0 * dg);
+                        let xm = m + 0.5;
+                        let xn = n1 as f64 - m + 0.5;
+                        let xk = k as f64 - m + 0.5;
+                        let nm = n2 as f64 - k as f64 + xm;
+                        let ub = xm * r * (1.0 + r * (-0.5 + r / 3.0)) +
+                            xn * s * (1.0 + s * (-0.5 + s / 3.0)) +
+                            xk * t * (1.0 + t * (-0.5 + t / 3.0)) +
+                            nm * e * (1.0 + e * (-0.5 + e / 3.0)) +
+                            y * gu - m * gl + 0.0034;
+                        let av = v.ln();
+                        if av > ub { continue; }
+                        let dr = if r < 0.0 {
+                            xm * r.powi(4) / (1.0 + r)
+                        } else {
+                            xm * r.powi(4)
+                        };
+                        let ds = if s < 0.0 {
+                            xn * s.powi(4) / (1.0 + s)
+                        } else {
+                            xn * s.powi(4)
+                        };
+                        let dt = if t < 0.0 {
+                            xk * t.powi(4) / (1.0 + t)
+                        } else {
+                            xk * t.powi(4)
+                        };
+                        let de = if e < 0.0 {
+                            nm * e.powi(4) / (1.0 + e)
+                        } else {
+                            nm * e.powi(4)
+                        };
+        
+                        if av < ub - 0.25*(dr + ds + dt + de) + (y + m)*(gl - gu) - 0.0078 {
+                            break y as i64;
+                        }
+        
+                        // Step 4.3: Final Acceptance/Rejection Test
+                        let av_critical = a -
+                            ln_of_factorial(y) -
+                            ln_of_factorial(n1 as f64 - y) - 
+                            ln_of_factorial(k as f64 - y) - 
+                            ln_of_factorial((n2 - k) as f64 + y);
+                        if v.ln() <= av_critical {
+                            break y as i64;
+                        }
                     }
-                } else {
-                    for i in (y as u64 + 1)..=(m as u64) {
-                        f *= i as f64 * (n2 - k + i) as f64;
-                        f /= (n1 - i) as f64 * (k - i) as f64;
-                    }
-                }
-
-                if v < f { break y as i64; }
-            } else {
-                // Step 4.2: Squeezing
-                let y1 = y + 1.0;
-                let ym = y - m;
-                let yn = n1 as f64 - y + 1.0;
-                let yk = k as f64 - y + 1.0;
-                let nk = n2 as f64 - k as f64 + y1;
-                let r = -ym / y1;
-                let s = ym / yn;
-                let t = ym / yk;
-                let e = -ym / nk;
-                let g = yn * yk / (y1 * nk) - 1.0;
-                let dg = if g < 0.0 {
-                    1.0 + g
-                } else {
-                    g
-                };
-                let gu = g * (1.0 + g * (-0.5 + g / 3.0));
-                let gl = gu - g.powi(4) / (4.0 * dg);
-                let xm = m + 0.5;
-                let xn = n1 as f64 - m + 0.5;
-                let xk = k as f64 - m + 0.5;
-                let nm = n2 as f64 - k as f64 + xm;
-                let ub = xm * r * (1.0 + r * (-0.5 + r / 3.0)) +
-                    xn * s * (1.0 + s * (-0.5 + s / 3.0)) +
-                    xk * t * (1.0 + t * (-0.5 + t / 3.0)) +
-                    nm * e * (1.0 + e * (-0.5 + e / 3.0)) +
-                    y * gu - m * gl + 0.0034;
-                let av = v.ln();
-                if av > ub { continue; }
-                let dr = if r < 0.0 {
-                    xm * r.powi(4) / (1.0 + r)
-                } else {
-                    xm * r.powi(4)
-                };
-                let ds = if s < 0.0 {
-                    xn * s.powi(4) / (1.0 + s)
-                } else {
-                    xn * s.powi(4)
-                };
-                let dt = if t < 0.0 {
-                    xk * t.powi(4) / (1.0 + t)
-                } else {
-                    xk * t.powi(4)
-                };
-                let de = if e < 0.0 {
-                    nm * e.powi(4) / (1.0 + e)
-                } else {
-                    nm * e.powi(4)
-                };
-
-                if av < ub - 0.25*(dr + ds + dt + de) + (y + m)*(gl - gu) - 0.0078 {
-                    break y as i64;
-                }
-
-                // Step 4.3: Final Acceptance/Rejection Test
-                let av_critical = a -
-                    ln_of_factorial(y) -
-                    ln_of_factorial(n1 as f64 - y) - 
-                    ln_of_factorial(k as f64 - y) - 
-                    ln_of_factorial((n2 - k) as f64 + y);
-                if v.ln() <= av_critical {
-                    break y as i64;
                 }
             }
         };
-        
-        (offset_x + sign_x * x as i64) as u64
+
+        (offset_x + sign_x * x) as u64
     }
 }
 

--- a/rand_distr/src/hypergeometric.rs
+++ b/rand_distr/src/hypergeometric.rs
@@ -2,7 +2,7 @@
 
 use crate::Distribution;
 use rand::Rng;
-use std::fmt;
+use core::fmt;
 
 /// The hypergeometric distribution `Hypergeometric(N, K, n)`.
 /// 

--- a/rand_distr/src/hypergeometric.rs
+++ b/rand_distr/src/hypergeometric.rs
@@ -195,11 +195,11 @@ impl Hypergeometric {
             
             let numerator = x_l * ((n2 - k) as f64 + x_l);
             let denominator = (n1 as f64 - x_l + 1.0) * (k as f64 - x_l + 1.0);
-            let lambda_l = -ln_of_factorial(numerator / denominator);
+            let lambda_l = -((numerator / denominator).ln());
 
             let numerator = (n1 as f64 - x_r + 1.0) * (k as f64 - x_r + 1.0);
             let denominator = x_r * ((n2 - k) as f64 + x_r);
-            let lambda_r = -ln_of_factorial(numerator / denominator);
+            let lambda_r = -((numerator / denominator).ln());
 
             // the paper literally gives `p2 + kL/lambdaL` where it (probably)
             // should have been `p2 <- p1 + kL/lambdaL`; another print error?!
@@ -245,15 +245,15 @@ impl Distribution<u64> for Hypergeometric {
                             break (y, v);
                         } else if u <= p2 {
                             // Region 2, left exponential tail
-                            let y = (x_l + v.ln() / lambda_l).floor(); // TODO: use an `Exp` instead
+                            let y = (x_l + v.ln() / lambda_l).floor();
                             if y as i64 >= i64::max(0, k as i64 - n2 as i64) {
                                 let v = v * (u - p1) * lambda_l;
                                 break (y, v);
                             }
                         } else {
                             // Region 3, right exponential tail
-                            let y = (x_r - v.ln() / lambda_r).floor(); // TODO: use an `Exp` instead
-                            if y as u64 >= u64::min(n1, k) {
+                            let y = (x_r - v.ln() / lambda_r).floor();
+                            if y as u64 <= u64::min(n1, k) {
                                 let v = v * (u - p2) * lambda_r;
                                 break (y, v);
                             }
@@ -379,11 +379,11 @@ mod test {
         }
 
         let mean = results.iter().sum::<f64>() / results.len() as f64;
-        assert!((mean as f64 - expected_mean).abs() < expected_mean / 20.0);
+        assert!((mean as f64 - expected_mean).abs() < expected_mean / 50.0);
 
         let variance =
             results.iter().map(|x| (x - mean) * (x - mean)).sum::<f64>() / results.len() as f64;
-        assert!((variance - expected_variance).abs() < expected_variance / 2.6);
+        assert!((variance - expected_variance).abs() < expected_variance / 10.0);
     }
 
     #[test]

--- a/rand_distr/src/hypergeometric.rs
+++ b/rand_distr/src/hypergeometric.rs
@@ -142,7 +142,12 @@ impl Hypergeometric {
             }
         };
         // when sampling more than half the total population, take the smaller
-        // group as sampled instead (we can then return n1-x instead):
+        // group as sampled instead (we can then return n1-x instead).
+        // 
+        // Note: the boundary condition given in the paper is `sample_size < n / 2`;
+        // we're deviating here, because when n is even, it doesn't matter whether
+        // we switch here or not, but when n is odd `n/2 < n - n/2`, so switching
+        // when `k == n/2`, we'd actually be taking the _larger_ group as sampled.
         let k = if sample_size <= n / 2 {
             sample_size
         } else {

--- a/rand_distr/src/hypergeometric.rs
+++ b/rand_distr/src/hypergeometric.rs
@@ -1,0 +1,140 @@
+//! The hypergeometric distribution.
+
+use crate::Distribution;
+use rand::Rng;
+use std::fmt;
+
+/// The hypergeometric distribution `Hypergeometric(N, K, n)`.
+/// 
+/// This is the distribution of successes in samples of size `n` drawn without
+/// replacement from a population of size `N` containing `K` success states.
+/// It has the density function:
+/// `f(k) = binomial(K, k) * binomial(N-K, n-k) / binomial(N, n)`,
+/// where `binomial(a, b) = a! / (b! * (a - b)!)`.
+/// 
+/// The [binomial distribution](crate::Binomial) is the analagous distribution
+/// for sampling with replacement. It is a good approximation when the population
+/// size is much larger than the sample size.
+/// 
+/// # Example
+/// 
+/// ```
+/// use rand_distr::{Distribution, Hypergeometric};
+///
+/// let hypergeo = Hypergeometric::new(60, 24, 7).unwrap();
+/// let v = hypergeo.sample(&mut rand::thread_rng());
+/// println!("{} is from a hypergeometric distribution", v);
+/// ```
+#[derive(Copy, Clone, Debug)]
+pub struct Hypergeometric {
+    total_population_size: u64,
+    population_with_feature: u64,
+    sample_size: u64,
+}
+
+/// Error type returned from `Hypergeometric::new`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Error {
+    /// `population_with_feature > total_population_size`.
+    ProbabilityTooLarge,
+    /// `sample_size > total_population_size`.
+    SampleSizeTooLarge,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::ProbabilityTooLarge => "population_with_feature > total_population_size in geometric distribution",
+            Error::SampleSizeTooLarge => "sample_size > total_population_size in geometric distribution",
+        })
+    }
+}
+
+impl Hypergeometric {
+    /// Constructs a new `Hypergeometric` with the given shape parameters.
+    pub fn new(total_population_size: u64, population_with_feature: u64, sample_size: u64) -> Result<Self, Error> {
+        if population_with_feature > total_population_size {
+            return Err(Error::ProbabilityTooLarge);
+        }
+
+        if sample_size > total_population_size {
+            return Err(Error::SampleSizeTooLarge);
+        }
+
+        Ok(Hypergeometric { total_population_size, population_with_feature, sample_size })
+    }
+}
+
+impl Distribution<u64> for Hypergeometric {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u64 {
+        // This is exact, but very naive; execution time is linear in `sample_size`.
+        // I've found references to a better rejection-based method called H2PEC
+        // (published in 1988 by Kachitvichyanukul and Schmeiser), but no existing
+        // implementations, pseudo-code or even an informal explanation of it, so...
+
+        let mut n = self.total_population_size;
+        let mut k = self.population_with_feature;
+
+        let mut result = 0;
+        for _ in 0..self.sample_size {
+            let x = rng.gen_range(0..n);
+            
+            if x < k {
+                k -= 1;
+                result += 1;
+            }
+
+            n -= 1;
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_hypergeometric_invalid_params() {
+        assert!(Hypergeometric::new(100, 101, 5).is_err());
+        assert!(Hypergeometric::new(100, 10, 101).is_err());
+        assert!(Hypergeometric::new(100, 101, 101).is_err());
+        assert!(Hypergeometric::new(100, 10, 5).is_ok());
+    }
+
+    fn test_hypergeometric_mean_and_variance<R: Rng>(n: u64, k: u64, s: u64, rng: &mut R)
+    {
+        let distr = Hypergeometric::new(n, k, s).unwrap();
+
+        let expected_mean = s as f64 * k as f64 / n as f64;
+        let expected_variance = {
+            let numerator = (s * k * (n - k) * (n - s)) as f64;
+            let denominator = (n * n * (n - 1)) as f64;
+            numerator / denominator
+        };
+
+        let mut results = [0.0; 1000];
+        for i in results.iter_mut() {
+            *i = distr.sample(rng) as f64;
+        }
+
+        let mean = results.iter().sum::<f64>() / results.len() as f64;
+        assert!((mean as f64 - expected_mean).abs() < expected_mean / 50.0);
+
+        let variance =
+            results.iter().map(|x| (x - mean) * (x - mean)).sum::<f64>() / results.len() as f64;
+        assert!((variance - expected_variance).abs() < expected_variance / 10.0);
+    }
+
+    #[test]
+    fn test_hypergeometric() {
+        let mut rng = crate::test::rng(737);
+
+        test_hypergeometric_mean_and_variance(1000, 500, 100, &mut rng);
+        test_hypergeometric_mean_and_variance(500, 400, 30, &mut rng);
+        test_hypergeometric_mean_and_variance(100, 30, 7, &mut rng);
+        test_hypergeometric_mean_and_variance(60, 24, 7, &mut rng);
+        test_hypergeometric_mean_and_variance(40, 17, 7, &mut rng);
+    }
+}

--- a/rand_distr/src/lib.rs
+++ b/rand_distr/src/lib.rs
@@ -46,7 +46,7 @@
 //!   - [`Cauchy`] distribution
 //! - Related to Bernoulli trials (yes/no events, with a given probability):
 //!   - [`Binomial`] distribution
-//!   - [`Geo`]metric distribution
+//!   - [`Geometric`] distribution
 //! - Related to positive real-valued quantities that grow exponentially
 //!   (e.g. prices, incomes, populations):
 //!   - [`LogNormal`] distribution
@@ -96,7 +96,7 @@ pub use self::gamma::{
     Beta, BetaError, ChiSquared, ChiSquaredError, Error as GammaError, FisherF, FisherFError,
     Gamma, StudentT,
 };
-pub use self::geometric::{Error as GeoError, Geo};
+pub use self::geometric::{Error as GeoError, Geometric};
 pub use self::hypergeometric::{Error as HyperGeoError, Hypergeometric};
 pub use self::inverse_gaussian::{InverseGaussian, Error as InverseGaussianError};
 pub use self::normal::{Error as NormalError, LogNormal, Normal, StandardNormal};

--- a/rand_distr/src/lib.rs
+++ b/rand_distr/src/lib.rs
@@ -94,6 +94,7 @@ pub use self::gamma::{
     Beta, BetaError, ChiSquared, ChiSquaredError, Error as GammaError, FisherF, FisherFError,
     Gamma, StudentT,
 };
+pub use self::geometric::{Error as GeoError, Geo};
 pub use self::inverse_gaussian::{InverseGaussian, Error as InverseGaussianError};
 pub use self::normal::{Error as NormalError, LogNormal, Normal, StandardNormal};
 pub use self::normal_inverse_gaussian::{NormalInverseGaussian, Error as NormalInverseGaussianError};
@@ -172,6 +173,7 @@ mod cauchy;
 mod dirichlet;
 mod exponential;
 mod gamma;
+mod geometric;
 mod inverse_gaussian;
 mod normal;
 mod normal_inverse_gaussian;

--- a/rand_distr/src/lib.rs
+++ b/rand_distr/src/lib.rs
@@ -95,6 +95,7 @@ pub use self::gamma::{
     Gamma, StudentT,
 };
 pub use self::geometric::{Error as GeoError, Geo};
+pub use self::hypergeometric::{Error as HyperGeoError, Hypergeometric};
 pub use self::inverse_gaussian::{InverseGaussian, Error as InverseGaussianError};
 pub use self::normal::{Error as NormalError, LogNormal, Normal, StandardNormal};
 pub use self::normal_inverse_gaussian::{NormalInverseGaussian, Error as NormalInverseGaussianError};
@@ -174,6 +175,7 @@ mod dirichlet;
 mod exponential;
 mod gamma;
 mod geometric;
+mod hypergeometric;
 mod inverse_gaussian;
 mod normal;
 mod normal_inverse_gaussian;

--- a/rand_distr/src/lib.rs
+++ b/rand_distr/src/lib.rs
@@ -47,6 +47,7 @@
 //! - Related to Bernoulli trials (yes/no events, with a given probability):
 //!   - [`Binomial`] distribution
 //!   - [`Geometric`] distribution
+//!   - [`Hypergeometric`] distribution
 //! - Related to positive real-valued quantities that grow exponentially
 //!   (e.g. prices, incomes, populations):
 //!   - [`LogNormal`] distribution
@@ -74,7 +75,6 @@
 //! - Misc. distributions
 //!   - [`InverseGaussian`] distribution
 //!   - [`NormalInverseGaussian`] distribution
-//!   - [`Hypergeometric`] distribution
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -96,7 +96,7 @@ pub use self::gamma::{
     Beta, BetaError, ChiSquared, ChiSquaredError, Error as GammaError, FisherF, FisherFError,
     Gamma, StudentT,
 };
-pub use self::geometric::{Error as GeoError, Geometric};
+pub use self::geometric::{Error as GeoError, Geometric, StandardGeometric};
 pub use self::hypergeometric::{Error as HyperGeoError, Hypergeometric};
 pub use self::inverse_gaussian::{InverseGaussian, Error as InverseGaussianError};
 pub use self::normal::{Error as NormalError, LogNormal, Normal, StandardNormal};

--- a/rand_distr/src/lib.rs
+++ b/rand_distr/src/lib.rs
@@ -46,6 +46,7 @@
 //!   - [`Cauchy`] distribution
 //! - Related to Bernoulli trials (yes/no events, with a given probability):
 //!   - [`Binomial`] distribution
+//!   - [`Geo`]metric distribution
 //! - Related to positive real-valued quantities that grow exponentially
 //!   (e.g. prices, incomes, populations):
 //!   - [`LogNormal`] distribution
@@ -73,6 +74,7 @@
 //! - Misc. distributions
 //!   - [`InverseGaussian`] distribution
 //!   - [`NormalInverseGaussian`] distribution
+//!   - [`Hypergeometric`] distribution
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/rand_distr/src/normal.rs
+++ b/rand_distr/src/normal.rs
@@ -334,12 +334,12 @@ mod tests {
     #[test]
     fn test_log_normal_cv() {
         let lnorm = LogNormal::from_mean_cv(0.0, 0.0).unwrap();
-        assert_eq!((lnorm.norm.mean, lnorm.norm.std_dev), (-std::f64::INFINITY, 0.0));
+        assert_eq!((lnorm.norm.mean, lnorm.norm.std_dev), (-core::f64::INFINITY, 0.0));
 
         let lnorm = LogNormal::from_mean_cv(1.0, 0.0).unwrap();
         assert_eq!((lnorm.norm.mean, lnorm.norm.std_dev), (0.0, 0.0));
 
-        let e = std::f64::consts::E;
+        let e = core::f64::consts::E;
         let lnorm = LogNormal::from_mean_cv(e.sqrt(), (e - 1.0).sqrt()).unwrap();
         assert_almost_eq!(lnorm.norm.mean, 0.0, 2e-16);
         assert_almost_eq!(lnorm.norm.std_dev, 1.0, 2e-16);

--- a/rand_distr/tests/value_stability.rs
+++ b/rand_distr/tests/value_stability.rs
@@ -38,9 +38,9 @@ fn binominal_stability() {
 fn geometric_stability() {
     test_samples(464, StandardGeometric, &[0, 2, 0, 2, 10, 0, 0, 0, 0, 2, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2]);
     
-    test_samples(464, Geometric::new(0.5).unwrap(), &[0, 1, 2, 4, 0, 2, 0, 1]);
-    test_samples(464, Geometric::new(0.05).unwrap(), &[2, 24, 36, 62, 0, 28, 6, 26]);
-    test_samples(464, Geometric::new(0.95).unwrap(), &[0, 0, 0, 1, 0, 0, 0, 0]);
+    test_samples(464, Geometric::new(0.5).unwrap(), &[2, 1, 1, 0, 0, 1, 0, 1]);
+    test_samples(464, Geometric::new(0.05).unwrap(), &[24, 51, 81, 67, 27, 11, 7, 6]);
+    test_samples(464, Geometric::new(0.95).unwrap(), &[0, 0, 0, 0, 1, 0, 0, 0]);
 
     // expect non-random behaviour for series of pre-determined trials
     test_samples(464, Geometric::new(0.0).unwrap(), &[u64::max_value(); 100][..]);

--- a/rand_distr/tests/value_stability.rs
+++ b/rand_distr/tests/value_stability.rs
@@ -49,7 +49,7 @@ fn geometric_stability() {
 fn hypergeometric_stability() {
     // We have multiple code paths based on the distribution's mode and sample_size
     test_samples(7221, Hypergeometric::new(99, 33, 8).unwrap(), &[4, 3, 2, 2, 3, 2, 3, 1]); // Algorithm HIN
-    test_samples(7221, Hypergeometric::new(100, 50, 50).unwrap(), &[23, 27, 25, 26, 21, 24, 20, 22]); // Algorithm H2PE
+    test_samples(7221, Hypergeometric::new(100, 50, 50).unwrap(), &[23, 27, 26, 27, 22, 24, 31, 22]); // Algorithm H2PE
 }
 
 #[test]

--- a/rand_distr/tests/value_stability.rs
+++ b/rand_distr/tests/value_stability.rs
@@ -49,7 +49,7 @@ fn geometric_stability() {
 fn hypergeometric_stability() {
     // We have multiple code paths based on the distribution's mode and sample_size
     test_samples(7221, Hypergeometric::new(99, 33, 8).unwrap(), &[4, 3, 2, 2, 3, 2, 3, 1]); // Algorithm HIN
-    test_samples(7221, Hypergeometric::new(100, 50, 50).unwrap(), &[0]); // Algorithm H2PE
+    test_samples(7221, Hypergeometric::new(100, 50, 50).unwrap(), &[23, 27, 25, 26, 21, 24, 20, 22]); // Algorithm H2PE
 }
 
 #[test]

--- a/rand_distr/tests/value_stability.rs
+++ b/rand_distr/tests/value_stability.rs
@@ -36,13 +36,13 @@ fn binominal_stability() {
 
 #[test]
 fn geometric_stability() {
-    test_samples(464, Geo::new(0.5).unwrap(), &[0, 1, 2, 4, 0, 2, 0, 1]);
-    test_samples(464, Geo::new(0.05).unwrap(), &[2, 24, 36, 62, 0, 28, 6, 26]);
-    test_samples(464, Geo::new(0.95).unwrap(), &[0, 0, 0, 1, 0, 0, 0, 0]);
+    test_samples(464, Geometric::new(0.5).unwrap(), &[0, 1, 2, 4, 0, 2, 0, 1]);
+    test_samples(464, Geometric::new(0.05).unwrap(), &[2, 24, 36, 62, 0, 28, 6, 26]);
+    test_samples(464, Geometric::new(0.95).unwrap(), &[0, 0, 0, 1, 0, 0, 0, 0]);
 
     // expect non-random behaviour for series of pre-determined trials
-    test_samples(464, Geo::new(0.0).unwrap(), &[u64::max_value(); 100][..]);
-    test_samples(464, Geo::new(1.0).unwrap(), &[0; 100][..]);
+    test_samples(464, Geometric::new(0.0).unwrap(), &[u64::max_value(); 100][..]);
+    test_samples(464, Geometric::new(1.0).unwrap(), &[0; 100][..]);
 }
 
 #[test]

--- a/rand_distr/tests/value_stability.rs
+++ b/rand_distr/tests/value_stability.rs
@@ -47,7 +47,9 @@ fn geometric_stability() {
 
 #[test]
 fn hypergeometric_stability() {
-    test_samples(7221, Hypergeometric::new(99, 33, 8).unwrap(), &[4, 3, 2, 3, 3]);
+    // We have multiple code paths based on the distribution's mode and sample_size
+    test_samples(7221, Hypergeometric::new(99, 33, 8).unwrap(), &[4, 3, 2, 2, 3, 2, 3, 1]); // Algorithm HIN
+    test_samples(7221, Hypergeometric::new(100, 50, 50).unwrap(), &[0]); // Algorithm H2PE
 }
 
 #[test]

--- a/rand_distr/tests/value_stability.rs
+++ b/rand_distr/tests/value_stability.rs
@@ -36,7 +36,7 @@ fn binominal_stability() {
 
 #[test]
 fn geometric_stability() {
-    test_samples(464, StandardGeometric, &[0, 2, 0, 2, 10, 0, 0, 0, 0, 2, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2]);
+    test_samples(464, StandardGeometric, &[3, 0, 1, 0, 0, 3, 2, 1, 2, 0]);
     
     test_samples(464, Geometric::new(0.5).unwrap(), &[2, 1, 1, 0, 0, 1, 0, 1]);
     test_samples(464, Geometric::new(0.05).unwrap(), &[24, 51, 81, 67, 27, 11, 7, 6]);

--- a/rand_distr/tests/value_stability.rs
+++ b/rand_distr/tests/value_stability.rs
@@ -46,6 +46,11 @@ fn geometric_stability() {
 }
 
 #[test]
+fn hypergeometric_stability() {
+    test_samples(7221, Hypergeometric::new(99, 33, 8).unwrap(), &[4, 3, 2, 3, 3]);
+}
+
+#[test]
 fn unit_ball_stability() {
     test_samples(2, UnitBall, &[
         [0.018035709265959987f64, -0.4348771383120438, -0.07982762085055706],

--- a/rand_distr/tests/value_stability.rs
+++ b/rand_distr/tests/value_stability.rs
@@ -34,6 +34,16 @@ fn binominal_stability() {
     test_samples(353, Binomial::new(2000, 0.6).unwrap(), &[1194, 1208, 1192, 1210]);
 }
 
+#[test]
+fn geometric_stability() {
+    test_samples(464, Geo::new(0.5).unwrap(), &[0, 1, 2, 4, 0, 2, 0, 1]);
+    test_samples(464, Geo::new(0.05).unwrap(), &[2, 24, 36, 62, 0, 28, 6, 26]);
+    test_samples(464, Geo::new(0.95).unwrap(), &[0, 0, 0, 1, 0, 0, 0, 0]);
+
+    // expect non-random behaviour for series of pre-determined trials
+    test_samples(464, Geo::new(0.0).unwrap(), &[u64::max_value(); 100][..]);
+    test_samples(464, Geo::new(1.0).unwrap(), &[0; 100][..]);
+}
 
 #[test]
 fn unit_ball_stability() {

--- a/rand_distr/tests/value_stability.rs
+++ b/rand_distr/tests/value_stability.rs
@@ -36,6 +36,8 @@ fn binominal_stability() {
 
 #[test]
 fn geometric_stability() {
+    test_samples(464, StandardGeometric, &[0, 2, 0, 2, 10, 0, 0, 0, 0, 2, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2]);
+    
     test_samples(464, Geometric::new(0.5).unwrap(), &[0, 1, 2, 4, 0, 2, 0, 1]);
     test_samples(464, Geometric::new(0.05).unwrap(), &[2, 24, 36, 62, 0, 28, 6, 26]);
     test_samples(464, Geometric::new(0.95).unwrap(), &[0, 0, 0, 1, 0, 0, 0, 0]);


### PR DESCRIPTION
I needed both these distributions recently (for procedural generation and numerical simulation, respectively), and I figured I might as well contribute them for other people's convenience.

I use the obvious sampling algorithm for the hypergeometric distribution, which is exact, but runs in `O(n)` time and requires `n` uniform variates. That was good enough for my purposes, but a better, rejection-based algorithm called `H2PEC` apparently exists, I just couldn't find any material explaining it. The original 1988 paper seems to be lost to time, save for the first two pages. If someone can point me in the right direction, I'd be willing to do the rest of the work there.

I also touched rand_distr/src/normal.rs so as to run the tests with `--no-default-features`.