### PR TITLE
Add `min_const_gen` to "all stable features" test invocation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
           cargo build --target ${{ matrix.target }} --no-default-features --features alloc,getrandom,small_rng
           cargo test --target ${{ matrix.target }} --lib --tests --no-default-features --features=alloc,getrandom,small_rng
           # all stable features:
-          cargo test --target ${{ matrix.target }} --features=serde1,log,small_rng
+          cargo test --target ${{ matrix.target }} --features=serde1,log,small_rng,min_const_gen
           cargo test --target ${{ matrix.target }} --examples
       - name: Test rand_core
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,9 +82,16 @@ jobs:
           cargo test --target ${{ matrix.target }} --lib --tests --no-default-features
           cargo build --target ${{ matrix.target }} --no-default-features --features alloc,getrandom,small_rng
           cargo test --target ${{ matrix.target }} --lib --tests --no-default-features --features=alloc,getrandom,small_rng
-          # all stable features:
-          cargo test --target ${{ matrix.target }} --features=serde1,log,small_rng,min_const_gen
           cargo test --target ${{ matrix.target }} --examples
+      - name: Test rand (all stable features, non-MSRV)
+        if: ${{ matrix.toolchain != '1.36.0' }}
+        run: |
+          cargo test --target ${{ matrix.target }} --features=serde1,log,small_rng,min_const_gen
+      - name: Test rand (all stable features, MSRV)
+        if: ${{ matrix.toolchain == '1.36.0' }}
+        run: |
+          # const generics are not stable on 1.36.0
+          cargo test --target ${{ matrix.target }} --features=serde1,log,small_rng
       - name: Test rand_core
         run: |
           cargo test --target ${{ matrix.target }} --manifest-path rand_core/Cargo.toml


### PR DESCRIPTION
I was in the process of making a PR to support `min_const_gen` without `std` when I saw #1173 already existed! This PR is intended to unblock/accelerate that, though it makes sense as an orthogonal change. If it's preferable to fix it in that PR, feel free to close this one 🙂 

---

- cda046507 **Add `min_const_gen` to "all stable features" test invocation**

  `min_const_gen` is a stable feature, but was not added to this test
  invocation when it was introduced.
  
  Unblocks #1173.
