### PR TITLE
chacha: safer outputting

### DIFF
--- a/rand_chacha/src/chacha.rs
+++ b/rand_chacha/src/chacha.rs
@@ -87,13 +87,7 @@ macro_rules! chacha_impl {
             type Results = Array64<u32>;
             #[inline]
             fn generate(&mut self, r: &mut Self::Results) {
-                // Fill slice of words by writing to equivalent slice of bytes, then fixing endianness.
-                self.state.refill4($rounds, unsafe {
-                    &mut *(&mut *r as *mut Array64<u32> as *mut [u8; 256])
-                });
-                for x in r.as_mut() {
-                    *x = x.to_le();
-                }
+                self.state.refill4($rounds, &mut r.0);
             }
         }
 

--- a/rand_chacha/src/guts.rs
+++ b/rand_chacha/src/guts.rs
@@ -159,22 +159,13 @@ fn refill_wide_impl<Mach: Machine>(
     let sc = m.unpack(state.c);
     let sd = [m.unpack(state.d), d1, d2, d3];
     state.d = d4.into();
-    out[0..4].copy_from_slice(&(a[0] + k).to_lanes());
-    out[4..8].copy_from_slice(&(b[0] + sb).to_lanes());
-    out[8..12].copy_from_slice(&(c[0] + sc).to_lanes());
-    out[12..16].copy_from_slice(&(d[0] + sd[0]).to_lanes());
-    out[16..20].copy_from_slice(&(a[1] + k).to_lanes());
-    out[20..24].copy_from_slice(&(b[1] + sb).to_lanes());
-    out[24..28].copy_from_slice(&(c[1] + sc).to_lanes());
-    out[28..32].copy_from_slice(&(d[1] + sd[1]).to_lanes());
-    out[32..36].copy_from_slice(&(a[2] + k).to_lanes());
-    out[36..40].copy_from_slice(&(b[2] + sb).to_lanes());
-    out[40..44].copy_from_slice(&(c[2] + sc).to_lanes());
-    out[44..48].copy_from_slice(&(d[2] + sd[2]).to_lanes());
-    out[48..52].copy_from_slice(&(a[3] + k).to_lanes());
-    out[52..56].copy_from_slice(&(b[3] + sb).to_lanes());
-    out[56..60].copy_from_slice(&(c[3] + sc).to_lanes());
-    out[60..64].copy_from_slice(&(d[3] + sd[3]).to_lanes());
+    for i in 0..4 {
+        let i4 = i * 4;
+        out[i4..(i4+4)].copy_from_slice(&(a[i] + k).to_lanes());
+        out[(i4+4)..(i4+8)].copy_from_slice(&(b[i] + sb).to_lanes());
+        out[(i4+8)..(i4+12)].copy_from_slice(&(c[i] + sc).to_lanes());
+        out[(i4+12)..(i4+16)].copy_from_slice(&(d[i] + sd[i]).to_lanes());
+    }
 }
 
 dispatch!(m, Mach, {

--- a/rand_chacha/src/guts.rs
+++ b/rand_chacha/src/guts.rs
@@ -159,13 +159,22 @@ fn refill_wide_impl<Mach: Machine>(
     let sc = m.unpack(state.c);
     let sd = [m.unpack(state.d), d1, d2, d3];
     state.d = d4.into();
-    let mut words = out.chunks_exact_mut(4);
-    for ((((&a, &b), &c), &d), &sd) in a.iter().zip(&b).zip(&c).zip(&d).zip(&sd) {
-        words.next().unwrap().copy_from_slice(&(a + k).to_lanes());
-        words.next().unwrap().copy_from_slice(&(b + sb).to_lanes());
-        words.next().unwrap().copy_from_slice(&(c + sc).to_lanes());
-        words.next().unwrap().copy_from_slice(&(d + sd).to_lanes());
-    }
+    out[0..4].copy_from_slice(&(a[0] + k).to_lanes());
+    out[4..8].copy_from_slice(&(b[0] + sb).to_lanes());
+    out[8..12].copy_from_slice(&(c[0] + sc).to_lanes());
+    out[12..16].copy_from_slice(&(d[0] + sd[0]).to_lanes());
+    out[16..20].copy_from_slice(&(a[1] + k).to_lanes());
+    out[20..24].copy_from_slice(&(b[1] + sb).to_lanes());
+    out[24..28].copy_from_slice(&(c[1] + sc).to_lanes());
+    out[28..32].copy_from_slice(&(d[1] + sd[1]).to_lanes());
+    out[32..36].copy_from_slice(&(a[2] + k).to_lanes());
+    out[36..40].copy_from_slice(&(b[2] + sb).to_lanes());
+    out[40..44].copy_from_slice(&(c[2] + sc).to_lanes());
+    out[44..48].copy_from_slice(&(d[2] + sd[2]).to_lanes());
+    out[48..52].copy_from_slice(&(a[3] + k).to_lanes());
+    out[52..56].copy_from_slice(&(b[3] + sb).to_lanes());
+    out[56..60].copy_from_slice(&(c[3] + sc).to_lanes());
+    out[60..64].copy_from_slice(&(d[3] + sd[3]).to_lanes());
 }
 
 dispatch!(m, Mach, {

--- a/rand_chacha/src/guts.rs
+++ b/rand_chacha/src/guts.rs
@@ -159,13 +159,22 @@ fn refill_wide_impl<Mach: Machine>(
     let sc = m.unpack(state.c);
     let sd = [m.unpack(state.d), d1, d2, d3];
     state.d = d4.into();
-    for i in 0..4 {
-        let i4 = i * 4;
-        out[i4..(i4+4)].copy_from_slice(&(a[i] + k).to_lanes());
-        out[(i4+4)..(i4+8)].copy_from_slice(&(b[i] + sb).to_lanes());
-        out[(i4+8)..(i4+12)].copy_from_slice(&(c[i] + sc).to_lanes());
-        out[(i4+12)..(i4+16)].copy_from_slice(&(d[i] + sd[i]).to_lanes());
-    }
+    out[0..4].copy_from_slice(&(a[0] + k).to_lanes());
+    out[4..8].copy_from_slice(&(b[0] + sb).to_lanes());
+    out[8..12].copy_from_slice(&(c[0] + sc).to_lanes());
+    out[12..16].copy_from_slice(&(d[0] + sd[0]).to_lanes());
+    out[16..20].copy_from_slice(&(a[1] + k).to_lanes());
+    out[20..24].copy_from_slice(&(b[1] + sb).to_lanes());
+    out[24..28].copy_from_slice(&(c[1] + sc).to_lanes());
+    out[28..32].copy_from_slice(&(d[1] + sd[1]).to_lanes());
+    out[32..36].copy_from_slice(&(a[2] + k).to_lanes());
+    out[36..40].copy_from_slice(&(b[2] + sb).to_lanes());
+    out[40..44].copy_from_slice(&(c[2] + sc).to_lanes());
+    out[44..48].copy_from_slice(&(d[2] + sd[2]).to_lanes());
+    out[48..52].copy_from_slice(&(a[3] + k).to_lanes());
+    out[52..56].copy_from_slice(&(b[3] + sb).to_lanes());
+    out[56..60].copy_from_slice(&(c[3] + sc).to_lanes());
+    out[60..64].copy_from_slice(&(d[3] + sd[3]).to_lanes());
 }
 
 dispatch!(m, Mach, {


### PR DESCRIPTION
mod guts was originally designed for the byteslice interface RustCrypto APIs require--but the algorithm operates on u32 words internally, and rand wants a wordslice interface, so we were converting to bytes in mod guts and converting back to words in mod chacha. We can simply output directly to a wordslice in guts. It is simpler; it may be marginally faster; it avoids an unsafe (cf. #1170).