### PR TITLE
Prepare rand_chacha v0.3.1 release

### DIFF
--- a/rand_chacha/CHANGELOG.md
+++ b/rand_chacha/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.1] - 2021-05-12
-- add getters corresponding to existing setters: `get_seed`, `get_state`
-- add serde support, gated by the `serde1` feature
+## [0.3.1] - 2021-06-09
+- add getters corresponding to existing setters: `get_seed`, `get_stream` (#1124)
+- add serde support, gated by the `serde1` feature (#1124)
+- ensure expected layout via `repr(transparent)` (#1120)
 
 ## [0.3.0] - 2020-12-08
 - Bump `rand_core` version to 0.6.0


### PR DESCRIPTION
Release changes from #1120 and #1124. Seem to be the only significant changes (ignoring homepage/doc links in cargo.toml). Approve @vks?

Closes #1134.