### PR TITLE
Fix unsoundness in <BlockRng64 as RngCore>:: next_u32

### DIFF
--- a/rand_core/src/error.rs
+++ b/rand_core/src/error.rs
@@ -50,9 +50,7 @@ impl Error {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
     #[inline]
     pub fn new<E>(err: E) -> Self
-    where
-        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
-    {
+    where E: Into<Box<dyn std::error::Error + Send + Sync + 'static>> {
         Error { inner: err.into() }
     }
 
@@ -223,6 +221,9 @@ mod test {
     fn test_error_codes() {
         // Make sure the values are the same as in `getrandom`.
         assert_eq!(super::Error::CUSTOM_START, getrandom::Error::CUSTOM_START);
-        assert_eq!(super::Error::INTERNAL_START, getrandom::Error::INTERNAL_START);
+        assert_eq!(
+            super::Error::INTERNAL_START,
+            getrandom::Error::INTERNAL_START
+        );
     }
 }

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -65,17 +65,15 @@ macro_rules! fill_via_chunks {
                 core::ptr::copy_nonoverlapping(
                     $src.as_ptr() as *const u8,
                     $dst.as_mut_ptr(),
-                    chunk_size_u8);
+                    chunk_size_u8,
+                );
             }
         } else {
             for (&n, chunk) in $src.iter().zip($dst.chunks_mut(SIZE)) {
                 let tmp = n.to_le();
                 let src_ptr = &tmp as *const $ty as *const u8;
                 unsafe {
-                    core::ptr::copy_nonoverlapping(
-                        src_ptr,
-                        chunk.as_mut_ptr(),
-                        chunk.len());
+                    core::ptr::copy_nonoverlapping(src_ptr, chunk.as_mut_ptr(), chunk.len());
                 }
             }
         }

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -41,8 +41,8 @@
 use core::convert::AsMut;
 use core::default::Default;
 
-#[cfg(feature = "std")] extern crate std;
 #[cfg(feature = "alloc")] extern crate alloc;
+#[cfg(feature = "std")] extern crate std;
 #[cfg(feature = "alloc")] use alloc::boxed::Box;
 
 pub use error::Error;


### PR DESCRIPTION
Previously, certain implementations of `BlockRngCore` could cause `BlockRng64`'s implementation of `RngCore::next_u32` to exhibit undefined behavior (UB). This removes that UB by adding a bounds check, and adds documentation to `BlockRngCore::Results` clarifying requirements for that type.

While we're here, run `rustfmt` on existing code.

Fixes #1158