### PR TITLE
Fix assertions inside read_{u32,u64}_into

### DIFF
--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2021-02-12
+### Fixed
+- Fixed assertions in `le::read_u32_into` and `le::read_u64_into` which could
+  have allowed buffers not to be fully populated (#1096)
+
 ## [0.6.1] - 2021-01-03
 ### Fixed
 - Avoid panic when using `RngCore::seed_from_u64` with a seed which is not a

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_core/src/le.rs
+++ b/rand_core/src/le.rs
@@ -16,7 +16,7 @@ use core::convert::TryInto;
 /// Reads unsigned 32 bit integers from `src` into `dst`.
 #[inline]
 pub fn read_u32_into(src: &[u8], dst: &mut [u32]) {
-    assert!(4 * src.len() >= dst.len());
+    assert!(src.len() >= 4 * dst.len());
     for (out, chunk) in dst.iter_mut().zip(src.chunks_exact(4)) {
         *out = u32::from_le_bytes(chunk.try_into().unwrap());
     }
@@ -25,7 +25,7 @@ pub fn read_u32_into(src: &[u8], dst: &mut [u32]) {
 /// Reads unsigned 64 bit integers from `src` into `dst`.
 #[inline]
 pub fn read_u64_into(src: &[u8], dst: &mut [u64]) {
-    assert!(8 * src.len() >= dst.len());
+    assert!(src.len() >= 8 * dst.len());
     for (out, chunk) in dst.iter_mut().zip(src.chunks_exact(8)) {
         *out = u64::from_le_bytes(chunk.try_into().unwrap());
     }


### PR DESCRIPTION
Unless I'm mistaken the size multiplier was on the wrong side, making the assertions too permissive. This could have resulted in destination buffers not being fully populated.