### PR TITLE
Fix Miri tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
           rustup component add miri
       - name: Test rand
         run: |
-          cargo miri test --no-default-features
+          cargo miri test --no-default-features --lib --tests
           cargo miri test --features=log,small_rng
           cargo miri test --manifest-path rand_core/Cargo.toml
           cargo miri test --manifest-path rand_core/Cargo.toml --features=serde1


### PR DESCRIPTION
Because Miri now runs the doctests as well, we have to make sure it does not run them for `no_std` targets, like we do for our normal tests.