### PR TITLE
Bump "average" crate to 0.12

### DIFF
--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -30,4 +30,4 @@ rand_pcg = { version = "0.3.0", path = "../rand_pcg" }
 # For inline examples
 rand = { path = "..", version = "0.8.0", default-features = false, features = ["std_rng", "std"] }
 # Histogram implementation for testing uniformity
-average = "0.10.3"
+average = { version = "0.12", features = [ "std" ] }


### PR DESCRIPTION
This fixes the following warnings (from rustc 1.51.1):

```
warning: panic message is not a string literal
  --> rand_distr/tests/value_stability.rs:29:9
   |
29 |         assert_almost_eq!(self, rhs, 1e-6);
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(non_fmt_panic)]` on by default
   = note: this is no longer accepted in Rust 2021
   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

warning: panic message is not a string literal
  --> rand_distr/tests/value_stability.rs:34:9
   |
34 |         assert_almost_eq!(self, rhs, 1e-14);
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this is no longer accepted in Rust 2021
   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

warning: panic message is not a string literal
   --> rand_distr/tests/value_stability.rs:380:9
    |
380 |         assert_almost_eq!(a, b, 1e-5);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this is no longer accepted in Rust 2021
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```