### PR TITLE
Prepare rand_core 0.6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             toolchain: nightly
-            variant: minimal
+            variant: minimal_versions
 
     steps:
       - uses: actions/checkout@v2
@@ -67,8 +67,8 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           override: true
       - run: ${{ matrix.deps }}
-      - name: Maybe minimal
-        if: ${{ matrix.variant == 'minimal' }}
+      - name: Maybe minimal versions
+        if: ${{ matrix.variant == 'minimal_versions' }}
         run: cargo generate-lockfile -Z minimal-versions
       - name: Maybe nightly
         if: ${{ matrix.toolchain == 'nightly' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ rand_chacha = { path = "rand_chacha", version = "0.2.3", default-features = fals
 rand_hc = { path = "rand_hc", version = "0.3.0", optional = true }
 
 [dev-dependencies]
-rand_pcg = { path = "rand_pcg", version = "0.2" }
+rand_pcg = { path = "rand_pcg", version = "0.3.0" }
 # Only for benches:
 rand_hc = { path = "rand_hc", version = "0.3.0" }
 # Only to test serde1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ members = [
 ]
 
 [dependencies]
-rand_core = { path = "rand_core", version = "0.5.1" }
+rand_core = { path = "rand_core", version = "0.6.0" }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,12 +71,12 @@ libc = { version = "0.2.22", optional = true, default-features = false }
 [target.'cfg(not(target_os = "emscripten"))'.dependencies]
 rand_chacha = { path = "rand_chacha", version = "0.2.3", default-features = false, optional = true }
 [target.'cfg(target_os = "emscripten")'.dependencies]
-rand_hc = { path = "rand_hc", version = "0.2.1", optional = true }
+rand_hc = { path = "rand_hc", version = "0.3.0", optional = true }
 
 [dev-dependencies]
 rand_pcg = { path = "rand_pcg", version = "0.2" }
 # Only for benches:
-rand_hc = { path = "rand_hc", version = "0.2" }
+rand_hc = { path = "rand_hc", version = "0.3.0" }
 # Only to test serde1
 bincode = "1.2.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ libc = { version = "0.2.22", optional = true, default-features = false }
 # Emscripten does not support 128-bit integers, which are used by ChaCha code.
 # We work around this by using a different RNG.
 [target.'cfg(not(target_os = "emscripten"))'.dependencies]
-rand_chacha = { path = "rand_chacha", version = "0.2.3", default-features = false, optional = true }
+rand_chacha = { path = "rand_chacha", version = "0.3.0", default-features = false, optional = true }
 [target.'cfg(target_os = "emscripten")'.dependencies]
 rand_hc = { path = "rand_hc", version = "0.3.0", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Test Status](https://github.com/rust-random/rand/workflows/Tests/badge.svg?event=push)](https://github.com/rust-random/rand/actions)
 [![Crate](https://img.shields.io/crates/v/rand.svg)](https://crates.io/crates/rand)
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
-[![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand)
+[![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand)
 [![API](https://docs.rs/rand/badge.svg)](https://docs.rs/rand)
 [![Minimum rustc version](https://img.shields.io/badge/rustc-1.36+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 

--- a/rand_chacha/CHANGELOG.md
+++ b/rand_chacha/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-- impl PartialEq+Eq for ChaChaXRng and ChaChaXCore (#975)
+## [0.3.0] - 2020-12-08
+- Bump `rand_core` version to 0.6.0
+- Bump MSRV to 1.36 (#1011)
+- Remove usage of deprecated feature "simd" of `ppv-lite86` (#979), then revert
+  this change (#1023) since SIMD is only enabled by default from `ppv-lite86 v0.2.10`
+- impl PartialEq+Eq for ChaChaXRng and ChaChaXCore (#979)
 - Fix panic on block counter wrap that was occurring in debug builds (#980)
 
 ## [0.2.2] - 2020-03-09

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_chacha"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers", "The CryptoCorrosion Contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["algorithms", "no-std"]
 edition = "2018"
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "0.5" }
+rand_core = { path = "../rand_core", version = "0.6.0" }
 ppv-lite86 = { version = "0.2.8", default-features = false, features = ["simd"] }
 
 [features]

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
+## [0.6.0] - 2020-12-08
+### Breaking changes
 - Bump MSRV to 1.36, various code improvements (#1011)
 - Update to getrandom v0.2 (#1041)
 - Fix: `next_u32_via_fill` and `next_u64_via_fill` now use LE as documented (#1061)
+
+### Other
 - Reduce usage of `unsafe` (#962, #963, #1011)
 - Annotate feature-gates in documentation (#1019)
 - Document available error codes (#1061)

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_core/README.md
+++ b/rand_core/README.md
@@ -43,7 +43,7 @@ The traits and error types are also available via `rand`.
 
 The current version is:
 ```
-rand_core = "0.5.0"
+rand_core = "0.6.0"
 ```
 
 Rand libs have inter-dependencies and make use of the

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -25,7 +25,7 @@ std = ["alloc", "rand/std"]
 alloc = ["rand/alloc"]
 
 [dev-dependencies]
-rand_pcg = { version = "0.2", path = "../rand_pcg" }
+rand_pcg = { version = "0.3.0", path = "../rand_pcg" }
 # For inline examples
 rand = { path = "..", version = "0.7", default-features = false, features = ["std_rng", "std"] }
 # Histogram implementation for testing uniformity

--- a/rand_hc/CHANGELOG.md
+++ b/rand_hc/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-- impl PartialEq+Eq for Hc128Rng and Hc128Core (#975)
+## [0.3.0] - 2020-12-08
+- Bump `rand_core` version to 0.6.0
+- Bump MSRV to 1.36 (#1011)
+- impl PartialEq+Eq for Hc128Rng and Hc128Core (#979)
 - Drop some unsafe code, fixing an unsound internal function (#960)
 
 ## [0.2.0] - 2019-06-12

--- a/rand_hc/Cargo.toml
+++ b/rand_hc/Cargo.toml
@@ -15,4 +15,4 @@ categories = ["algorithms", "no-std"]
 edition = "2018"
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "0.5" }
+rand_core = { path = "../rand_core", version = "0.6.0" }

--- a/rand_hc/Cargo.toml
+++ b/rand_hc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_hc"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_pcg/CHANGELOG.md
+++ b/rand_pcg/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-- Derive PartialEq+Eq for Lcg64Xsh32, Lcg128Xsl64, and Mcg128Xsl64 (#975)
+## [0.3.0] - 2020-12-08
+- Bump `rand_core` version to 0.6.0
+- Bump MSRV to 1.36 (#1011)
+- Derive PartialEq+Eq for Lcg64Xsh32, Lcg128Xsl64, and Mcg128Xsl64 (#979)
 
 ## [0.2.1] - 2019-10-22
 - Bump `bincode` version to 1.1.4 to fix minimal-dependency builds

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_pcg"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2018"
 serde1 = ["serde"]
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "0.5" }
+rand_core = { path = "../rand_core", version = "0.6.0" }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Unfinished:

- [x] rand_chacha
- [x] rand_hc
- [x] rand_pcg

rand_chacha: #1023 re-enabled a dependency on the `simd` feature of `ppv-lite86` since at the time that wasn't enabled-by-default, but this should be fixed now: https://github.com/cryptocorrosion/cryptocorrosion/pull/36. So I think we should remove this feature dependency again since [it is deprecated](https://github.com/cryptocorrosion/cryptocorrosion/blob/master/utils-simd/ppv-lite86/Cargo.toml#L20).