### PR TITLE
Fix build on non-32/64-bit architectures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,7 +186,7 @@ jobs:
             target: avr-unknown-gnu-atmega328
             override: true
       - name: Build top-level only
-        run: cargo build --target=avr-unknown-gnu-atmega328 --no-default-features
+        run: cargo build -Z build-std=core --target=avr-unknown-gnu-atmega328 --no-default-features
 
   test-ios:
     runs-on: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,6 +184,7 @@ jobs:
             profile: minimal
             toolchain: nightly-2021-01-07 # Pinned compiler version due to https://github.com/rust-lang/compiler-builtins/issues/400
             target: avr-unknown-gnu-atmega328
+            components: rust-src
             override: true
       - name: Build top-level only
         run: cargo build -Z build-std=core --target=avr-unknown-gnu-atmega328 --no-default-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,6 @@ jobs:
         with:
             profile: minimal
             toolchain: nightly-2021-01-07 # Pinned compiler version due to https://github.com/rust-lang/compiler-builtins/issues/400
-            target: avr-unknown-gnu-atmega328
             components: rust-src
             override: true
       - name: Build top-level only

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,6 +174,20 @@ jobs:
       - name: Build top-level only
         run: cargo build --target=thumbv6m-none-eabi --no-default-features
 
+  test-avr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            profile: minimal
+            toolchain: nightly-2021-01-07 # Pinned compiler version due to https://github.com/rust-lang/compiler-builtins/issues/400
+            target: avr-unknown-gnu-atmega328
+            override: true
+      - name: Build top-level only
+        run: cargo build --target=avr-unknown-gnu-atmega328 --no-default-features
+
   test-ios:
     runs-on: macos-latest
     steps:

--- a/src/distributions/utils.rs
+++ b/src/distributions/utils.rs
@@ -138,6 +138,10 @@ macro_rules! wmul_impl_usize {
         }
     };
 }
+#[cfg(target_pointer_width = "8")]
+wmul_impl_usize! { u8 }
+#[cfg(target_pointer_width = "16")]
+wmul_impl_usize! { u16 }
 #[cfg(target_pointer_width = "32")]
 wmul_impl_usize! { u32 }
 #[cfg(target_pointer_width = "64")]

--- a/src/distributions/utils.rs
+++ b/src/distributions/utils.rs
@@ -138,8 +138,6 @@ macro_rules! wmul_impl_usize {
         }
     };
 }
-#[cfg(target_pointer_width = "8")]
-wmul_impl_usize! { u8 }
 #[cfg(target_pointer_width = "16")]
 wmul_impl_usize! { u16 }
 #[cfg(target_pointer_width = "32")]


### PR DESCRIPTION
I've been trying to build `rand` for AVR (which has 8-bit pointers), failing with errors like the following:

```
error[E0599]: no method named `wmul` found for type `usize` in the current scope
   --> /home/patrick/.cargo/registry/src/github.com-1ecc6299db9ec823/rand-0.8.4/src/distributions/uniform.rs:491:42
    |
491 |                         let (hi, lo) = v.wmul(range);
    |                                          ^^^^ method not found in `usize`
...
561 | uniform_int_impl! { isize, usize, usize }
    | ----------------------------------------- in this macro invocation
    |
    = help: items from traits can only be used if the trait is implemented and in scope
note: `WideningMultiply` defines an item `wmul`, perhaps you need to implement it
   --> /home/patrick/.cargo/registry/src/github.com-1ecc6299db9ec823/rand-0.8.4/src/distributions/utils.rs:14:1
    |
14  | pub(crate) trait WideningMultiply<RHS = Self> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

```

This fixes it, and should fix it for any 8-bit and 16-bit architecture.