### PR TITLE
fill_via_chunks: use safe code via chunks_exact_mut on BE

### DIFF
--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -52,17 +52,19 @@ pub fn fill_bytes_via_next<R: RngCore + ?Sized>(rng: &mut R, dest: &mut [u8]) {
     }
 }
 
-trait ToLe: Copy {
+/// Contract: implementing type must be memory-safe to observe as a byte array
+/// (implies no uninitialised padding).
+unsafe trait ToLe: Copy {
     type Bytes: AsRef<[u8]>;
     fn to_le_bytes(self) -> Self::Bytes;
 }
-impl ToLe for u32 {
+unsafe impl ToLe for u32 {
     type Bytes = [u8; 4];
     fn to_le_bytes(self) -> Self::Bytes {
         self.to_le_bytes()
     }
 }
-impl ToLe for u64 {
+unsafe impl ToLe for u64 {
     type Bytes = [u8; 8];
     fn to_le_bytes(self) -> Self::Bytes {
         self.to_le_bytes()


### PR DESCRIPTION
Address #1170 (@joshlf):

- [ ] `fill_via_chunks`: remove/replace first use of `unsafe`
- [x] `fill_via_chunks`: replace second use of `unsafe`
- [x] inline `fill_via_chunks` or use a generic function?
- [ ] ~~remove `unsafe` in `BlockRngCore::generate for ChaChaXCore`~~ (#1181)

This removes some `unsafe` code and is actually a substantial performance boost (if the LE specific path is commented out). Specifically, using `chunks_exact_mut` is a massive boost to the `gen_bytes_chacha*` benches (the only ones affected).

We *could* remove the LE-specific branch, but as mentioned it is substantially faster than the chunking code (much more than the 8% previously mentioned). I don't *think* there's a better `safe` alternative than chunking.

Some quick benchmarks:
```
# LE code (copy_nonoverlapping):
test gen_bytes_chacha12      ... bench:     235,341 ns/iter (+/- 2,141) = 4351 MB/s
test gen_bytes_chacha20      ... bench:     374,516 ns/iter (+/- 2,762) = 2734 MB/s
test gen_bytes_chacha8       ... bench:     167,612 ns/iter (+/- 1,709) = 6109 MB/s
# New chunking code:
test gen_bytes_chacha12      ... bench:     336,035 ns/iter (+/- 5,764) = 3047 MB/s
test gen_bytes_chacha20      ... bench:     472,304 ns/iter (+/- 3,544) = 2168 MB/s
test gen_bytes_chacha8       ... bench:     270,032 ns/iter (+/- 4,526) = 3792 MB/s
# Old chunking code:
test gen_bytes_chacha12      ... bench:     888,131 ns/iter (+/- 4,710) = 1152 MB/s
test gen_bytes_chacha20      ... bench:   1,022,726 ns/iter (+/- 2,474) = 1001 MB/s
test gen_bytes_chacha8       ... bench:     819,164 ns/iter (+/- 3,944) = 1250 MB/s
```