### PR TITLE
Add missing trait implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 ## [Unreleased]
 ### Additions
 - Use const-generics to support arrays of all sizes (#1104)
+- Implement `Clone` and `Copy` for `Alphanumeric` (#1126)
 
 ### Other
 - Reorder asserts in `Uniform` float distributions for easier debugging of non-finite arguments

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correctly document `no_std` support (#1100)
 - Add `std_math` feature to prefer `std` over `libm` for floating point math (#1100)
 - Add mean and std_dev accessors to Normal (#1114)
+- Make sure all distributions and their error types implement `Error`, `Display`, `Clone`,
+ `Copy`, `PartialEq` and `Eq` as appropriate (#1126)
 
 ## [0.4.0] - 2020-12-18
 - Bump `rand` to v0.8.0

--- a/rand_distr/src/hypergeometric.rs
+++ b/rand_distr/src/hypergeometric.rs
@@ -73,6 +73,10 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+impl std::error::Error for Error {}
+
 // evaluate fact(numerator.0)*fact(numerator.1) / fact(denominator.0)*fact(denominator.1)
 fn fraction_of_products_of_factorials(numerator: (u64, u64), denominator: (u64, u64)) -> f64 {
     let min_top = u64::min(numerator.0, numerator.1);

--- a/rand_distr/src/inverse_gaussian.rs
+++ b/rand_distr/src/inverse_gaussian.rs
@@ -3,7 +3,7 @@ use num_traits::Float;
 use rand::Rng;
 
 /// Error type returned from `InverseGaussian::new`
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Error {
     /// `mean <= 0` or `nan`.
     MeanNegativeOrNull,

--- a/rand_distr/src/inverse_gaussian.rs
+++ b/rand_distr/src/inverse_gaussian.rs
@@ -12,7 +12,7 @@ pub enum Error {
 }
 
 /// The [inverse Gaussian distribution](https://en.wikipedia.org/wiki/Inverse_Gaussian_distribution)
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct InverseGaussian<F>
 where
     F: Float,

--- a/rand_distr/src/inverse_gaussian.rs
+++ b/rand_distr/src/inverse_gaussian.rs
@@ -1,6 +1,7 @@
 use crate::{Distribution, Standard, StandardNormal};
 use num_traits::Float;
 use rand::Rng;
+use core::fmt;
 
 /// Error type returned from `InverseGaussian::new`
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10,6 +11,19 @@ pub enum Error {
     /// `shape <= 0` or `nan`.
     ShapeNegativeOrNull,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::MeanNegativeOrNull => "mean <= 0 or is NaN in inverse Gaussian distribution",
+            Error::ShapeNegativeOrNull => "shape <= 0 or is NaN in inverse Gaussian distribution",
+        })
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+impl std::error::Error for Error {}
 
 /// The [inverse Gaussian distribution](https://en.wikipedia.org/wiki/Inverse_Gaussian_distribution)
 #[derive(Debug, Clone, Copy)]

--- a/rand_distr/src/normal_inverse_gaussian.rs
+++ b/rand_distr/src/normal_inverse_gaussian.rs
@@ -12,7 +12,7 @@ pub enum Error {
 }
 
 /// The [normal-inverse Gaussian distribution](https://en.wikipedia.org/wiki/Normal-inverse_Gaussian_distribution)
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct NormalInverseGaussian<F>
 where
     F: Float,

--- a/rand_distr/src/normal_inverse_gaussian.rs
+++ b/rand_distr/src/normal_inverse_gaussian.rs
@@ -1,6 +1,7 @@
 use crate::{Distribution, InverseGaussian, Standard, StandardNormal};
 use num_traits::Float;
 use rand::Rng;
+use core::fmt;
 
 /// Error type returned from `NormalInverseGaussian::new`
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10,6 +11,19 @@ pub enum Error {
     /// `|beta| >= alpha` or `nan`.
     AbsoluteBetaNotLessThanAlpha,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::AlphaNegativeOrNull => "alpha <= 0 or is NaN in normal inverse Gaussian distribution",
+            Error::AbsoluteBetaNotLessThanAlpha => "|beta| >= alpha or is NaN in normal inverse Gaussian distribution",
+        })
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+impl std::error::Error for Error {}
 
 /// The [normal-inverse Gaussian distribution](https://en.wikipedia.org/wiki/Normal-inverse_Gaussian_distribution)
 #[derive(Debug, Clone, Copy)]

--- a/rand_distr/src/normal_inverse_gaussian.rs
+++ b/rand_distr/src/normal_inverse_gaussian.rs
@@ -3,7 +3,7 @@ use num_traits::Float;
 use rand::Rng;
 
 /// Error type returned from `NormalInverseGaussian::new`
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Error {
     /// `alpha <= 0` or `nan`.
     AlphaNegativeOrNull,

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -57,7 +57,7 @@ use std::mem::{self, MaybeUninit};
 ///
 /// - [Wikipedia article on Password Strength](https://en.wikipedia.org/wiki/Password_strength)
 /// - [Diceware for generating memorable passwords](https://en.wikipedia.org/wiki/Diceware)
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct Alphanumeric;
 

--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -439,15 +439,15 @@ pub enum WeightedError {
 }
 
 #[cfg(feature = "std")]
-impl ::std::error::Error for WeightedError {}
+impl std::error::Error for WeightedError {}
 
 impl fmt::Display for WeightedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            WeightedError::NoItem => write!(f, "No weights provided."),
-            WeightedError::InvalidWeight => write!(f, "A weight is invalid."),
-            WeightedError::AllWeightsZero => write!(f, "All weights are zero."),
-            WeightedError::TooMany => write!(f, "Too many weights (hit u32::MAX)"),
-        }
+        f.write_str(match *self {
+            WeightedError::NoItem => "No weights provided in distribution",
+            WeightedError::InvalidWeight => "A weight is invalid in distribution",
+            WeightedError::AllWeightsZero => "All weights are zero in distribution",
+            WeightedError::TooMany => "Too many weights (hit u32::MAX) in distribution",
+        })
     }
 }


### PR DESCRIPTION
Adds implementations of `Copy`, `Clone`, `PartialEq`, `Eq`, `Error` and `Display` for distributions and their error types where appropriate, improving consistency.

Fixes #1125.