### PR TITLE
Implement Gumbel in rand_distr

### DIFF
--- a/rand_distr/src/gumbel.rs
+++ b/rand_distr/src/gumbel.rs
@@ -90,7 +90,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::vec;
 
     #[test]
     #[should_panic]
@@ -132,11 +131,11 @@ mod tests {
         let iterations = 100_000;
         let increment = 1.0 / iterations as f64;
         let probabilities = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9];
-        let quantiles = probabilities
-            .iter()
-            .map(|x| neg_log_log(*x))
-            .collect::<vec::Vec<f64>>();
-        let mut proportions = vec![0.0; 9];
+        let mut quantiles = [0.0; 9];
+        for (i, p) in probabilities.iter().enumerate() {
+            quantiles[i] = neg_log_log(*p);
+        }
+        let mut proportions = [0.0; 9];
         let d = Gumbel::new(location, scale).unwrap();
         let mut rng = crate::test::rng(1);
         for _ in 0..iterations {

--- a/rand_distr/src/gumbel.rs
+++ b/rand_distr/src/gumbel.rs
@@ -20,7 +20,7 @@ use rand::Rng;
 /// use rand::prelude::*;
 /// use rand_distr::Gumbel;
 ///
-/// let val: f64 = thread_rng().sample(Gumbel::new(1., 10.).unwrap());
+/// let val: f64 = thread_rng().sample(Gumbel::new(0.0, 1.0).unwrap());
 /// println!("{}", val);
 /// ```
 #[derive(Clone, Copy, Debug)]

--- a/rand_distr/src/gumbel.rs
+++ b/rand_distr/src/gumbel.rs
@@ -15,6 +15,9 @@ use rand::Rng;
 
 /// Samples floating-point numbers according to the Gumbel distribution
 ///
+/// This distribution has a density function:
+/// `f(x) = exp(-(z + exp(-z))) / σ`, where `z = (x - μ) / σ`
+///
 /// # Example
 /// ```
 /// use rand::prelude::*;

--- a/rand_distr/src/gumbel.rs
+++ b/rand_distr/src/gumbel.rs
@@ -1,0 +1,132 @@
+// Copyright 2018 Developers of the Rand project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! The Gumbel distribution.
+
+use crate::{Distribution, OpenClosed01};
+use core::fmt;
+use num_traits::Float;
+use rand::Rng;
+
+/// Samples floating-point numbers according to the Gumbel distribution
+///
+/// # Example
+/// ```
+/// use rand::prelude::*;
+/// use rand_distr::Gumbel;
+///
+/// let val: f64 = thread_rng().sample(Gumbel::new(1., 10.).unwrap());
+/// println!("{}", val);
+/// ```
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+pub struct Gumbel<F>
+where
+    F: Float,
+    OpenClosed01: Distribution<F>,
+{
+    location: F,
+    scale: F,
+}
+
+/// Error type returned from `Gumbel::new`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Error {
+    /// location is infinite or NaN
+    LocationNotValid,
+    /// scale is not finite positive number
+    ScaleNotValid,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::ScaleNotValid => "scale is not positive and finite in Gumbel distribution",
+            Error::LocationNotValid => "location is not finite in Gumbel distribution",
+        })
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+impl std::error::Error for Error {}
+
+impl<F> Gumbel<F>
+where
+    F: Float,
+    OpenClosed01: Distribution<F>,
+{
+    /// Construct a new `Gumbel` distribution with given `location` and `scale`.
+    pub fn new(location: F, scale: F) -> Result<Gumbel<F>, Error> {
+        if scale <= F::zero() || scale.is_infinite() || scale.is_nan() {
+            return Err(Error::ScaleNotValid);
+        }
+        if location.is_infinite() || location.is_nan() {
+            return Err(Error::LocationNotValid);
+        }
+        Ok(Gumbel { location, scale })
+    }
+}
+
+impl<F> Distribution<F> for Gumbel<F>
+where
+    F: Float,
+    OpenClosed01: Distribution<F>,
+{
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> F {
+        let x: F = rng.sample(OpenClosed01);
+        self.location - self.scale * (-(x).ln()).ln()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn test_zero_scale() {
+        Gumbel::new(0.0, 0.0).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_infinite_scale() {
+        Gumbel::new(0.0, std::f64::INFINITY).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_nan_scale() {
+        Gumbel::new(0.0, std::f64::NAN).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_infinite_location() {
+        Gumbel::new(std::f64::INFINITY, 1.0).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_nan_location() {
+        Gumbel::new(std::f64::NAN, 1.0).unwrap();
+    }
+
+    #[test]
+    fn test_sample_against_cdf() {
+        let scale = 1.0;
+        let shape = 2.0;
+        let d = Gumbel::new(scale, shape).unwrap();
+        let mut rng = crate::test::rng(1);
+        for _ in 0..1000 {
+            let r = d.sample(&mut rng);
+            assert!(r >= 0.);
+        }
+    }
+}

--- a/rand_distr/src/gumbel.rs
+++ b/rand_distr/src/gumbel.rs
@@ -101,25 +101,25 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_infinite_scale() {
-        Gumbel::new(0.0, std::f64::INFINITY).unwrap();
+        Gumbel::new(0.0, core::f64::INFINITY).unwrap();
     }
 
     #[test]
     #[should_panic]
     fn test_nan_scale() {
-        Gumbel::new(0.0, std::f64::NAN).unwrap();
+        Gumbel::new(0.0, core::f64::NAN).unwrap();
     }
 
     #[test]
     #[should_panic]
     fn test_infinite_location() {
-        Gumbel::new(std::f64::INFINITY, 1.0).unwrap();
+        Gumbel::new(core::f64::INFINITY, 1.0).unwrap();
     }
 
     #[test]
     #[should_panic]
     fn test_nan_location() {
-        Gumbel::new(std::f64::NAN, 1.0).unwrap();
+        Gumbel::new(core::f64::NAN, 1.0).unwrap();
     }
 
     #[test]

--- a/rand_distr/src/gumbel.rs
+++ b/rand_distr/src/gumbel.rs
@@ -90,7 +90,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::vec;
+    use alloc::vec;
 
     #[test]
     #[should_panic]

--- a/rand_distr/src/gumbel.rs
+++ b/rand_distr/src/gumbel.rs
@@ -15,7 +15,7 @@ use rand::Rng;
 
 /// Samples floating-point numbers according to the Gumbel distribution
 ///
-/// This distribution has a density function:
+/// This distribution has density function:
 /// `f(x) = exp(-(z + exp(-z))) / σ`, where `z = (x - μ) / σ`
 ///
 /// # Example

--- a/rand_distr/src/gumbel.rs
+++ b/rand_distr/src/gumbel.rs
@@ -38,16 +38,16 @@ where
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Error {
     /// location is infinite or NaN
-    LocationNotValid,
+    LocationNotFinite,
     /// scale is not finite positive number
-    ScaleNotValid,
+    ScaleNotPositive,
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
-            Error::ScaleNotValid => "scale is not positive and finite in Gumbel distribution",
-            Error::LocationNotValid => "location is not finite in Gumbel distribution",
+            Error::ScaleNotPositive => "scale is not positive and finite in Gumbel distribution",
+            Error::LocationNotFinite => "location is not finite in Gumbel distribution",
         })
     }
 }
@@ -64,10 +64,10 @@ where
     /// Construct a new `Gumbel` distribution with given `location` and `scale`.
     pub fn new(location: F, scale: F) -> Result<Gumbel<F>, Error> {
         if scale <= F::zero() || scale.is_infinite() || scale.is_nan() {
-            return Err(Error::ScaleNotValid);
+            return Err(Error::ScaleNotPositive);
         }
         if location.is_infinite() || location.is_nan() {
-            return Err(Error::LocationNotValid);
+            return Err(Error::LocationNotFinite);
         }
         Ok(Gumbel { location, scale })
     }

--- a/rand_distr/src/gumbel.rs
+++ b/rand_distr/src/gumbel.rs
@@ -16,7 +16,8 @@ use rand::Rng;
 /// Samples floating-point numbers according to the Gumbel distribution
 ///
 /// This distribution has density function:
-/// `f(x) = exp(-(z + exp(-z))) / σ`, where `z = (x - μ) / σ`
+/// `f(x) = exp(-(z + exp(-z))) / σ`, where `z = (x - μ) / σ`,
+/// `μ` is the location parameter, and `σ` the scale parameter.
 ///
 /// # Example
 /// ```

--- a/rand_distr/src/gumbel.rs
+++ b/rand_distr/src/gumbel.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Developers of the Rand project.
+// Copyright 2021 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/rand_distr/src/gumbel.rs
+++ b/rand_distr/src/gumbel.rs
@@ -80,7 +80,7 @@ where
 {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> F {
         let x: F = rng.sample(OpenClosed01);
-        self.location - self.scale * (-(x).ln()).ln()
+        self.location - self.scale * (-x.ln()).ln()
     }
 }
 

--- a/rand_distr/src/lib.rs
+++ b/rand_distr/src/lib.rs
@@ -56,6 +56,7 @@
 //!   - [`Poisson`] distribution
 //!   - [`Exp`]onential distribution, and [`Exp1`] as a primitive
 //!   - [`Weibull`] distribution
+//!   - [`Gumbel`] distribution
 //!   - [`Zeta`] distribution
 //!   - [`Zipf`] distribution
 //! - Gamma and derived distributions:
@@ -77,7 +78,6 @@
 //! - Misc. distributions
 //!   - [`InverseGaussian`] distribution
 //!   - [`NormalInverseGaussian`] distribution
-//!   - [`Gumbel`] distribution
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/rand_distr/src/lib.rs
+++ b/rand_distr/src/lib.rs
@@ -77,6 +77,7 @@
 //! - Misc. distributions
 //!   - [`InverseGaussian`] distribution
 //!   - [`NormalInverseGaussian`] distribution
+//!   - [`Gumbel`] distribution
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -104,6 +105,7 @@ pub use self::gamma::{
     Gamma, StudentT,
 };
 pub use self::geometric::{Error as GeoError, Geometric, StandardGeometric};
+pub use self::gumbel::{Error as GumbelError, Gumbel};
 pub use self::hypergeometric::{Error as HyperGeoError, Hypergeometric};
 pub use self::inverse_gaussian::{InverseGaussian, Error as InverseGaussianError};
 pub use self::normal::{Error as NormalError, LogNormal, Normal, StandardNormal};
@@ -186,6 +188,7 @@ mod dirichlet;
 mod exponential;
 mod gamma;
 mod geometric;
+mod gumbel;
 mod hypergeometric;
 mod inverse_gaussian;
 mod normal;


### PR DESCRIPTION
This adds the Gumbel distribution to `rand_distr`, which I think could be useful given its connection to extreme value theory. In particular, there is a [result](https://en.wikipedia.org/wiki/Fisher%E2%80%93Tippett%E2%80%93Gnedenko_theorem) which says that extreme order statistics can only converge in distribution to either the Weibull, Gumbel, or Frechet distributions as the sample size tends to infinity. This crate already has the Weibull, so I think adding the Gumbel and Frechet might make some sense.

(I'm not sure if I should have created an issue first; if so I can do that now.)