### PR TITLE
Remove special cases for emscripten

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ getrandom = ["rand_core/getrandom"]
 simd_support = ["packed_simd"]
 
 # Option (enabled by default): enable StdRng
-std_rng = ["rand_chacha", "rand_hc"]
+std_rng = ["rand_chacha"]
 
 # Option: enable SmallRng
 small_rng = []
@@ -58,6 +58,7 @@ members = [
 rand_core = { path = "rand_core", version = "0.6.0" }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
+rand_chacha = { path = "rand_chacha", version = "0.3.0", default-features = false, optional = true }
 
 [dependencies.packed_simd]
 # NOTE: so far no version works reliably due to dependence on unstable features
@@ -69,13 +70,6 @@ features = ["into_bits"]
 [target.'cfg(unix)'.dependencies]
 # Used for fork protection (reseeding.rs)
 libc = { version = "0.2.22", optional = true, default-features = false }
-
-# Emscripten does not support 128-bit integers, which are used by ChaCha code.
-# We work around this by using a different RNG.
-[target.'cfg(not(target_os = "emscripten"))'.dependencies]
-rand_chacha = { path = "rand_chacha", version = "0.3.0", default-features = false, optional = true }
-[target.'cfg(target_os = "emscripten")'.dependencies]
-rand_hc = { path = "rand_hc", version = "0.3.0", optional = true }
 
 [dev-dependencies]
 rand_pcg = { path = "rand_pcg", version = "0.3.0" }

--- a/rand_distr/src/weighted_alias.rs
+++ b/rand_distr/src/weighted_alias.rs
@@ -353,16 +353,12 @@ macro_rules! impl_weight_for_int {
 impl_weight_for_float!(f64);
 impl_weight_for_float!(f32);
 impl_weight_for_int!(usize);
-#[cfg(not(target_os = "emscripten"))]
-#[cfg_attr(doc_cfg, doc(cfg(not(target_os = "emscripten"))))]
 impl_weight_for_int!(u128);
 impl_weight_for_int!(u64);
 impl_weight_for_int!(u32);
 impl_weight_for_int!(u16);
 impl_weight_for_int!(u8);
 impl_weight_for_int!(isize);
-#[cfg(not(target_os = "emscripten"))]
-#[cfg_attr(doc_cfg, doc(cfg(not(target_os = "emscripten"))))]
 impl_weight_for_int!(i128);
 impl_weight_for_int!(i64);
 impl_weight_for_int!(i32);
@@ -401,14 +397,12 @@ mod test {
         );
     }
 
-    #[cfg(not(target_os = "emscripten"))]
     #[test]
     #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_weighted_index_u128() {
         test_weighted_index(|x: u128| x as f64);
     }
 
-    #[cfg(not(target_os = "emscripten"))]
     #[test]
     #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_weighted_index_i128() {

--- a/rand_pcg/src/lib.rs
+++ b/rand_pcg/src/lib.rs
@@ -37,9 +37,8 @@
 #![deny(missing_debug_implementations)]
 #![no_std]
 
-#[cfg(not(target_os = "emscripten"))] mod pcg128;
+mod pcg128;
 mod pcg64;
 
-#[cfg(not(target_os = "emscripten"))]
 pub use self::pcg128::{Lcg128Xsl64, Mcg128Xsl64, Pcg64, Pcg64Mcg};
 pub use self::pcg64::{Lcg64Xsh32, Pcg32};

--- a/src/distributions/integer.rs
+++ b/src/distributions/integer.rs
@@ -14,8 +14,8 @@ use crate::Rng;
 use core::arch::x86::{__m128i, __m256i};
 #[cfg(all(target_arch = "x86_64", feature = "simd_support"))]
 use core::arch::x86_64::{__m128i, __m256i};
-#[cfg(not(target_os = "emscripten"))] use core::num::NonZeroU128;
-use core::num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
+use core::num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+    NonZeroU128};
 #[cfg(feature = "simd_support")] use packed_simd::*;
 
 impl Distribution<u8> for Standard {
@@ -46,7 +46,6 @@ impl Distribution<u64> for Standard {
     }
 }
 
-#[cfg(not(target_os = "emscripten"))]
 impl Distribution<u128> for Standard {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u128 {
@@ -86,7 +85,6 @@ impl_int_from_uint! { i8, u8 }
 impl_int_from_uint! { i16, u16 }
 impl_int_from_uint! { i32, u32 }
 impl_int_from_uint! { i64, u64 }
-#[cfg(not(target_os = "emscripten"))]
 impl_int_from_uint! { i128, u128 }
 impl_int_from_uint! { isize, usize }
 
@@ -108,7 +106,6 @@ impl_nzint!(NonZeroU8, NonZeroU8::new);
 impl_nzint!(NonZeroU16, NonZeroU16::new);
 impl_nzint!(NonZeroU32, NonZeroU32::new);
 impl_nzint!(NonZeroU64, NonZeroU64::new);
-#[cfg(not(target_os = "emscripten"))]
 impl_nzint!(NonZeroU128, NonZeroU128::new);
 impl_nzint!(NonZeroUsize, NonZeroUsize::new);
 
@@ -173,7 +170,6 @@ mod tests {
         rng.sample::<i16, _>(Standard);
         rng.sample::<i32, _>(Standard);
         rng.sample::<i64, _>(Standard);
-        #[cfg(not(target_os = "emscripten"))]
         rng.sample::<i128, _>(Standard);
 
         rng.sample::<usize, _>(Standard);
@@ -181,7 +177,6 @@ mod tests {
         rng.sample::<u16, _>(Standard);
         rng.sample::<u32, _>(Standard);
         rng.sample::<u64, _>(Standard);
-        #[cfg(not(target_os = "emscripten"))]
         rng.sample::<u128, _>(Standard);
     }
 

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -556,7 +556,6 @@ uniform_int_impl! { i8, u8, u32 }
 uniform_int_impl! { i16, u16, u32 }
 uniform_int_impl! { i32, u32, u32 }
 uniform_int_impl! { i64, u64, u64 }
-#[cfg(not(target_os = "emscripten"))]
 uniform_int_impl! { i128, u128, u128 }
 uniform_int_impl! { isize, usize, usize }
 uniform_int_impl! { u8, u8, u32 }
@@ -564,7 +563,6 @@ uniform_int_impl! { u16, u16, u32 }
 uniform_int_impl! { u32, u32, u32 }
 uniform_int_impl! { u64, u64, u64 }
 uniform_int_impl! { usize, usize, usize }
-#[cfg(not(target_os = "emscripten"))]
 uniform_int_impl! { u128, u128, u128 }
 
 #[cfg(feature = "simd_support")]
@@ -1224,7 +1222,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_integers() {
-        #[cfg(not(target_os = "emscripten"))] use core::{i128, u128};
+        use core::{i128, u128};
         use core::{i16, i32, i64, i8, isize};
         use core::{u16, u32, u64, u8, usize};
 
@@ -1292,9 +1290,7 @@ mod tests {
                 );)*
             }};
         }
-        t!(i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
-        #[cfg(not(target_os = "emscripten"))]
-        t!(i128, u128);
+        t!(i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, i128, u128);
 
         #[cfg(feature = "simd_support")]
         {

--- a/src/distributions/utils.rs
+++ b/src/distributions/utils.rs
@@ -56,7 +56,6 @@ macro_rules! wmul_impl {
 wmul_impl! { u8, u16, 8 }
 wmul_impl! { u16, u32, 16 }
 wmul_impl! { u32, u64, 32 }
-#[cfg(not(target_os = "emscripten"))]
 wmul_impl! { u64, u128, 64 }
 
 // This code is a translation of the __mulddi3 function in LLVM's
@@ -120,9 +119,6 @@ macro_rules! wmul_impl_large {
         )+
     };
 }
-#[cfg(target_os = "emscripten")]
-wmul_impl_large! { u64, 32 }
-#[cfg(not(target_os = "emscripten"))]
 wmul_impl_large! { u128, 64 }
 
 macro_rules! wmul_impl_usize {

--- a/src/distributions/weighted.rs
+++ b/src/distributions/weighted.rs
@@ -43,6 +43,5 @@ pub mod alias_method {
     impl_weight!(f64, f32,);
     impl_weight!(u8, u16, u32, u64, usize,);
     impl_weight!(i8, i16, i32, i64, isize,);
-    #[cfg(not(target_os = "emscripten"))]
     impl_weight!(u128, i128,);
 }

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -389,12 +389,8 @@ macro_rules! impl_fill {
     }
 }
 
-impl_fill!(u16, u32, u64, usize,);
-#[cfg(not(target_os = "emscripten"))]
-impl_fill!(u128);
-impl_fill!(i8, i16, i32, i64, isize,);
-#[cfg(not(target_os = "emscripten"))]
-impl_fill!(i128);
+impl_fill!(u16, u32, u64, usize, u128,);
+impl_fill!(i8, i16, i32, i64, isize, i128,);
 
 #[cfg(feature = "min_const_gen")]
 impl<T, const N: usize> Fill for [T; N]

--- a/src/rngs/std.rs
+++ b/src/rngs/std.rs
@@ -10,13 +10,9 @@
 
 use crate::{CryptoRng, Error, RngCore, SeedableRng};
 
-#[cfg(all(any(test, feature = "std"), not(target_os = "emscripten")))]
 pub(crate) use rand_chacha::ChaCha12Core as Core;
-#[cfg(all(any(test, feature = "std"), target_os = "emscripten"))]
-pub(crate) use rand_hc::Hc128Core as Core;
 
-#[cfg(not(target_os = "emscripten"))] use rand_chacha::ChaCha12Rng as Rng;
-#[cfg(target_os = "emscripten")] use rand_hc::Hc128Rng as Rng;
+use rand_chacha::ChaCha12Rng as Rng;
 
 /// The standard RNG. The PRNG algorithm in `StdRng` is chosen to be efficient
 /// on the current platform, to be statistically strong and unpredictable


### PR DESCRIPTION
Because emscripten supports 128-bit integers now, we no longer have to
add special cases for it. In particular, we can now use ChaCha12 on all
platforms.

I tested this on my machine, and all affected crates build fine with emscripten. Running the tests did not work due to some compilation error though.