### PR TITLE
rand_distr: fix no_std build

### DIFF
--- a/rand_distr/src/binomial.rs
+++ b/rand_distr/src/binomial.rs
@@ -13,6 +13,7 @@ use crate::{Distribution, Uniform};
 use rand::Rng;
 use core::fmt;
 use core::cmp::Ordering;
+use num_traits::Float;
 
 /// The binomial distribution `Binomial(n, p)`.
 ///

--- a/rand_distr/src/geometric.rs
+++ b/rand_distr/src/geometric.rs
@@ -3,6 +3,7 @@
 use crate::Distribution;
 use rand::Rng;
 use core::fmt;
+use num_traits::Float;
 
 /// The geometric distribution `Geometric(p)` bounded to `[0, u64::MAX]`.
 /// 

--- a/rand_distr/src/hypergeometric.rs
+++ b/rand_distr/src/hypergeometric.rs
@@ -4,6 +4,7 @@ use crate::Distribution;
 use rand::Rng;
 use rand::distributions::uniform::Uniform;
 use core::fmt;
+use num_traits::Float;
 
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]

--- a/rand_distr/src/utils.rs
+++ b/rand_distr/src/utils.rs
@@ -11,6 +11,7 @@
 use crate::ziggurat_tables;
 use rand::distributions::hidden_export::IntoFloat;
 use rand::Rng;
+use num_traits::Float;
 
 /// Calculates ln(gamma(x)) (natural logarithm of the gamma
 /// function) using the Lanczos approximation.


### PR DESCRIPTION
It seems that [the current CI test for no_std build](https://github.com/rust-random/rand/blob/f8106ef79d9a4b5061222bebacf5dc8cee76389d/.github/workflows/test.yml#L104) would fail to catch this kind of error. Due to the dev dependencies, default features are always enabled in the test.

```
❯ cargo tree --manifest-path rand_distr/Cargo.toml -e features -i rand --no-default-features
rand v0.8.5 (/Users/chengxu/dev/git/rand)
└── rand_distr v0.4.2 (/Users/chengxu/dev/git/rand/rand_distr)
├── rand feature "alloc"
│   └── rand feature "std"
│       [dev-dependencies]
│       └── rand_distr v0.4.2 (/Users/chengxu/dev/git/rand/rand_distr)
├── rand feature "getrandom"
│   └── rand feature "std" (*)
├── rand feature "libc"
│   └── rand feature "std" (*)
├── rand feature "rand_chacha"
│   ├── rand feature "std" (*)
│   └── rand feature "std_rng"
│       [dev-dependencies]
│       └── rand_distr v0.4.2 (/Users/chengxu/dev/git/rand/rand_distr)
├── rand feature "small_rng"
│   [dev-dependencies]
│   └── rand_distr v0.4.2 (/Users/chengxu/dev/git/rand/rand_distr)
├── rand feature "std" (*)
└── rand feature "std_rng" (*)
```