### PR TITLE
Add mean and std_dev accessors to Normal

### DIFF
--- a/rand_distr/src/normal.rs
+++ b/rand_distr/src/normal.rs
@@ -189,6 +189,16 @@ where F: Float, StandardNormal: Distribution<F>
     pub fn from_zscore(&self, zscore: F) -> F {
         self.mean + self.std_dev * zscore
     }
+
+    /// Returns the mean (`μ`) of the distribution.
+    pub fn mean(&self) -> F {
+        self.mean
+    }
+
+    /// Returns the standard deviation (`σ`) of the distribution.
+    pub fn std_dev(&self) -> F {
+        self.std_dev
+    }
 }
 
 impl<F> Distribution<F> for Normal<F>


### PR DESCRIPTION
This makes the `rand_distr::Normal` struct useful for storing the mean and stdev, instead of only being able to sample from the distribution. Without these accessors, users have to define a separate `Normal` struct for storing mean and stdev information (for things other than just sampling, such as computing the pdf for a value), and then they have to convert their `Normal` struct to `rand_distr::Normal` whenever a sample is needed. With `mean` and `std_dev` accessors, `rand_distr::Normal` will be sufficient for most uses, and extra functionality can provided in other crates with extension traits.

A design question -- `Normal` is `Copy`, so would you prefer for these methods to take `self` or `&self`?

Edit: The Miri CI failure is unrelated to the changes in this PR.