### PR TITLE
Update and tweak the rand_distr README

### DIFF
--- a/rand_distr/README.md
+++ b/rand_distr/README.md
@@ -2,7 +2,7 @@
 
 [![Test Status](https://github.com/rust-random/rand/workflows/Tests/badge.svg?event=push)](https://github.com/rust-random/rand/actions)
 [![Latest version](https://img.shields.io/crates/v/rand_distr.svg)](https://crates.io/crates/rand_distr)
-[[![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
+[![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_distr)
 [![API](https://docs.rs/rand_distr/badge.svg)](https://docs.rs/rand_distr)
 [![Minimum rustc version](https://img.shields.io/badge/rustc-1.36+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
@@ -17,7 +17,7 @@ sphere surface.
 
 It is worth mentioning the [statrs] crate which provides similar functionality
 along with various support functions, including PDF and CDF computation. In
-contrast, this `rand_distr` crate focusses on sampling from distributions.
+contrast, this `rand_distr` crate focuses on sampling from distributions.
 
 Unlike most Rand crates, `rand_distr` does not currently support `no_std`.
 

--- a/rand_distr/README.md
+++ b/rand_distr/README.md
@@ -7,13 +7,14 @@
 [![API](https://docs.rs/rand_distr/badge.svg)](https://docs.rs/rand_distr)
 [![Minimum rustc version](https://img.shields.io/badge/rustc-1.36+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
-Implements a full suite of random number distributions sampling routines.
+Implements a full suite of random number distribution sampling routines.
 
-This crate is a super-set of the [rand::distributions] module, including support
-for sampling from Beta, Binomial, Cauchy, ChiSquared, Dirichlet, exponential,
-Fisher F, Gamma, Log-normal, Normal, Pareto, Poisson, StudentT, Triangular and
-Weibull distributions, as well as sampling points from the unit circle and unit
-sphere surface.
+This crate is a superset of the [rand::distributions] module, including support
+for sampling from Beta, Binomial, Cauchy, ChiSquared, Dirichlet, Exponential,
+FisherF, Gamma, Geometric, Hypergeometric, InverseGaussian, LogNormal, Normal,
+Pareto, PERT, Poisson, StudentT, Triangular and Weibull distributions.  Sampling
+from the unit ball, unit circle, unit disc and unit sphere surfaces is also
+supported.
 
 It is worth mentioning the [statrs] crate which provides similar functionality
 along with various support functions, including PDF and CDF computation. In


### PR DESCRIPTION
I noticed the README had a couple of typos and wasn't updated with the new (v0.2.0 to v0.4.0) distribution offerings.  This PR resolves those issues, while also making small improvements to language consistency and clarity.