### PR TITLE
Rand v0.8, rand_distr v0.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             toolchain: 1.36.0 # MSRV
           - os: ubuntu-latest
-            deps: sudo apt install gcc-multilib
+            deps: sudo apt-get update ; sudo apt install gcc-multilib
             target: i686-unknown-linux-gnu
             toolchain: nightly
           - os: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
-## [Unreleased]
+## [0.8.0] - 2020-12-18
 ### Additions
 - impl PartialEq+Eq for StdRng, SmallRng, and StepRng (#975)
 - Added a `serde1` feature and added Serialize/Deserialize to `UniformInt` and `WeightedIndex` (#974)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,35 +9,60 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
 ## [0.8.0] - 2020-12-18
-### Additions
-- impl PartialEq+Eq for StdRng, SmallRng, and StepRng (#975)
-- Added a `serde1` feature and added Serialize/Deserialize to `UniformInt` and `WeightedIndex` (#974)
-- Document types supported by `random` (#994)
-- Implement weighted sampling without replacement (#976, #1013)
-- Add `IteratorRandom::choose_stable` as an alternative to `choose` which does not depend on size hints (#1057)
-
-### Changes
-- `getrandom` updated to v0.2 (#1041)
-- `ThreadRng` is no longer `Copy` to enable safe usage within thread-local destructors (see #968)
-- `gen_range(a, b)` was replaced with `gen_range(a..b)`, and `gen_range(a..=b)`
-  is supported (#744, #1003). Note that `a` and `b` can no longer be references or SIMD types.
-- Replace `AsByteSliceMut` with `Fill` (#940)
-- Move alias method for `WeightedIndex` to `rand_distr` (#945)
-- `Alphanumeric` samples bytes instead of chars (#935)
+### Platform support
 - The minimum supported Rust version is now 1.36 (#1011)
-- Restrict `rand::rngs::adapter` to `std` (#1027)
-- Better NaN handling for `WeightedIndex` (#1005)
-- Implement `IntoIterator` for `IndexVec`, replacing the `into_iter` method (#1007)
-- Reduce packaged crate size (#983)
-- Drop some unsafe code (#962, #963, #1011)
-- Improve treatment of rounding errors in `WeightedIndex::update_weights` (#956)
-- `StdRng`: Switch from ChaCha20 to ChaCha12 for better performance (#1028)
-- `SmallRng`: Replace PCG algorithm with xoshiro{128,256}++ (#1038)
+- `getrandom` updated to v0.2 (#1041)
+- Remove `wasm-bindgen` and `stdweb` feature flags. For details of WASM support,
+  see the [getrandom documentation](https://docs.rs/getrandom/latest). (#948)
+- `ReadRng::next_u32` and `next_u64` now use little-Endian conversion instead
+  of native-Endian, affecting results on Big-Endian platforms (#1061)
 - The `nightly` feature no longer implies the `simd_support` feature (#1048)
 - Fix `simd_support` feature to work on current nightlies (#1056)
+
+### Rngs
+- `ThreadRng` is no longer `Copy` to enable safe usage within thread-local destructors (#1035)
+- `gen_range(a, b)` was replaced with `gen_range(a..b)`. `gen_range(a..=b)` is
+  also supported. Note that `a` and `b` can no longer be references or SIMD types. (#744, #1003)
+- Replace `AsByteSliceMut` with `Fill` and add support for `[bool], [char], [f32], [f64]` (#940)
+- Restrict `rand::rngs::adapter` to `std` (#1027; see also #928)
+- `StdRng`: add new `std_rng` feature flag (enabled by default, but might need
+  to be used if disabling default crate features) (#948)
+- `StdRng`: Switch from ChaCha20 to ChaCha12 for better performance (#1028)
+- `SmallRng`: Replace PCG algorithm with xoshiro{128,256}++ (#1038)
+
+### Sequences
+- Add `IteratorRandom::choose_stable` as an alternative to `choose` which does
+  not depend on size hints (#1057)
 - Improve accuracy and performance of `IteratorRandom::choose` (#1059)
-- `ReadRng::next_u32` and `next_u64` now use little-Endian conversion instead
-  of native-Endian, affecting results on Big-Endian platforms (#1026)
+- Implement `IntoIterator` for `IndexVec`, replacing the `into_iter` method (#1007)
+- Add value stability tests for `seq` module (#933)
+
+### Misc
+- Support `PartialEq` and `Eq` for `StdRng`, `SmallRng` and `StepRng` (#979)
+- Added a `serde1` feature and added Serialize/Deserialize to `UniformInt` and `WeightedIndex` (#974)
+- Drop some unsafe code (#962, #963, #1011)
+- Reduce packaged crate size (#983)
+- Migrate to GitHub Actions from Travis+AppVeyor (#1073)
+
+### Distributions
+- `Alphanumeric` samples bytes instead of chars (#935)
+- `Uniform` now supports `char`, enabling `rng.gen_range('A'..='Z')` (#1068)
+- Add `UniformSampler::sample_single_inclusive` (#1003)
+
+#### Weighted sampling
+- Implement weighted sampling without replacement (#976, #1013)
+- `rand::distributions::alias_method::WeightedIndex` was moved to `rand_distr::WeightedAliasIndex`.
+  The simpler alternative `rand::distribution::WeightedIndex` remains. (#945)
+- Improve treatment of rounding errors in `WeightedIndex::update_weights` (#956)
+- `WeightedIndex`: return error on NaN instead of panic (#1005)
+
+### Documentation
+- Document types supported by `random` (#994)
+- Document notes on password generation (#995)
+- Note that `SmallRng` may not be the best choice for performance and in some
+  other cases (#1038)
+- Use `doc(cfg)` to annotate feature-gated items (#1019)
+- Adjust README (#1065)
 
 ## [0.7.3] - 2020-01-10
 ### Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.7.4"
+version = "0.8.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rand = "0.7"
+rand = "0.8.0"
 ```
 
 To get started using Rand, see [The Book](https://rust-random.github.io/book).
@@ -68,7 +68,7 @@ Current Rand versions are:
 -   Version 0.7 was released in June 2019, moving most non-uniform distributions
     to an external crate, moving `from_entropy` to `SeedableRng`, and many small
     changes and fixes.
--   The `master` branch is close to 0.8 release.
+-   Version 0.8 was released in December 2020 with many small changes.
 
 A detailed [changelog](CHANGELOG.md) is available for releases.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,12 +43,13 @@ exceptions for theoretical issues without a known exploit:
 
 | Crate | Versions | Exceptions |
 | ----- | -------- | ---------- |
+| `rand` | 0.8 |  |
 | `rand` | 0.7 |  |
 | `rand` | 0.5, 0.6 | Jitter |
 | `rand` | 0.4 | Jitter, ISAAC |
-| `rand_core` | 0.2 - 0.5 | |
-| `rand_chacha` | 0.1 - 0.2 | |
-| `rand_hc` | 0.1 - 0.2 | |
+| `rand_core` | 0.2 - 0.6 | |
+| `rand_chacha` | 0.1 - 0.3 | |
+| `rand_hc` | 0.1 - 0.3 | |
 
 Explanation of exceptions:
 

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2020-12-18
+- Bump `rand` to v0.8.0
 - New `Geometric`, `StandardGeometric` and `Hypergeometric` distributions (#1062)
 - New `Beta` sampling algorithm for improved performance and accuracy (#1000)
 - `Normal` and `LogNormal` now support `from_mean_cv` and `from_zscore` (#1044)

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_distr"
-version = "0.2.2"
+version = "0.4.0"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [dependencies]
-rand = { path = "..", version = "0.7", default-features = false }
+rand = { path = "..", version = "0.8.0", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 
 [features]
@@ -27,6 +27,6 @@ alloc = ["rand/alloc"]
 [dev-dependencies]
 rand_pcg = { version = "0.3.0", path = "../rand_pcg" }
 # For inline examples
-rand = { path = "..", version = "0.7", default-features = false, features = ["std_rng", "std"] }
+rand = { path = "..", version = "0.8.0", default-features = false, features = ["std_rng", "std"] }
 # Histogram implementation for testing uniformity
 average = "0.10.3"


### PR DESCRIPTION
Slated for the end of the week. I think we can go ahead with this?

@newpavlov @josephlr how is getrandom v0.2.1 progressing? I guess you are waiting for CI fixes too.

To check:

- [x] changelogs are okay
- [x] book is ready: https://github.com/rust-random/book/pull/28