### PR TITLE
Replace a non-breaking space with a normal space

### DIFF
--- a/src/rng.rs
+++ b/src/rng.rs
@@ -22,7 +22,7 @@ use core::{mem, slice};
 ///
 /// # Generic usage
 ///
-/// The basic pattern is `fn foo<R: Rng + ?Sized>(rng: &mut R)`. Some
+/// The basic pattern is `fn foo<R: Rng + ?Sized>(rng: &mut R)`. Some
 /// things are worth noting here:
 ///
 /// - Since `Rng: RngCore` and every `RngCore` implements `Rng`, it makes no


### PR DESCRIPTION
Seems like a non-breaking space snuck in by accident:
<img width="644" alt="Screen Shot 2020-11-18 at 6 52 00 PM" src="https://user-images.githubusercontent.com/17372886/99615000-861dc880-29cf-11eb-9073-2e59b8b23a5c.png">
