### PR TITLE
rand_distr: fix no_std build

### DIFF
--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2021-12-30
+- Fix `no_std` build (#1208)
+
 ## [0.4.2] - 2021-09-18
 - New `Zeta` and `Zipf` distributions (#1136)
 - New `SkewNormal` distribution (#1149)

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_distr"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_distr/src/binomial.rs
+++ b/rand_distr/src/binomial.rs
@@ -13,6 +13,8 @@ use crate::{Distribution, Uniform};
 use rand::Rng;
 use core::fmt;
 use core::cmp::Ordering;
+#[allow(unused_imports)]
+use num_traits::Float;
 
 /// The binomial distribution `Binomial(n, p)`.
 ///

--- a/rand_distr/src/geometric.rs
+++ b/rand_distr/src/geometric.rs
@@ -3,6 +3,8 @@
 use crate::Distribution;
 use rand::Rng;
 use core::fmt;
+#[allow(unused_imports)]
+use num_traits::Float;
 
 /// The geometric distribution `Geometric(p)` bounded to `[0, u64::MAX]`.
 /// 

--- a/rand_distr/src/hypergeometric.rs
+++ b/rand_distr/src/hypergeometric.rs
@@ -4,6 +4,8 @@ use crate::Distribution;
 use rand::Rng;
 use rand::distributions::uniform::Uniform;
 use core::fmt;
+#[allow(unused_imports)]
+use num_traits::Float;
 
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]

--- a/rand_distr/src/utils.rs
+++ b/rand_distr/src/utils.rs
@@ -11,6 +11,7 @@
 use crate::ziggurat_tables;
 use rand::distributions::hidden_export::IntoFloat;
 use rand::Rng;
+use num_traits::Float;
 
 /// Calculates ln(gamma(x)) (natural logarithm of the gamma
 /// function) using the Lanczos approximation.
@@ -25,7 +26,7 @@ use rand::Rng;
 /// `Ag(z)` is an infinite series with coefficients that can be calculated
 /// ahead of time - we use just the first 6 terms, which is good enough
 /// for most purposes.
-pub(crate) fn log_gamma<F: num_traits::Float>(x: F) -> F {
+pub(crate) fn log_gamma<F: Float>(x: F) -> F {
     // precalculated 6 coefficients for the first 6 terms of the series
     let coefficients: [F; 6] = [
         F::from(76.18009172947146).unwrap(),


### PR DESCRIPTION
Closes #1205.

Note that the [`test-no-std`](https://github.com/rust-random/rand/blob/master/.github/workflows/test.yml#L167-L179) job checks only `rand` and `rand_core` and does not affect `rand_distr` and other crates . IIUC we need a virtual manifest for it to work, not the current repository structure.

Changing working directory to `rand_distr` and running `cargo build` in it will not work due to the dev feature unification, i.e. we would need `resolver = "2"` for `no_std` tests to work in that case.