### PR TITLE
Full update of weighted index by assigning weights

### DIFF
--- a/benches/weighted.rs
+++ b/benches/weighted.rs
@@ -37,7 +37,7 @@ fn weighted_index_assignment_large(b: &mut Bencher) {
 }
 
 #[bench]
-fn weighted_index_creation(b: &mut Bencher) {
+fn weighted_index_new(b: &mut Bencher) {
     let mut rng = rand::thread_rng();
     let weights = &[1u32, 2, 4, 0, 5, 1, 7, 1, 2, 3, 4, 5, 6, 7][..];
     b.iter(|| {
@@ -47,11 +47,65 @@ fn weighted_index_creation(b: &mut Bencher) {
 }
 
 #[bench]
-fn weighted_index_creation_large(b: &mut Bencher) {
+fn weighted_index_new_large(b: &mut Bencher) {
     let mut rng = rand::thread_rng();
     let weights: Vec<u64> = (0u64..1000).collect();
     b.iter(|| {
         let distr = WeightedIndex::new(&weights).unwrap();
+        rng.sample(&distr)
+    })
+}
+
+#[bench]
+fn weighted_index_from_cumulative_weights(b: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    let weights = vec![1u32, 2, 4, 0, 5, 1, 7, 1, 2, 3, 4, 5, 6, 7];
+    let cumulative_weights: Vec<_> = weights
+        .into_iter()
+        .scan(0, |acc, item| {
+            *acc += item;
+            Some(*acc)
+        })
+        .collect();
+    b.iter(|| {
+        let distr = WeightedIndex::from_cumulative_weights_unchecked(cumulative_weights.clone());
+        rng.sample(distr)
+    })
+}
+
+#[bench]
+fn weighted_index_from_cumulative_weights_large(b: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    let weights: Vec<u64> = (0u64..1000).collect();
+    let cumulative_weights: Vec<_> = weights
+        .into_iter()
+        .scan(0, |acc, item| {
+            *acc += item;
+            Some(*acc)
+        })
+        .collect();
+    b.iter(|| {
+        let distr = WeightedIndex::from_cumulative_weights_unchecked(cumulative_weights.clone());
+        rng.sample(&distr)
+    })
+}
+
+#[bench]
+fn weighted_index_from_weights(b: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    let weights = vec![1u32, 2, 4, 0, 5, 1, 7, 1, 2, 3, 4, 5, 6, 7];
+    b.iter(|| {
+        let distr = WeightedIndex::from_weights(weights.clone()).unwrap();
+        rng.sample(distr)
+    })
+}
+
+#[bench]
+fn weighted_index_from_weights_large(b: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    let weights: Vec<u64> = (0u64..1000).collect();
+    b.iter(|| {
+        let distr = WeightedIndex::from_weights(weights.clone()).unwrap();
         rng.sample(&distr)
     })
 }

--- a/benches/weighted.rs
+++ b/benches/weighted.rs
@@ -15,20 +15,52 @@ use rand::Rng;
 use test::Bencher;
 
 #[bench]
+fn weighted_index_assignment(b: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    let weights = &[1u32, 2, 3, 0, 5, 6, 7, 1, 2, 3, 4, 5, 6, 7][..];
+    let mut distr = WeightedIndex::new(weights).unwrap();
+    b.iter(|| {
+        distr.assign_new_weights(weights).unwrap();
+        rng.sample(&distr)
+    })
+}
+
+#[bench]
+fn weighted_index_assignment_large(b: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    let weights: Vec<u64> = (0u64..1000).collect();
+    let mut distr = WeightedIndex::new(&weights).unwrap();
+    b.iter(|| {
+        distr.assign_new_weights(&weights).unwrap();
+        rng.sample(&distr)
+    })
+}
+
+#[bench]
 fn weighted_index_creation(b: &mut Bencher) {
     let mut rng = rand::thread_rng();
-    let weights = [1u32, 2, 4, 0, 5, 1, 7, 1, 2, 3, 4, 5, 6, 7];
+    let weights = &[1u32, 2, 4, 0, 5, 1, 7, 1, 2, 3, 4, 5, 6, 7][..];
     b.iter(|| {
-        let distr = WeightedIndex::new(weights.to_vec()).unwrap();
+        let distr = WeightedIndex::new(weights).unwrap();
         rng.sample(distr)
+    })
+}
+
+#[bench]
+fn weighted_index_creation_large(b: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    let weights: Vec<u64> = (0u64..1000).collect();
+    b.iter(|| {
+        let distr = WeightedIndex::new(&weights).unwrap();
+        rng.sample(&distr)
     })
 }
 
 #[bench]
 fn weighted_index_modification(b: &mut Bencher) {
     let mut rng = rand::thread_rng();
-    let weights = [1u32, 2, 3, 0, 5, 6, 7, 1, 2, 3, 4, 5, 6, 7];
-    let mut distr = WeightedIndex::new(weights.to_vec()).unwrap();
+    let weights = &[1u32, 2, 3, 0, 5, 6, 7, 1, 2, 3, 4, 5, 6, 7][..];
+    let mut distr = WeightedIndex::new(weights).unwrap();
     b.iter(|| {
         distr.update_weights(&[(2, &4), (5, &1)]).unwrap();
         rng.sample(&distr)


### PR DESCRIPTION
I need to update my weighted indices inside a hot loop. Instead of reconstructing the entire index from scratch, this commit allows updating the inner cumulative weights in-place using a slice of weights via `WeightedIndex::assign_weights`. WeightedIndex::assign_weights_unchecked` is also provided in those cases where the user promises that all weights are valid and their sum exceeds zero.

# Open questions

How to handle a partial update? If assignment fails during `WeightedIndex::assign_weights`, the index can be left in a partially updated undefined state. The method's doc comment notes that but does not go further than that. I see the following ways to handle this:

1. Leave things as they are. Users of `assign_weights` read the documentation and will keep this caveat in mind.
2. Roll back the changes by using e.g. `SubAssign`. This will probably require keeping around the old cumulative weights, which implies an extra allocation in the function body, which goes against the point of this new feature.
3. Add a field `has_errored: bool` to `WeightedIndex`, initialized to `false`. If an error is encountered during assignment, set to `true`. If `WeightedIndex` is used for sampling with `has_errored == True`, panic. I don't recall where I have seen this, but I believe this solution is even used somewhere in the standard library.