### PR TITLE
distributions/uniform: fix panic in gen_range(0..=MAX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [0.8.2] - 2021-01-12
+### Fixes
+- Fix panic in `UniformInt::sample_single_inclusive` and `Rng::gen_range` when
+  providing a full integer range (eg `0..=MAX`) (#1087)
+
 ## [0.8.1] - 2020-12-31
 ### Other
 - Enable all stable features in the playground (#1081)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This commit fixes a panic when generating a single sample in an
inclusive range that spans the entire integer range, eg for u8:
```rust
rng.gen_range(0..=u8::MAX)
// panicked at 'attempt to add with overflow', src/distributions/uniform.rs:529:42
```
[Playground example](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&code=use%20rand%3A%3ARng%3B%0A%0Afn%20main()%20%7B%0A%20%20%20%20rand%3A%3Athread_rng().gen_range(0u8..%3D255u8)%3B%0A%7D).

The cause is a discrepancy between the "single sample" and the "many
samples" codepaths:
```rust
// Ok
UniformSampler::new_inclusive(u8::MIN, u8::MAX).sample(&mut rng);
// Panic
UniformSampler::sample_single_inclusive(u8::MIN, u8::MAX, &mut rng);
```
In `sample`, a `range` of 0 is interpreted to mean "sample from the
whole range" ([documented here](https://github.com/rust-random/rand/blob/bda997404d9ab8a89d590734d8b0bb72aed10758/src/distributions/uniform.rs#L399-L400))
In `sample_range_inclusive`, no check is performed, which leads to
overflow when computing the `ints_to_reject`.

**Testing**
- Added a test case.
- Old code panics, new code passes.