### PR TITLE
Create a distribution by mapping the output of another one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 ### Additions
 - Use const-generics to support arrays of all sizes (#1104)
 - Implement `Clone` and `Copy` for `Alphanumeric` (#1126)
+- Add `Distribution::map` to derive a distribution using a closure (#1129)
 
 ### Other
 - Reorder asserts in `Uniform` float distributions for easier debugging of non-finite arguments


### PR DESCRIPTION
This is useful if consumers are to be given an opaque type implementing the Distribution trait, but the output of the provided implementations needs additional post processing, e.g. to attach compile time units of measurement.