### PR TITLE
serde for BlockRng, ReseedingRng and ReadRng

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 # Meta-features:
 default = ["std", "std_rng"]
 nightly = [] # enables performance optimizations requiring nightly rust
-serde1 = ["serde"]
+serde1 = ["serde", "rand_core/serde1"]
 
 # Option (enabled by default): without "std" rand uses libcore; this option
 # enables functionality expected to be available on a standard platform.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ serde = { version = "1.0.103", features = ["derive"], optional = true }
 [dependencies.packed_simd]
 # NOTE: so far no version works reliably due to dependence on unstable features
 package = "packed_simd_2"
-version = "0.3.4"
+version = "0.3.5"
 optional = true
 features = ["into_bits"]
 

--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -114,6 +114,12 @@ pub trait BlockRngCore {
 /// [`try_fill_bytes`]: RngCore::try_fill_bytes
 #[derive(Clone)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serde1",
+    serde(
+        bound = "for<'x> R: Serialize + Deserialize<'x> + Sized, for<'x> R::Results: Serialize + Deserialize<'x>"
+    )
+)]
 pub struct BlockRng<R: BlockRngCore + ?Sized> {
     results: R::Results,
     index: usize,

--- a/src/rngs/adapter/mod.rs
+++ b/src/rngs/adapter/mod.rs
@@ -11,5 +11,6 @@
 mod read;
 mod reseeding;
 
+#[allow(deprecated)]
 pub use self::read::{ReadError, ReadRng};
 pub use self::reseeding::ReseedingRng;

--- a/src/rngs/adapter/read.rs
+++ b/src/rngs/adapter/read.rs
@@ -9,6 +9,8 @@
 
 //! A wrapper around any Read to treat it as an RNG.
 
+#![allow(deprecated)]
+
 use std::fmt;
 use std::io::Read;
 
@@ -30,20 +32,10 @@ use rand_core::{impls, Error, RngCore};
 /// have enough data, will only be reported through [`try_fill_bytes`].
 /// The other [`RngCore`] methods will panic in case of an error.
 ///
-/// # Example
-///
-/// ```
-/// use rand::Rng;
-/// use rand::rngs::adapter::ReadRng;
-///
-/// let data = vec![1, 2, 3, 4, 5, 6, 7, 8];
-/// let mut rng = ReadRng::new(&data[..]);
-/// println!("{:x}", rng.gen::<u32>());
-/// ```
-///
 /// [`OsRng`]: crate::rngs::OsRng
 /// [`try_fill_bytes`]: RngCore::try_fill_bytes
 #[derive(Debug)]
+#[deprecated(since="0.8.4", note="removal due to lack of usage")]
 pub struct ReadRng<R> {
     reader: R,
 }
@@ -86,6 +78,7 @@ impl<R: Read> RngCore for ReadRng<R> {
 
 /// `ReadRng` error type
 #[derive(Debug)]
+#[deprecated(since="0.8.4")]
 pub struct ReadError(std::io::Error);
 
 impl fmt::Display for ReadError {

--- a/src/rngs/adapter/read.rs
+++ b/src/rngs/adapter/read.rs
@@ -44,7 +44,6 @@ use rand_core::{impls, Error, RngCore};
 /// [`OsRng`]: crate::rngs::OsRng
 /// [`try_fill_bytes`]: RngCore::try_fill_bytes
 #[derive(Debug)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReadRng<R> {
     reader: R,
 }

--- a/src/rngs/adapter/read.rs
+++ b/src/rngs/adapter/read.rs
@@ -44,6 +44,7 @@ use rand_core::{impls, Error, RngCore};
 /// [`OsRng`]: crate::rngs::OsRng
 /// [`try_fill_bytes`]: RngCore::try_fill_bytes
 #[derive(Debug)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReadRng<R> {
     reader: R,
 }

--- a/src/rngs/adapter/reseeding.rs
+++ b/src/rngs/adapter/reseeding.rs
@@ -14,6 +14,8 @@ use core::mem::size_of;
 
 use rand_core::block::{BlockRng, BlockRngCore};
 use rand_core::{CryptoRng, Error, RngCore, SeedableRng};
+#[cfg(feature = "serde1")]
+use serde::{Deserialize, Serialize};
 
 /// A wrapper around any PRNG that implements [`BlockRngCore`], that adds the
 /// ability to reseed it.
@@ -76,6 +78,13 @@ use rand_core::{CryptoRng, Error, RngCore, SeedableRng};
 /// [`ReseedingRng::new`]: ReseedingRng::new
 /// [`reseed()`]: ReseedingRng::reseed
 #[derive(Debug)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serde1",
+    serde(
+        bound = "for<'x> R: Serialize + Deserialize<'x> + Sized, for<'x> R::Results: Serialize + Deserialize<'x>, for<'x> Rsdr: Serialize + Deserialize<'x>"
+    )
+)]
 pub struct ReseedingRng<R, Rsdr>(BlockRng<ReseedingCore<R, Rsdr>>)
 where
     R: BlockRngCore + SeedableRng,
@@ -148,6 +157,7 @@ where
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 struct ReseedingCore<R, Rsdr> {
     inner: R,
     reseeder: Rsdr,

--- a/src/rngs/adapter/reseeding.rs
+++ b/src/rngs/adapter/reseeding.rs
@@ -14,8 +14,6 @@ use core::mem::size_of;
 
 use rand_core::block::{BlockRng, BlockRngCore};
 use rand_core::{CryptoRng, Error, RngCore, SeedableRng};
-#[cfg(feature = "serde1")]
-use serde::{Deserialize, Serialize};
 
 /// A wrapper around any PRNG that implements [`BlockRngCore`], that adds the
 /// ability to reseed it.
@@ -78,13 +76,6 @@ use serde::{Deserialize, Serialize};
 /// [`ReseedingRng::new`]: ReseedingRng::new
 /// [`reseed()`]: ReseedingRng::reseed
 #[derive(Debug)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
-#[cfg_attr(
-    feature = "serde1",
-    serde(
-        bound = "for<'x> R: Serialize + Deserialize<'x> + Sized, for<'x> R::Results: Serialize + Deserialize<'x>, for<'x> Rsdr: Serialize + Deserialize<'x>"
-    )
-)]
 pub struct ReseedingRng<R, Rsdr>(BlockRng<ReseedingCore<R, Rsdr>>)
 where
     R: BlockRngCore + SeedableRng,
@@ -157,7 +148,6 @@ where
 }
 
 #[derive(Debug)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 struct ReseedingCore<R, Rsdr> {
     inner: R,
     reseeder: Rsdr,


### PR DESCRIPTION
Closes #1101, which also discussed serde for other RNGs.

- implements for `ReadRng`: probably useless?
- implements for `ReseedingRng`: probably useless since the reseeder will normally be a non-deterministic RNG
- corrects bounds for `BlockRng`: required for `ReseedingRng` and I guess was never picked up in previous tests?
- `rand/serde1` now requires `rand_core/serde1`, required for `ReseedingRng` and probably sensible
- does not implement for `OsRng`: useless, and easy to skip as a field in structs
- does not implement for `StdRng` or `SmallRng`: as @kazcw points out, non-stable serialisation would be a pit-fall
- does not implement for `Hc128Rng`: would require https://crates.io/crates/serde-big-array or some workaround until some future MSRV bump but I doubt anyone cares anyway

I'm tempted to remove the `ReadRng` and possibly `ReseedingRng` support but there doesn't seem a good reason either way. Thoughts?