### PR TITLE
Update to packed_simd_2 0.3.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ rand_chacha = { path = "rand_chacha", version = "0.3.0", default-features = fals
 [dependencies.packed_simd]
 # NOTE: so far no version works reliably due to dependence on unstable features
 package = "packed_simd_2"
-version = "0.3.6"
+version = "0.3.7"
 optional = true
 features = ["into_bits"]
 

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -1430,7 +1430,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_float_overflow() {
-        Uniform::from(::core::f64::MIN..::core::f64::MAX);
+        let _ = Uniform::from(::core::f64::MIN..::core::f64::MAX);
     }
 
     #[test]


### PR DESCRIPTION
Fixes build with `simd_support` feature on nightly.