### PR TITLE
Implement SampleUniform for char

### DIFF
--- a/rand_distr/src/lib.rs
+++ b/rand_distr/src/lib.rs
@@ -80,6 +80,10 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+// This is used for doc links:
+#[allow(unused)]
+use rand::Rng;
+
 pub use rand::distributions::{
     uniform, Alphanumeric, Bernoulli, BernoulliError, DistIter, Distribution, Open01, OpenClosed01,
     Standard, Uniform,

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -359,11 +359,11 @@ where
         }
 
         // Partially sort the array to find the `amount` elements with the greatest
-        // keys. Do this by using `partition_at_index` to put the elements with
+        // keys. Do this by using `select_nth_unstable` to put the elements with
         // the *smallest* keys at the beginning of the list in `O(n)` time, which
         // provides equivalent information about the elements with the *greatest* keys.
         let (_, mid, greater)
-            = candidates.partition_at_index(length.as_usize() - amount.as_usize());
+            = candidates.select_nth_unstable(length.as_usize() - amount.as_usize());
 
         let mut result: Vec<N> = Vec::with_capacity(amount.as_usize());
         result.push(mid.index);

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -296,7 +296,7 @@ pub trait IteratorRandom: Iterator + Sized {
     /// depends on size hints. In particular, `Iterator` combinators that don't
     /// change the values yielded but change the size hints may result in
     /// `choose` returning different elements. If you want consistent results
-    /// and RNG usage consider using [`choose_stable`].
+    /// and RNG usage consider using [`IteratorRandom::choose_stable`].
     fn choose<R>(mut self, rng: &mut R) -> Option<Self::Item>
     where R: Rng + ?Sized {
         let (mut lower, mut upper) = self.size_hint();
@@ -364,6 +364,8 @@ pub trait IteratorRandom: Iterator + Sized {
     /// constructing elements where possible, however the selection and `rng`
     /// calls are the same in the face of this optimization. If you want to
     /// force every element to be created regardless call `.inspect(|e| ())`.
+    ///
+    /// [`choose`]: IteratorRandom::choose
     fn choose_stable<R>(mut self, rng: &mut R) -> Option<Self::Item>
     where R: Rng + ?Sized {
         let mut consumed = 0;


### PR DESCRIPTION
This enables `rng.gen_range('A'..='Z')`.

I don't recall why we didn't do this before but I don't see any real issues. Thoughts @vks / @newpavlov?