### PR TITLE
Prepare rand 0.8.4 release, core 0.6.3, distr 0.4.1, pcg 0.3.1, hc 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,19 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
-## [Unreleased]
+## [0.8.4] - 2021-06-15
 ### Additions
 - Use const-generics to support arrays of all sizes (#1104)
 - Implement `Clone` and `Copy` for `Alphanumeric` (#1126)
 - Add `Distribution::map` to derive a distribution using a closure (#1129)
+- Add `Slice` distribution (#1107)
+- Add `DistString` trait with impls for `Standard` and `Alphanumeric` (#1133)
 
 ### Other
 - Reorder asserts in `Uniform` float distributions for easier debugging of non-finite arguments
   (#1094, #1108)
 - Add range overflow check in `Uniform` float distributions (#1108)
-
-### Distributions
-- Add slice distribution (#1107)
+- Deprecate `rngs::adapter::ReadRng` (#1130)
 
 ## [0.8.3] - 2021-01-25
 ### Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3] - 2021-06-15
+### Changed
+- Improved bound for `serde` impls on `BlockRng` (#1130)
+- Minor doc additions (#1118)
+
 ## [0.6.2] - 2021-02-12
 ### Fixed
 - Fixed assertions in `le::read_u32_into` and `le::read_u64_into` which could

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -4,12 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.4.1] - 2021-06-15
+- Empirically test PDF of normal distribution (#1121)
 - Correctly document `no_std` support (#1100)
 - Add `std_math` feature to prefer `std` over `libm` for floating point math (#1100)
 - Add mean and std_dev accessors to Normal (#1114)
 - Make sure all distributions and their error types implement `Error`, `Display`, `Clone`,
  `Copy`, `PartialEq` and `Eq` as appropriate (#1126)
+- Port benchmarks to use Criterion crate (#1116)
 
 ## [0.4.0] - 2020-12-18
 - Bump `rand` to v0.8.0

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_distr"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_hc/CHANGELOG.md
+++ b/rand_hc/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2021-06-15
+- Adjust crate links
+
 ## [0.3.0] - 2020-12-08
 - Bump `rand_core` version to 0.6.0
 - Bump MSRV to 1.36 (#1011)

--- a/rand_hc/Cargo.toml
+++ b/rand_hc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_pcg/CHANGELOG.md
+++ b/rand_pcg/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2021-06-15
+- Add `advance` methods to RNGs (#1111)
+- Document dependencies between streams (#1122)
+
 ## [0.3.0] - 2020-12-08
 - Bump `rand_core` version to 0.6.0
 - Bump MSRV to 1.36 (#1011)

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_pcg"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
There is enough here that we should at least release `rand` 0.8.4 soon. @vks should we do `rand_distr` 0.4.1 now or wait for #1136?

The only possibly-breaking change I see is the deprecation of `ReadRng`. Since I see no evidence of anyone using this I don't *think* introducing it now will be a problem.