### PR TITLE
Fix doc links

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,7 +21,9 @@ jobs:
         env:
           RUSTDOCFLAGS: --cfg doc_cfg
         # --all builds all crates, but with default features for other crates (okay in this case)
-        run: cargo doc --all --features nightly,serde1,getrandom,small_rng
+        run: |
+          cargo doc --all --features nightly,serde1,getrandom,small_rng
+          echo '<meta http-equiv="refresh" content="0; URL=rand/index.html"/>' > target/doc/index.html
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/"
+documentation = "https://docs.rs/rand"
 homepage = "https://crates.io/crates/rand"
 description = """
 Random number generators and other randomness functionality.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
 documentation = "https://docs.rs/rand"
-homepage = "https://crates.io/crates/rand"
+homepage = "https://rust-random.github.io/book"
 description = """
 Random number generators and other randomness functionality.
 """

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers", "The Rust Project Developers", "The Cr
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_chacha/"
+documentation = "https://docs.rs/rand_chacha"
 homepage = "https://crates.io/crates/rand_chacha"
 description = """
 ChaCha random number generator

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
 documentation = "https://docs.rs/rand_chacha"
-homepage = "https://crates.io/crates/rand_chacha"
+homepage = "https://rust-random.github.io/book"
 description = """
 ChaCha random number generator
 """

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
 documentation = "https://docs.rs/rand_core"
-homepage = "https://crates.io/crates/rand_core"
+homepage = "https://rust-random.github.io/book"
 description = """
 Core random number generator traits and tools for implementation.
 """

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_core/"
+documentation = "https://docs.rs/rand_core"
 homepage = "https://crates.io/crates/rand_core"
 description = """
 Core random number generator traits and tools for implementation.

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
 documentation = "https://docs.rs/rand_distr"
-homepage = "https://crates.io/crates/rand_distr"
+homepage = "https://rust-random.github.io/book"
 description = """
 Sampling from random number distributions
 """

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_distr/"
+documentation = "https://docs.rs/rand_distr"
 homepage = "https://crates.io/crates/rand_distr"
 description = """
 Sampling from random number distributions

--- a/rand_hc/Cargo.toml
+++ b/rand_hc/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_hc/"
+documentation = "https://docs.rs/rand_hc"
 homepage = "https://crates.io/crates/rand_hc"
 description = """
 HC128 random number generator

--- a/rand_hc/Cargo.toml
+++ b/rand_hc/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
 documentation = "https://docs.rs/rand_hc"
-homepage = "https://crates.io/crates/rand_hc"
+homepage = "https://rust-random.github.io/book"
 description = """
 HC128 random number generator
 """

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
-documentation = "https://rust-random.github.io/rand/rand_pcg/"
+documentation = "https://docs.rs/rand_pcg"
 homepage = "https://crates.io/crates/rand_pcg"
 description = """
 Selected PCG random number generators

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-random/rand"
 documentation = "https://docs.rs/rand_pcg"
-homepage = "https://crates.io/crates/rand_pcg"
+homepage = "https://rust-random.github.io/book"
 description = """
 Selected PCG random number generators
 """


### PR DESCRIPTION
Closes #1077:

- add a redirect at https://rust-random.github.io/rand/ (have to test this live)
- use docs.rs for documentation links, since people usually want doc corresponding to the published version not the master branch
- use the book as the "homepage" since linking back to the crate pages is not useful and we already have a repo link