### PR TITLE
Ensure `Array64` is `repr(transparent)`

### DIFF
--- a/rand_chacha/src/chacha.rs
+++ b/rand_chacha/src/chacha.rs
@@ -24,6 +24,7 @@ const BUF_BLOCKS: u8 = 4;
 // number of 32-bit words per ChaCha block (fixed by algorithm definition)
 const BLOCK_WORDS: u8 = 16;
 
+#[repr(transparent)]
 pub struct Array64<T>([T; 64]);
 impl<T> Default for Array64<T>
 where T: Default


### PR DESCRIPTION
Let me start by saying that I'm far from an expert when it comes to unsafe code in Rust. However, if I read [RFC 1758](https://github.com/rust-lang/rfcs/blob/master/text/1758-repr-transparent.md) correctly, it it seems that `Array64` should be marked `repr(transparent)`. This is because I believe it is considered an implementation detail that single-element tuple structs currently have the same representation as its single field:

> As a matter of optimisation, eligible #[repr(Rust)] structs behave as if they were #[repr(transparent)] but as an implementation detail that can't be relied upon by users.

With the transparent representation, the `generate` method can safely cast the `Array64<u32>` argument:

```rust
                // Fill slice of words by writing to equivalent slice of bytes, then fixing endianness.
                self.state.refill4($rounds, unsafe {
                    &mut *(&mut *r as *mut Array64<u32> as *mut [u8; 256])
                });
```