### PR TITLE
rand: fix incorrect example in Uniform

### DIFF
--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -80,7 +80,10 @@
 //!         where B1: SampleBorrow<Self::X> + Sized,
 //!               B2: SampleBorrow<Self::X> + Sized
 //!     {
-//!         UniformSampler::new(low, high)
+//!         UniformMyF32(UniformFloat::<f32>::new_inclusive(
+//!             low.borrow().0,
+//!             high.borrow().0,
+//!         ))
 //!     }
 //!     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
 //!         MyF32(self.0.sample(rng))


### PR DESCRIPTION
The current example to implement `SampleUniform` for custom types is incorrect. It mistakenly forwards the implementation of `UniformSampler::new_inclusive` to `UniformSampler::new`.