### PR TITLE
Propagate std and getrandom features

### DIFF
--- a/rand_chacha/CHANGELOG.md
+++ b/rand_chacha/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Made `rand_chacha` propagate the `std` and `getrandom` features down to `rand_core`
+- Made `rand_chacha` propagate the `std` feature down to `rand_core`
 
 ## [0.3.1] - 2021-06-09
 - add getters corresponding to existing setters: `get_seed`, `get_stream` (#1124)

--- a/rand_chacha/CHANGELOG.md
+++ b/rand_chacha/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Made `rand_chacha` propagate the `std` and `getrandom` features down to `rand_core`
+
 ## [0.3.1] - 2021-06-09
 - add getters corresponding to existing setters: `get_seed`, `get_stream` (#1124)
 - add serde support, gated by the `serde1` feature (#1124)

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -26,6 +26,5 @@ serde_json = "1.0"
 [features]
 default = ["std"]
 std = ["ppv-lite86/std", "rand_core/std"]
-getrandom = ["rand_core/getrandom"]
 simd = [] # deprecated
 serde1 = ["serde"]

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 
 [features]
 default = ["std"]
-std = ["ppv-lite86/std"]
+std = ["ppv-lite86/std", "rand_core/std"]
+getrandom = ["rand_core/getrandom"]
 simd = [] # deprecated
 serde1 = ["serde"]

--- a/rand_chacha/README.md
+++ b/rand_chacha/README.md
@@ -36,7 +36,8 @@ Links:
 
 `rand_chacha` is `no_std` compatible when disabling default features; the `std`
 feature can be explicitly required to re-enable `std` support. Using `std`
-allows detection of CPU features and thus better optimisation.
+allows detection of CPU features and thus better optimisation. Using `std`
+also enables `getrandom` functionality, such as `ChaCha20::from_entropy()`.
 
 
 # License

--- a/rand_chacha/README.md
+++ b/rand_chacha/README.md
@@ -37,7 +37,7 @@ Links:
 `rand_chacha` is `no_std` compatible when disabling default features; the `std`
 feature can be explicitly required to re-enable `std` support. Using `std`
 allows detection of CPU features and thus better optimisation. Using `std`
-also enables `getrandom` functionality, such as `ChaCha20::from_entropy()`.
+also enables `getrandom` functionality, such as `ChaCha20Rng::from_entropy()`.
 
 
 # License


### PR DESCRIPTION
## Problem
I pulled `rand_chacha` into my repo and tried to do `ChaCha20Rng::from_entropy()` and found that there was no such function. Why? Because `SeedableRng` didn't impelement it because `rand_chacha::rand_core` wasn't compiled with the `getrandom` feature/dep.

## Current Workaround
If you pull in `rand_chacha` you now also have to pull in the correct version of `rand_core` with the default features or `getrandom` set.

## Better Solution
Add a `getrandom` feature flag to `rand_chacha` so you don't have to do the above hack.