### PR TITLE
Enable all stable features in the playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [0.8.1] - 2020-12-31
+### Other
+- Enable all stable features in the playground (#1081)
+
 ## [0.8.0] - 2020-12-18
 ### Platform support
 - The minimum supported Rust version is now 1.36 (#1011)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,6 @@ bincode = "1.2.1"
 # RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --all-features --no-deps --open
 all-features = true
 rustdoc-args = ["--cfg", "doc_cfg"]
+
+[package.metadata.playground]
+features = ["small_rng", "serde1"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2020-12-31
+### Other
+- Enable all stable features in the playground (#1081)
+
 ## [0.6.0] - 2020-12-08
 ### Breaking changes
 - Bump MSRV to 1.36, various code improvements (#1011)

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -28,3 +28,6 @@ getrandom = { version = "0.2", optional = true }
 # RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --all-features --no-deps --open
 all-features = true
 rustdoc-args = ["--cfg", "doc_cfg"]
+
+[package.metadata.playground]
+all-features = true

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
I tried to use `SmallRng` in the playground, but it could not be used because the `small_rng` feature is not enabled.
https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=83ab37f952323079a0760f6a3ba0f740

Refs: [playground's custom metadata format]( https://github.com/integer32llc/rust-playground/blob/f68374b402b5dedbcea417086af29deb315e3031/top-crates/src/main.rs#L183-L192)