### PR TITLE
Fix #1088: no-std + alloc build; prepare 0.8.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,14 +73,15 @@ jobs:
       - name: Maybe nightly
         if: ${{ matrix.toolchain == 'nightly' }}
         run: |
-          cargo test --target ${{ matrix.target }} --tests --features=nightly
+          cargo test --target ${{ matrix.target }} --features=nightly
           cargo test --target ${{ matrix.target }} --all-features
           cargo test --target ${{ matrix.target }} --benches --features=nightly
           cargo test --target ${{ matrix.target }} --manifest-path rand_distr/Cargo.toml --benches
       - name: Test rand
         run: |
-          cargo test --target ${{ matrix.target }} --tests --no-default-features
-          cargo test --target ${{ matrix.target }} --tests --no-default-features --features=alloc,getrandom,small_rng
+          cargo test --target ${{ matrix.target }} --lib --tests --no-default-features
+          cargo build --target ${{ matrix.target }} --no-default-features --features alloc,getrandom,small_rng
+          cargo test --target ${{ matrix.target }} --lib --tests --no-default-features --features=alloc,getrandom,small_rng
           # all stable features:
           cargo test --target ${{ matrix.target }} --features=serde1,log,small_rng
           cargo test --target ${{ matrix.target }} --examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [0.8.3] - 2021-01-25
+### Fixes
+- Fix `no-std` + `alloc` build by gating `choose_multiple_weighted` on `std` (#1088)
+
 ## [0.8.2] - 2021-01-12
 ### Fixes
 - Fix panic in `UniformInt::sample_single_inclusive` and `Rng::gen_range` when

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/examples/monte-carlo.rs
+++ b/examples/monte-carlo.rs
@@ -24,7 +24,7 @@
 //! the square at random, calculate the fraction that fall within the circle,
 //! and multiply this fraction by 4.
 
-#![cfg(feature = "std")]
+#![cfg(all(feature = "std", feature = "std_rng"))]
 
 use rand::distributions::{Distribution, Uniform};
 

--- a/examples/monty-hall.rs
+++ b/examples/monty-hall.rs
@@ -26,7 +26,7 @@
 //!
 //! [Monty Hall Problem]: https://en.wikipedia.org/wiki/Monty_Hall_problem
 
-#![cfg(feature = "std")]
+#![cfg(all(feature = "std", feature = "std_rng"))]
 
 use rand::distributions::{Distribution, Uniform};
 use rand::Rng;

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -17,7 +17,9 @@ use alloc::collections::BTreeSet;
 #[cfg(feature = "std")] use std::collections::HashSet;
 
 #[cfg(feature = "alloc")]
-use crate::distributions::{uniform::SampleUniform, Distribution, Uniform, WeightedError};
+use crate::distributions::{uniform::SampleUniform, Distribution, Uniform};
+#[cfg(feature = "std")]
+use crate::distributions::WeightedError;
 use crate::Rng;
 
 #[cfg(feature = "serde1")]
@@ -270,6 +272,8 @@ where R: Rng + ?Sized {
 /// `O(length + amount * log length)` time otherwise.
 ///
 /// Panics if `amount > length`.
+#[cfg(feature = "std")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 pub fn sample_weighted<R, F, X>(
     rng: &mut R, length: usize, weight: F, amount: usize,
 ) -> Result<IndexVec, WeightedError>
@@ -301,6 +305,7 @@ where
 /// + amount * log length)` time otherwise.
 ///
 /// Panics if `amount > length`.
+#[cfg(feature = "std")]
 fn sample_efraimidis_spirakis<R, F, X, N>(
     rng: &mut R, length: N, weight: F, amount: N,
 ) -> Result<IndexVec, WeightedError>
@@ -375,9 +380,6 @@ where
 
     #[cfg(not(feature = "nightly"))]
     {
-        #[cfg(all(feature = "alloc", not(feature = "std")))]
-        use crate::alloc::collections::BinaryHeap;
-        #[cfg(feature = "std")]
         use std::collections::BinaryHeap;
 
         // Partially sort the array such that the `amount` elements with the largest
@@ -619,6 +621,7 @@ mod test {
         assert_eq!(v1, v2);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_sample_weighted() {
         let seed_rng = crate::test::rng;

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -212,7 +212,11 @@ pub trait SliceRandom {
     /// println!("{:?}", choices.choose_multiple_weighted(&mut rng, 2, |item| item.1).unwrap().collect::<Vec<_>>());
     /// ```
     /// [`choose_multiple`]: SliceRandom::choose_multiple
-    #[cfg(feature = "alloc")]
+    //
+    // Note: this is feature-gated on std due to usage of f64::powf.
+    // If necessary, we may use alloc+libm as an alternative (see PR #1089).
+    #[cfg(feature = "std")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
     fn choose_multiple_weighted<R, F, X>(
         &self, rng: &mut R, amount: usize, weight: F,
     ) -> Result<SliceChooseIter<Self, Self::Item>, WeightedError>
@@ -556,7 +560,7 @@ impl<T> SliceRandom for [T] {
         Ok(&mut self[distr.sample(rng)])
     }
 
-    #[cfg(feature = "alloc")]
+    #[cfg(feature = "std")]
     fn choose_multiple_weighted<R, F, X>(
         &self, rng: &mut R, amount: usize, weight: F,
     ) -> Result<SliceChooseIter<Self, Self::Item>, WeightedError>
@@ -1228,7 +1232,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(feature = "std")]
     fn test_multiple_weighted_edge_cases() {
         use super::*;
 
@@ -1308,7 +1312,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(feature = "std")]
     fn test_multiple_weighted_distributions() {
         use super::*;
 


### PR DESCRIPTION
Fixes #1088 

@newpavlov @vks review?

This removes `choose_multiple_weighted` (new in 0.8) from no-std builds (previously enabled on no-std + alloc but causing build failure).

It also attempts to fix CI (no, using `cargo test --tests --lib ...` isn't enough to catch this issue for some reason, and the examples must be excluded (Cargo is broken here because using `--examples` doesn't fail but excluding target specifiers does)).

**Alternative:** add an optional dependency on `libm` and enable `choose_multiple_weighted` on `cfg(any(std, all(alloc, libm)))`.