### PR TITLE
Remove unused fields

### DIFF
--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - unreleased
+- Remove unused fields from `Gamma`, `NormalInverseGaussian` and `Zipf` distributions (#1184)
+  This breaks serialization compatibility with older versions.
+
 ## [0.4.3] - 2021-12-30
 - Fix `no_std` build (#1208)
 

--- a/rand_distr/src/gamma.rs
+++ b/rand_distr/src/gamma.rs
@@ -544,7 +544,6 @@ struct BB<N> {
 struct BC<N> {
     alpha: N,
     beta: N,
-    delta: N,
     kappa1: N,
     kappa2: N,
 }
@@ -646,7 +645,7 @@ where
             Ok(Beta {
                 a, b, switched_params,
                 algorithm: BetaAlgorithm::BC(BC {
-                    alpha, beta, delta, kappa1, kappa2,
+                    alpha, beta, kappa1, kappa2,
                 })
             })
         }

--- a/rand_distr/src/normal_inverse_gaussian.rs
+++ b/rand_distr/src/normal_inverse_gaussian.rs
@@ -34,7 +34,6 @@ where
     StandardNormal: Distribution<F>,
     Standard: Distribution<F>,
 {
-    alpha: F,
     beta: F,
     inverse_gaussian: InverseGaussian<F>,
 }
@@ -63,7 +62,6 @@ where
         let inverse_gaussian = InverseGaussian::new(mu, F::one()).unwrap();
 
         Ok(Self {
-            alpha,
             beta,
             inverse_gaussian,
         })

--- a/rand_distr/src/zipf.rs
+++ b/rand_distr/src/zipf.rs
@@ -145,7 +145,6 @@ where F: Float, Standard: Distribution<F>, OpenClosed01: Distribution<F>
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Zipf<F>
 where F: Float, Standard: Distribution<F> {
-    n: F,
     s: F,
     t: F,
     q: F,
@@ -202,7 +201,7 @@ where F: Float, Standard: Distribution<F> {
         };
         debug_assert!(t > F::zero());
         Ok(Zipf {
-            n, s, t, q
+            s, t, q
         })
     }
 


### PR DESCRIPTION
This fixes some clippy warnings (due to new lints on nightly).

@dhardy The changes will break serialization compatibility with older versions. Do we have a policy whether that is a breaking or value-breaking change?