### PR TITLE
Use const-generics to support arrays of all sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ std_rng = ["rand_chacha", "rand_hc"]
 # Option: enable SmallRng
 small_rng = []
 
-# Option: TODO - enable SmallRng
+# Option: enable generating random arrays of any size using min-const-generics
 min_const_gen = []
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ std_rng = ["rand_chacha", "rand_hc"]
 # Option: enable SmallRng
 small_rng = []
 
+# Option: TODO - enable SmallRng
+min_const_gen = []
+
 [workspace]
 members = [
     "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,8 @@ std_rng = ["rand_chacha", "rand_hc"]
 # Option: enable SmallRng
 small_rng = []
 
-# Option: enable generating random arrays of any size using min-const-generics
+# Option: for rustc ≥ 1.51, enable generating random arrays of any size
+# using min-const-generics
 min_const_gen = []
 
 [workspace]

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -279,8 +279,8 @@ where
 /// *   Arrays (up to 32 elements): each element is generated sequentially;
 ///     see also [`Rng::fill`] which supports arbitrary array length for integer
 ///     types and tends to be faster for `u32` and smaller types.
-///     For arrays of size larger than 32 elements, enable the `min_const_gen`
-///     feature.
+///     When using `rustc` ≥ 1.51, enable the `min_const_gen` feature to support
+///     arrays larger than 32 elements.
 /// *   `Option<T>` first generates a `bool`, and if true generates and returns
 ///     `Some(value)` where `value: T`, otherwise returning `None`.
 ///

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -279,6 +279,8 @@ where
 /// *   Arrays (up to 32 elements): each element is generated sequentially;
 ///     see also [`Rng::fill`] which supports arbitrary array length for integer
 ///     types and tends to be faster for `u32` and smaller types.
+///     For arrays of size larger than 32 elements, enable the `min_const_gen`
+///     feature.
 /// *   `Option<T>` first generates a `bool`, and if true generates and returns
 ///     `Some(value)` where `value: T`, otherwise returning `None`.
 ///

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -281,6 +281,10 @@ where
 ///     types and tends to be faster for `u32` and smaller types.
 ///     When using `rustc` ≥ 1.51, enable the `min_const_gen` feature to support
 ///     arrays larger than 32 elements.
+///     Note that [`Rng::fill`] and `Standard`'s array support are *not* equivalent:
+///     the former is optimised for integer types (using fewer RNG calls for
+///     element types smaller than the RNG word size), while the latter supports
+///     any element type supported by `Standard`.
 /// *   `Option<T>` first generates a `bool`, and if true generates and returns
 ///     `Some(value)` where `value: T`, otherwise returning `None`.
 ///

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -156,7 +156,7 @@ tuple_impl! {A, B, C, D, E, F, G, H, I, J}
 tuple_impl! {A, B, C, D, E, F, G, H, I, J, K}
 tuple_impl! {A, B, C, D, E, F, G, H, I, J, K, L}
 
-#[cfg(feature = "nightly")]
+#[cfg(feature = "min_const_gen")]
 impl<T, const N: usize> Distribution<[T; N]> for Standard
 where
     Standard: Distribution<T>,
@@ -173,7 +173,7 @@ where
     }
 }
 
-#[cfg(not(feature = "nightly"))]
+#[cfg(not(feature = "min_const_gen"))]
 macro_rules! array_impl {
     // recursive, given at least one type parameter:
     {$n:expr, $t:ident, $($ts:ident,)*} => {
@@ -194,7 +194,7 @@ macro_rules! array_impl {
     };
 }
 
-#[cfg(not(feature = "nightly"))]
+#[cfg(not(feature = "min_const_gen"))]
 array_impl! {32, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T,}
 
 impl<T> Distribution<Option<T>> for Standard

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -156,6 +156,24 @@ tuple_impl! {A, B, C, D, E, F, G, H, I, J}
 tuple_impl! {A, B, C, D, E, F, G, H, I, J, K}
 tuple_impl! {A, B, C, D, E, F, G, H, I, J, K, L}
 
+#[cfg(feature = "nightly")]
+impl<T, const N: usize> Distribution<[T; N]> for Standard
+where
+    Standard: Distribution<T>,
+    T: Default + Copy,
+{
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, _rng: &mut R) -> [T; N] {
+        let mut sample = [Default::default(); N];
+        for elem in &mut sample {
+            *elem = _rng.gen();
+        }
+
+        sample
+    }
+}
+
+#[cfg(not(feature = "nightly"))]
 macro_rules! array_impl {
     // recursive, given at least one type parameter:
     {$n:expr, $t:ident, $($ts:ident,)*} => {
@@ -176,6 +194,7 @@ macro_rules! array_impl {
     };
 }
 
+#[cfg(not(feature = "nightly"))]
 array_impl! {32, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T,}
 
 impl<T> Distribution<Option<T>> for Standard

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -71,6 +71,7 @@ pub trait Rng: RngCore {
     /// The `rng.gen()` method is able to generate arrays (up to 32 elements)
     /// and tuples (up to 12 elements), so long as all element types can be
     /// generated.
+    /// For arrays larger than 32 elements, enable the `min_const_gen` feature.
     ///
     /// For arrays of integers, especially for those with small element types
     /// (< 64 bit), it will likely be faster to instead use [`Rng::fill`].

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -394,6 +394,16 @@ impl_fill!(i8, i16, i32, i64, isize,);
 #[cfg(not(target_os = "emscripten"))]
 impl_fill!(i128);
 
+#[cfg(feature = "nightly")]
+impl<T, const N: usize> Fill for [T; N]
+where [T]: Fill
+{
+    fn try_fill<R: Rng + ?Sized>(&mut self, rng: &mut R) -> Result<(), Error> {
+        self[..].try_fill(rng)
+    }
+}
+
+#[cfg(not(feature = "nightly"))]
 macro_rules! impl_fill_arrays {
     ($n:expr,) => {};
     ($n:expr, $N:ident) => {
@@ -413,8 +423,10 @@ macro_rules! impl_fill_arrays {
         impl_fill_arrays!(!div $n / 2, $($NN,)*);
     };
 }
+#[cfg(not(feature = "nightly"))]
 #[rustfmt::skip]
 impl_fill_arrays!(32, N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,);
+#[cfg(not(feature = "nightly"))]
 impl_fill_arrays!(!div 4096, N,N,N,N,N,N,N,);
 
 #[cfg(test)]

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -71,7 +71,8 @@ pub trait Rng: RngCore {
     /// The `rng.gen()` method is able to generate arrays (up to 32 elements)
     /// and tuples (up to 12 elements), so long as all element types can be
     /// generated.
-    /// For arrays larger than 32 elements, enable the `min_const_gen` feature.
+    /// When using `rustc` ≥ 1.51, enable the `min_const_gen` feature to support
+    /// arrays larger than 32 elements.
     ///
     /// For arrays of integers, especially for those with small element types
     /// (< 64 bit), it will likely be faster to instead use [`Rng::fill`].

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -394,7 +394,7 @@ impl_fill!(i8, i16, i32, i64, isize,);
 #[cfg(not(target_os = "emscripten"))]
 impl_fill!(i128);
 
-#[cfg(feature = "nightly")]
+#[cfg(feature = "min_const_gen")]
 impl<T, const N: usize> Fill for [T; N]
 where [T]: Fill
 {
@@ -403,7 +403,7 @@ where [T]: Fill
     }
 }
 
-#[cfg(not(feature = "nightly"))]
+#[cfg(not(feature = "min_const_gen"))]
 macro_rules! impl_fill_arrays {
     ($n:expr,) => {};
     ($n:expr, $N:ident) => {
@@ -423,10 +423,10 @@ macro_rules! impl_fill_arrays {
         impl_fill_arrays!(!div $n / 2, $($NN,)*);
     };
 }
-#[cfg(not(feature = "nightly"))]
+#[cfg(not(feature = "min_const_gen"))]
 #[rustfmt::skip]
 impl_fill_arrays!(32, N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,);
-#[cfg(not(feature = "nightly"))]
+#[cfg(not(feature = "min_const_gen"))]
 impl_fill_arrays!(!div 4096, N,N,N,N,N,N,N,);
 
 #[cfg(test)]


### PR DESCRIPTION
As discussed in #1085, this PR uses `min_const_generics` to add support for random arrays of every size.
Currently this uses the existing `nightly` feature.
This currently updates the trait bounds on the implementation to require `Default + Copy`, which wasn't required previously, which is a regression compared to what is currently supported.
This can either be addressed by using unsafe code and `MaybeUninit`, or adding this new `impl` only for arrays larger than 32.

Open questions:
* ~~Should this use a new feature flag?~~
* Any specific tests that should be added?
* ~~Any documentation that needs to be updated?~~