### PR TITLE
chacha: fix wasm32-unknown-unknown build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,6 +170,20 @@ jobs:
       - name: Build top-level only
         run: cargo build --target=thumbv6m-none-eabi --no-default-features
 
+  test-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            profile: minimal
+            toolchain: stable
+            target: wasm32-unknown-unknown
+            override: true
+      - name: Build rand_chacha for WASM target
+        run: cargo build --manifest-path rand_chacha/Cargo.toml --target=wasm32-unknown-unknown --no-default-features
+
   test-ios:
     runs-on: macos-latest
     steps:

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -19,6 +19,7 @@ rand_core = { path = "../rand_core", version = "0.6.0", default-features = false
 ppv-lite86 = { version = "0.2.8", default-features = false, features = ["simd"] }
 
 [features]
-default = ["std", "rand_core/getrandom"]
+default = ["std"]
 std = ["ppv-lite86/std", "rand_core/std"]
+getrandom = ["rand_core/getrandom"]
 simd = [] # deprecated

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -19,6 +19,6 @@ rand_core = { path = "../rand_core", version = "0.6.0", default-features = false
 ppv-lite86 = { version = "0.2.8", default-features = false, features = ["simd"] }
 
 [features]
-default = ["std"]
+default = ["std", "rand_core/getrandom"]
 std = ["ppv-lite86/std", "rand_core/std"]
 simd = [] # deprecated

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -15,10 +15,10 @@ categories = ["algorithms", "no-std"]
 edition = "2018"
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "0.6.0" }
+rand_core = { path = "../rand_core", version = "0.6.0", default-features = false }
 ppv-lite86 = { version = "0.2.8", default-features = false, features = ["simd"] }
 
 [features]
 default = ["std"]
-std = ["ppv-lite86/std"]
+std = ["ppv-lite86/std", "rand_core/std"]
 simd = [] # deprecated


### PR DESCRIPTION
`rand_chacha` pulls `rand_core/getrandom` feature, which it doesn't seem to require.
This breaks `wasm32-unknown-unknown` builds.