### PR TITLE
Remove redundant bounds

### DIFF
--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -178,10 +178,7 @@ impl<R: BlockRngCore> BlockRng<R> {
     }
 }
 
-impl<R: BlockRngCore<Item = u32>> RngCore for BlockRng<R>
-where
-    <R as BlockRngCore>::Results: AsRef<[u32]> + AsMut<[u32]>,
-{
+impl<R: BlockRngCore<Item = u32>> RngCore for BlockRng<R> {
     #[inline]
     fn next_u32(&mut self) -> u32 {
         if self.index >= self.results.as_ref().len() {
@@ -346,10 +343,7 @@ impl<R: BlockRngCore> BlockRng64<R> {
     }
 }
 
-impl<R: BlockRngCore<Item = u64>> RngCore for BlockRng64<R>
-where
-    <R as BlockRngCore>::Results: AsRef<[u64]> + AsMut<[u64]>,
-{
+impl<R: BlockRngCore<Item = u64>> RngCore for BlockRng64<R> {
     #[inline]
     fn next_u32(&mut self) -> u32 {
         let mut index = self.index - self.half_used as usize;

--- a/src/rngs/adapter/reseeding.rs
+++ b/src/rngs/adapter/reseeding.rs
@@ -113,7 +113,6 @@ where
 impl<R, Rsdr: RngCore> RngCore for ReseedingRng<R, Rsdr>
 where
     R: BlockRngCore<Item = u32> + SeedableRng,
-    <R as BlockRngCore>::Results: AsRef<[u32]> + AsMut<[u32]>,
 {
     #[inline(always)]
     fn next_u32(&mut self) -> u32 {


### PR DESCRIPTION
There were 3 trait implementations that placed redundant `AsRef`/`AsMut` bounds on `<R as BlockRngCore>::Results` which were already implied by the bounds in the `BlockRngCore` trait definition.

Noticed those because they show up in the documentation, e.g. [here](https://docs.rs/rand_core/0.6.3/rand_core/block/struct.BlockRng.html#impl-RngCore).

Also fix 2 warnings (one clippy warning, one rustc warning).