### PR TITLE
Fix no_std compatibility issues

### DIFF
--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -18,9 +18,9 @@ const RAND_BENCH_N: u64 = 1000;
 
 use rand::distributions::{Alphanumeric, Open01, OpenClosed01, Standard, Uniform};
 use rand::distributions::uniform::{UniformInt, UniformSampler};
-use std::mem::size_of;
-use std::num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8};
-use std::time::Duration;
+use core::mem::size_of;
+use core::num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8};
+use core::time::Duration;
 use test::{Bencher, black_box};
 
 use rand::prelude::*;
@@ -199,7 +199,7 @@ macro_rules! gen_range_int {
                 for _ in 0..RAND_BENCH_N {
                     accum = accum.wrapping_add(rng.gen_range($low..high));
                     // force recalculation of range each time
-                    high = high.wrapping_add(1) & std::$ty::MAX;
+                    high = high.wrapping_add(1) & core::$ty::MAX;
                 }
                 accum
             });

--- a/benches/generators.rs
+++ b/benches/generators.rs
@@ -14,7 +14,7 @@ extern crate test;
 const RAND_BENCH_N: u64 = 1000;
 const BYTES_LEN: usize = 1024;
 
-use std::mem::size_of;
+use core::mem::size_of;
 use test::{black_box, Bencher};
 
 use rand::prelude::*;

--- a/benches/misc.rs
+++ b/benches/misc.rs
@@ -98,7 +98,7 @@ fn misc_bernoulli_var(b: &mut Bencher) {
 
 #[bench]
 fn gen_1kb_u16_iter_repeat(b: &mut Bencher) {
-    use std::iter;
+    use core::iter;
     let mut rng = Pcg64Mcg::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
         let v: Vec<u16> = iter::repeat(()).map(|()| rng.gen()).take(512).collect();
@@ -141,7 +141,7 @@ fn gen_1kb_u16_fill(b: &mut Bencher) {
 
 #[bench]
 fn gen_1kb_u64_iter_repeat(b: &mut Bencher) {
-    use std::iter;
+    use core::iter;
     let mut rng = Pcg64Mcg::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
         let v: Vec<u64> = iter::repeat(()).map(|()| rng.gen()).take(128).collect();

--- a/benches/seq.rs
+++ b/benches/seq.rs
@@ -15,7 +15,7 @@ use test::Bencher;
 
 use rand::prelude::*;
 use rand::seq::*;
-use std::mem::size_of;
+use core::mem::size_of;
 
 // We force use of 32-bit RNG since seq code is optimised for use with 32-bit
 // generators on all platforms.
@@ -116,7 +116,7 @@ impl<I: ExactSizeIterator + Iterator + Clone> Iterator for WindowHintedIterator<
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (std::cmp::min(self.iter.len(), self.window_size), None)
+        (core::cmp::min(self.iter.len(), self.window_size), None)
     }
 }
 

--- a/rand_distr/benches/src/distributions.rs
+++ b/rand_distr/benches/src/distributions.rs
@@ -17,7 +17,7 @@ use criterion::{criterion_group, criterion_main, Criterion,
     Throughput};
 use criterion_cycles_per_byte::CyclesPerByte;
 
-use std::mem::size_of;
+use core::mem::size_of;
 
 use rand::prelude::*;
 use rand_distr::*;

--- a/rand_distr/tests/uniformity.rs
+++ b/rand_distr/tests/uniformity.rs
@@ -48,7 +48,7 @@ fn unit_sphere() {
 
 #[test]
 fn unit_circle() {
-    use std::f64::consts::PI;
+    use core::f64::consts::PI;
     let mut h = Histogram100::with_const_width(-PI, PI);
     let dist = rand_distr::UnitCircle;
     let mut rng = rand_pcg::Pcg32::from_entropy();

--- a/src/distributions/distribution.rs
+++ b/src/distributions/distribution.rs
@@ -209,7 +209,7 @@ pub trait DistString {
 
 #[cfg(test)]
 mod tests {
-    use crate::distributions::{Alphanumeric, Distribution, Standard, Uniform};
+    use crate::distributions::{Distribution, Uniform};
     use crate::Rng;
 
     #[test]
@@ -258,7 +258,7 @@ mod tests {
     #[cfg(feature = "alloc")]
     fn test_dist_string() {
         use core::str;
-        use crate::distributions::DistString;
+        use crate::distributions::{Alphanumeric, DistString, Standard};
         let mut rng = crate::test::rng(213);
 
         let s1 = Alphanumeric.sample_string(&mut rng, 20);

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -21,7 +21,7 @@ use crate::Rng;
 #[cfg(feature = "serde1")]
 use serde::{Serialize, Deserialize};
 #[cfg(feature = "min_const_gen")]
-use std::mem::{self, MaybeUninit};
+use core::mem::{self, MaybeUninit};
 
 
 // ----- Sampling distributions -----

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -103,8 +103,7 @@
 //! [`UniformDuration`]: crate::distributions::uniform::UniformDuration
 //! [`SampleBorrow::borrow`]: crate::distributions::uniform::SampleBorrow::borrow
 
-#[cfg(not(feature = "std"))] use core::time::Duration;
-#[cfg(feature = "std")] use std::time::Duration;
+use core::time::Duration;
 use core::ops::{Range, RangeInclusive};
 
 use crate::distributions::float::IntoFloat;
@@ -1153,7 +1152,8 @@ mod tests {
     #[test]
     #[cfg(feature = "serde1")]
     fn test_serialization_uniform_duration() {
-        let distr = UniformDuration::new(std::time::Duration::from_secs(10), std::time::Duration::from_secs(60));
+        use core::time::Duration;
+        let distr = UniformDuration::new(Duration::from_secs(10), Duration::from_secs(60));
         let de_distr: UniformDuration = bincode::deserialize(&bincode::serialize(&distr).unwrap()).unwrap();
         assert_eq!(
             distr.offset, de_distr.offset
@@ -1503,8 +1503,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_durations() {
-        #[cfg(not(feature = "std"))] use core::time::Duration;
-        #[cfg(feature = "std")] use std::time::Duration;
+        use core::time::Duration;
 
         let mut rng = crate::test::rng(253);
 

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -272,8 +272,8 @@ where R: Rng + ?Sized {
 /// `O(length + amount * log length)` time otherwise.
 ///
 /// Panics if `amount > length`.
-#[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+#[cfg(feature = "alloc")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub fn sample_weighted<R, F, X>(
     rng: &mut R, length: usize, weight: F, amount: usize,
 ) -> Result<IndexVec, WeightedError>
@@ -305,7 +305,7 @@ where
 /// + amount * log length)` time otherwise.
 ///
 /// Panics if `amount > length`.
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 fn sample_efraimidis_spirakis<R, F, X, N>(
     rng: &mut R, length: N, weight: F, amount: N,
 ) -> Result<IndexVec, WeightedError>
@@ -380,7 +380,7 @@ where
 
     #[cfg(not(feature = "nightly"))]
     {
-        use std::collections::BinaryHeap;
+        use alloc::collections::BinaryHeap;
 
         // Partially sort the array such that the `amount` elements with the largest
         // keys are first using a binary max heap.
@@ -621,7 +621,7 @@ mod test {
         assert_eq!(v1, v2);
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_sample_weighted() {
         let seed_rng = crate::test::rng;


### PR DESCRIPTION
- Using `features = ["min_const_gen"]` on `no_std` fails to compile because of a bad import.
- The `sample_efraimidis_spirakis` algorithm only requires `alloc` but it was marked with a `std` requirement.
- Replaced `std` with `core` in places where the standard library uses `core`.