### PR TITLE
Making distributions comparable by deriving PartialEq

### DIFF
--- a/rand_distr/src/binomial.rs
+++ b/rand_distr/src/binomial.rs
@@ -30,7 +30,7 @@ use num_traits::Float;
 /// let v = bin.sample(&mut rand::thread_rng());
 /// println!("{} is from a binomial distribution", v);
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Binomial {
     /// Number of trials.
@@ -346,5 +346,10 @@ mod test {
     #[should_panic]
     fn test_binomial_invalid_lambda_neg() {
         Binomial::new(20, -10.0).unwrap();
+    }
+
+    #[test]
+    fn binomial_distributions_can_be_compared() {
+        assert_eq!(Binomial::new(1, 1.0), Binomial::new(1, 1.0));
     }
 }

--- a/rand_distr/src/cauchy.rs
+++ b/rand_distr/src/cauchy.rs
@@ -31,7 +31,7 @@ use core::fmt;
 /// let v = cau.sample(&mut rand::thread_rng());
 /// println!("{} is from a Cauchy(2, 5) distribution", v);
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cauchy<F>
 where F: Float + FloatConst, Standard: Distribution<F>
@@ -163,5 +163,10 @@ mod test {
         for (a, b) in buf.iter().zip(expected.iter()) {
             assert_almost_eq!(*a, *b, 1e-5);
         }
+    }
+
+    #[test]
+    fn cauchy_distributions_can_be_compared() {
+        assert_eq!(Cauchy::new(1.0, 2.0), Cauchy::new(1.0, 2.0));
     }
 }

--- a/rand_distr/src/dirichlet.rs
+++ b/rand_distr/src/dirichlet.rs
@@ -32,7 +32,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 /// println!("{:?} is from a Dirichlet([1.0, 2.0, 3.0]) distribution", samples);
 /// ```
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Dirichlet<F>
 where
@@ -182,5 +182,10 @@ mod test {
     #[should_panic]
     fn test_dirichlet_invalid_alpha() {
         Dirichlet::new_with_size(0.0f64, 2).unwrap();
+    }
+
+    #[test]
+    fn dirichlet_distributions_can_be_compared() {
+        assert_eq!(Dirichlet::new(&[1.0, 2.0]), Dirichlet::new(&[1.0, 2.0]));
     }
 }

--- a/rand_distr/src/exponential.rs
+++ b/rand_distr/src/exponential.rs
@@ -91,7 +91,7 @@ impl Distribution<f64> for Exp1 {
 /// let v = exp.sample(&mut rand::thread_rng());
 /// println!("{} is from a Exp(2) distribution", v);
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Exp<F>
 where F: Float, Exp1: Distribution<F>
@@ -177,5 +177,10 @@ mod test {
     #[should_panic]
     fn test_exp_invalid_lambda_nan() {
         Exp::new(f64::nan()).unwrap();
+    }
+
+    #[test]
+    fn exponential_distributions_can_be_compared() {
+        assert_eq!(Exp::new(1.0), Exp::new(1.0));
     }
 }

--- a/rand_distr/src/frechet.rs
+++ b/rand_distr/src/frechet.rs
@@ -27,7 +27,7 @@ use rand::Rng;
 /// let val: f64 = thread_rng().sample(Frechet::new(0.0, 1.0, 1.0).unwrap());
 /// println!("{}", val);
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Frechet<F>
 where
@@ -181,5 +181,10 @@ mod tests {
             .iter()
             .zip(&probabilities)
             .all(|(p_hat, p)| (p_hat - p).abs() < 0.003))
+    }
+
+    #[test]
+    fn frechet_distributions_can_be_compared() {
+        assert_eq!(Frechet::new(1.0, 2.0, 3.0), Frechet::new(1.0, 2.0, 3.0));
     }
 }

--- a/rand_distr/src/gamma.rs
+++ b/rand_distr/src/gamma.rs
@@ -54,7 +54,7 @@ use serde::{Serialize, Deserialize};
 ///       Generating Gamma Variables" *ACM Trans. Math. Softw.* 26, 3
 ///       (September 2000), 363-372.
 ///       DOI:[10.1145/358407.358414](https://doi.acm.org/10.1145/358407.358414)
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct Gamma<F>
 where
@@ -91,7 +91,7 @@ impl fmt::Display for Error {
 #[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 enum GammaRepr<F>
 where
@@ -119,7 +119,7 @@ where
 ///
 /// See `Gamma` for sampling from a Gamma distribution with general
 /// shape parameters.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 struct GammaSmallShape<F>
 where
@@ -135,7 +135,7 @@ where
 ///
 /// See `Gamma` for sampling from a Gamma distribution with general
 /// shape parameters.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 struct GammaLargeShape<F>
 where
@@ -280,7 +280,7 @@ where
 /// let v = chi.sample(&mut rand::thread_rng());
 /// println!("{} is from a χ²(11) distribution", v)
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct ChiSquared<F>
 where
@@ -314,7 +314,7 @@ impl fmt::Display for ChiSquaredError {
 #[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for ChiSquaredError {}
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 enum ChiSquaredRepr<F>
 where
@@ -385,7 +385,7 @@ where
 /// let v = f.sample(&mut rand::thread_rng());
 /// println!("{} is from an F(2, 32) distribution", v)
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct FisherF<F>
 where
@@ -472,7 +472,7 @@ where
 /// let v = t.sample(&mut rand::thread_rng());
 /// println!("{} is from a t(11) distribution", v)
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct StudentT<F>
 where
@@ -522,7 +522,7 @@ where
 /// Generating beta variates with nonintegral shape parameters.
 /// Communications of the ACM 21, 317-322.
 /// https://doi.org/10.1145/359460.359482
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 enum BetaAlgorithm<N> {
     BB(BB<N>),
@@ -530,7 +530,7 @@ enum BetaAlgorithm<N> {
 }
 
 /// Algorithm BB for `min(alpha, beta) > 1`.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 struct BB<N> {
     alpha: N,
@@ -539,7 +539,7 @@ struct BB<N> {
 }
 
 /// Algorithm BC for `min(alpha, beta) <= 1`.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 struct BC<N> {
     alpha: N,
@@ -560,7 +560,7 @@ struct BC<N> {
 /// let v = beta.sample(&mut rand::thread_rng());
 /// println!("{} is from a Beta(2, 5) distribution", v);
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct Beta<F>
 where
@@ -810,5 +810,30 @@ mod test {
         for i in 0..1000 {
             assert!(!beta.sample(&mut rng).is_nan(), "failed at i={}", i);
         }
+    }
+
+    #[test]
+    fn gamma_distributions_can_be_compared() {
+        assert_eq!(Gamma::new(1.0, 2.0), Gamma::new(1.0, 2.0));
+    }
+
+    #[test]
+    fn beta_distributions_can_be_compared() {
+        assert_eq!(Beta::new(1.0, 2.0), Beta::new(1.0, 2.0));
+    }
+
+    #[test]
+    fn chi_squared_distributions_can_be_compared() {
+        assert_eq!(ChiSquared::new(1.0), ChiSquared::new(1.0));
+    }
+
+    #[test]
+    fn fisher_f_distributions_can_be_compared() {
+        assert_eq!(FisherF::new(1.0, 2.0), FisherF::new(1.0, 2.0));
+    }
+
+    #[test]
+    fn student_t_distributions_can_be_compared() {
+        assert_eq!(StudentT::new(1.0), StudentT::new(1.0));
     }
 }

--- a/rand_distr/src/geometric.rs
+++ b/rand_distr/src/geometric.rs
@@ -27,7 +27,7 @@ use num_traits::Float;
 /// let v = geo.sample(&mut rand::thread_rng());
 /// println!("{} is from a Geometric(0.25) distribution", v);
 /// ```
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Geometric
 {
@@ -234,5 +234,10 @@ mod test {
         let variance =
             results.iter().map(|x| (x - mean) * (x - mean)).sum::<f64>() / results.len() as f64;
         assert!((variance - expected_variance).abs() < expected_variance / 10.0);
+    }
+
+    #[test]
+    fn geometric_distributions_can_be_compared() {
+        assert_eq!(Geometric::new(1.0), Geometric::new(1.0));
     }
 }

--- a/rand_distr/src/gumbel.rs
+++ b/rand_distr/src/gumbel.rs
@@ -27,7 +27,7 @@ use rand::Rng;
 /// let val: f64 = thread_rng().sample(Gumbel::new(0.0, 1.0).unwrap());
 /// println!("{}", val);
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Gumbel<F>
 where
@@ -151,5 +151,10 @@ mod tests {
             .iter()
             .zip(&probabilities)
             .all(|(p_hat, p)| (p_hat - p).abs() < 0.003))
+    }
+
+    #[test]
+    fn gumbel_distributions_can_be_compared() {
+        assert_eq!(Gumbel::new(1.0, 2.0), Gumbel::new(1.0, 2.0));
     }
 }

--- a/rand_distr/src/hypergeometric.rs
+++ b/rand_distr/src/hypergeometric.rs
@@ -7,7 +7,7 @@ use core::fmt;
 #[allow(unused_imports)]
 use num_traits::Float;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 enum SamplingMethod {
     InverseTransform{ initial_p: f64, initial_x: i64 },
@@ -45,7 +45,7 @@ enum SamplingMethod {
 /// let v = hypergeo.sample(&mut rand::thread_rng());
 /// println!("{} is from a hypergeometric distribution", v);
 /// ```
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Hypergeometric {
     n1: u64,
@@ -418,5 +418,10 @@ mod test {
         test_hypergeometric_mean_and_variance(5000, 2500, 500, &mut rng);
         test_hypergeometric_mean_and_variance(10100, 10000, 1000, &mut rng);
         test_hypergeometric_mean_and_variance(100100, 100, 10000, &mut rng);
+    }
+
+    #[test]
+    fn hypergeometric_distributions_can_be_compared() {
+        assert_eq!(Hypergeometric::new(1, 2, 3), Hypergeometric::new(1, 2, 3));
     }
 }

--- a/rand_distr/src/inverse_gaussian.rs
+++ b/rand_distr/src/inverse_gaussian.rs
@@ -26,7 +26,7 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 
 /// The [inverse Gaussian distribution](https://en.wikipedia.org/wiki/Inverse_Gaussian_distribution)
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct InverseGaussian<F>
 where
@@ -108,5 +108,10 @@ mod tests {
         assert!(InverseGaussian::new(-1.0, -1.0).is_err());
         assert!(InverseGaussian::new(1.0, -1.0).is_err());
         assert!(InverseGaussian::new(1.0, 1.0).is_ok());
+    }
+
+    #[test]
+    fn inverse_gaussian_distributions_can_be_compared() {
+        assert_eq!(InverseGaussian::new(1.0, 2.0), InverseGaussian::new(1.0, 2.0));
     }
 }

--- a/rand_distr/src/normal.rs
+++ b/rand_distr/src/normal.rs
@@ -112,7 +112,7 @@ impl Distribution<f64> for StandardNormal {
 /// ```
 ///
 /// [`StandardNormal`]: crate::StandardNormal
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Normal<F>
 where F: Float, StandardNormal: Distribution<F>
@@ -227,7 +227,7 @@ where F: Float, StandardNormal: Distribution<F>
 /// let v = log_normal.sample(&mut rand::thread_rng());
 /// println!("{} is from an ln N(2, 9) distribution", v)
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct LogNormal<F>
 where F: Float, StandardNormal: Distribution<F>
@@ -367,5 +367,15 @@ mod tests {
         assert!(LogNormal::from_mean_cv(-1.0, 1.0).is_err());
         assert!(LogNormal::from_mean_cv(0.0, 1.0).is_err());
         assert!(LogNormal::from_mean_cv(1.0, -1.0).is_err());
+    }
+
+    #[test]
+    fn normal_distributions_can_be_compared() {
+        assert_eq!(Normal::new(1.0, 2.0), Normal::new(1.0, 2.0));
+    }
+
+    #[test]
+    fn log_normal_distributions_can_be_compared() {
+        assert_eq!(LogNormal::new(1.0, 2.0), LogNormal::new(1.0, 2.0));
     }
 }

--- a/rand_distr/src/normal_inverse_gaussian.rs
+++ b/rand_distr/src/normal_inverse_gaussian.rs
@@ -26,7 +26,7 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 
 /// The [normal-inverse Gaussian distribution](https://en.wikipedia.org/wiki/Normal-inverse_Gaussian_distribution)
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct NormalInverseGaussian<F>
 where
@@ -103,5 +103,10 @@ mod tests {
         assert!(NormalInverseGaussian::new(-1.0, -1.0).is_err());
         assert!(NormalInverseGaussian::new(1.0, 2.0).is_err());
         assert!(NormalInverseGaussian::new(2.0, 1.0).is_ok());
+    }
+
+    #[test]
+    fn normal_inverse_gaussian_distributions_can_be_compared() {
+        assert_eq!(NormalInverseGaussian::new(1.0, 2.0), NormalInverseGaussian::new(1.0, 2.0));
     }
 }

--- a/rand_distr/src/pareto.rs
+++ b/rand_distr/src/pareto.rs
@@ -23,7 +23,7 @@ use core::fmt;
 /// let val: f64 = thread_rng().sample(Pareto::new(1., 2.).unwrap());
 /// println!("{}", val);
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pareto<F>
 where F: Float, OpenClosed01: Distribution<F>
@@ -130,5 +130,10 @@ mod tests {
             6.837815045397157,
             105.8826669383772,
         ]);
+    }
+
+    #[test]
+    fn pareto_distributions_can_be_compared() {
+        assert_eq!(Pareto::new(1.0, 2.0), Pareto::new(1.0, 2.0));
     }
 }

--- a/rand_distr/src/pert.rs
+++ b/rand_distr/src/pert.rs
@@ -30,7 +30,7 @@ use core::fmt;
 /// ```
 ///
 /// [`Triangular`]: crate::Triangular
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pert<F>
 where
@@ -145,5 +145,10 @@ mod test {
         ] {
             assert!(Pert::new(min, max, mode).is_err());
         }
+    }
+
+    #[test]
+    fn pert_distributions_can_be_compared() {
+        assert_eq!(Pert::new(1.0, 3.0, 2.0), Pert::new(1.0, 3.0, 2.0));
     }
 }

--- a/rand_distr/src/poisson.rs
+++ b/rand_distr/src/poisson.rs
@@ -28,7 +28,7 @@ use core::fmt;
 /// let v = poi.sample(&mut rand::thread_rng());
 /// println!("{} is from a Poisson(2) distribution", v);
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Poisson<F>
 where F: Float + FloatConst, Standard: Distribution<F>
@@ -177,5 +177,10 @@ mod test {
     #[should_panic]
     fn test_poisson_invalid_lambda_neg() {
         Poisson::new(-10.0).unwrap();
+    }
+
+    #[test]
+    fn poisson_distributions_can_be_compared() {
+        assert_eq!(Poisson::new(1.0), Poisson::new(1.0));
     }
 }

--- a/rand_distr/src/skew_normal.rs
+++ b/rand_distr/src/skew_normal.rs
@@ -40,7 +40,7 @@ use rand::Rng;
 /// [skew normal distribution]: https://en.wikipedia.org/wiki/Skew_normal_distribution
 /// [`Normal`]: struct.Normal.html
 /// [A Method to Simulate the Skew Normal Distribution]: https://dx.doi.org/10.4236/am.2014.513201
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct SkewNormal<F>
 where
@@ -252,5 +252,10 @@ mod tests {
         for value in buf.iter() {
             assert!(value.is_nan());
         }
+    }
+
+    #[test]
+    fn skew_normal_distributions_can_be_compared() {
+        assert_eq!(SkewNormal::new(1.0, 2.0, 3.0), SkewNormal::new(1.0, 2.0, 3.0));
     }
 }

--- a/rand_distr/src/triangular.rs
+++ b/rand_distr/src/triangular.rs
@@ -31,7 +31,7 @@ use core::fmt;
 /// ```
 ///
 /// [`Pert`]: crate::Pert
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Triangular<F>
 where F: Float, Standard: Distribution<F>
@@ -129,5 +129,10 @@ mod test {
         ] {
             assert!(Triangular::new(min, max, mode).is_err());
         }
+    }
+
+    #[test]
+    fn triangular_distributions_can_be_compared() {
+        assert_eq!(Triangular::new(1.0, 3.0, 2.0), Triangular::new(1.0, 3.0, 2.0));
     }
 }

--- a/rand_distr/src/weibull.rs
+++ b/rand_distr/src/weibull.rs
@@ -23,7 +23,7 @@ use core::fmt;
 /// let val: f64 = thread_rng().sample(Weibull::new(1., 10.).unwrap());
 /// println!("{}", val);
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Weibull<F>
 where F: Float, OpenClosed01: Distribution<F>
@@ -128,5 +128,10 @@ mod tests {
             0.7556151370284702,
             7.877212340241561,
         ]);
+    }
+
+    #[test]
+    fn weibull_distributions_can_be_compared() {
+        assert_eq!(Weibull::new(1.0, 2.0), Weibull::new(1.0, 2.0));
     }
 }

--- a/rand_distr/src/zipf.rs
+++ b/rand_distr/src/zipf.rs
@@ -46,7 +46,7 @@ use core::fmt;
 ///
 /// [zeta distribution]: https://en.wikipedia.org/wiki/Zeta_distribution
 /// [Non-Uniform Random Variate Generation]: https://doi.org/10.1007/978-1-4613-8643-8
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Zeta<F>
 where F: Float, Standard: Distribution<F>, OpenClosed01: Distribution<F>
 {
@@ -142,7 +142,7 @@ where F: Float, Standard: Distribution<F>, OpenClosed01: Distribution<F>
 /// due to Jason Crease[1].
 ///
 /// [1]: https://jasoncrease.medium.com/rejection-sampling-the-zipf-distribution-6b359792cffa
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Zipf<F>
 where F: Float, Standard: Distribution<F> {
     n: F,
@@ -370,5 +370,15 @@ mod tests {
         test_samples(Zipf::new(10, 2.0).unwrap(), 0f64, &[
             1.0, 2.0, 3.0, 2.0
         ]);
+    }
+
+    #[test]
+    fn zipf_distributions_can_be_compared() {
+        assert_eq!(Zipf::new(1, 2.0), Zipf::new(1, 2.0));
+    }
+
+    #[test]
+    fn zeta_distributions_can_be_compared() {
+        assert_eq!(Zeta::new(1.0), Zeta::new(1.0));
     }
 }

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -33,7 +33,7 @@ use serde::{Serialize, Deserialize};
 /// This `Bernoulli` distribution uses 64 bits from the RNG (a `u64`),
 /// so only probabilities that are multiples of 2<sup>-64</sup> can be
 /// represented.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct Bernoulli {
     /// Probability of success, relative to the maximal integer.
@@ -210,5 +210,10 @@ mod test {
         assert_eq!(buf, [
             true, false, false, true, false, false, true, true, true, true
         ]);
+    }
+
+    #[test]
+    fn bernoulli_distributions_can_be_compared() {
+        assert_eq!(Bernoulli::new(1.0), Bernoulli::new(1.0));
     }
 }

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -172,7 +172,7 @@ use serde::{Serialize, Deserialize};
 /// [`new`]: Uniform::new
 /// [`new_inclusive`]: Uniform::new_inclusive
 /// [`Rng::gen_range`]: Rng::gen_range
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde1", serde(bound(serialize = "X::Sampler: Serialize")))]
 #[cfg_attr(feature = "serde1", serde(bound(deserialize = "X::Sampler: Deserialize<'de>")))]
@@ -418,7 +418,7 @@ impl<T: SampleUniform + PartialOrd> SampleRange<T> for RangeInclusive<T> {
 /// An alternative to using a modulus is widening multiply: After a widening
 /// multiply by `range`, the result is in the high word. Then comparing the low
 /// word against `zone` makes sure our distribution is uniform.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct UniformInt<X> {
     low: X,
@@ -806,7 +806,7 @@ impl UniformSampler for UniformChar {
 /// [`new`]: UniformSampler::new
 /// [`new_inclusive`]: UniformSampler::new_inclusive
 /// [`Standard`]: crate::distributions::Standard
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct UniformFloat<X> {
     low: X,
@@ -1646,5 +1646,13 @@ mod tests {
                 Duration::new(3, 236507617),
             ],
         );
+    }
+
+    #[test]
+    fn uniform_distributions_can_be_compared() {
+        assert_eq!(Uniform::new(1.0, 2.0), Uniform::new(1.0, 2.0));
+
+        // To cover UniformInt
+        assert_eq!(Uniform::new(1 as u32, 2 as u32), Uniform::new(1 as u32, 2 as u32));
     }
 }

--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -75,7 +75,7 @@ use serde::{Serialize, Deserialize};
 ///
 /// [`Uniform<X>`]: crate::distributions::Uniform
 /// [`RngCore`]: crate::RngCore
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub struct WeightedIndex<X: SampleUniform + PartialOrd> {
@@ -417,6 +417,11 @@ mod test {
         test_samples(&[1.0f64, 0.999, 0.998, 0.997], &mut buf, &[
             2, 2, 1, 3, 2, 1, 3, 3, 2, 1,
         ]);
+    }
+
+    #[test]
+    fn weighted_index_distributions_can_be_compared() {
+        assert_eq!(WeightedIndex::new(&[1, 2]), WeightedIndex::new(&[1, 2]));
     }
 }
 


### PR DESCRIPTION
Code changes to implement suggested change in #1217. Deriving PartialEq such as to make relevant distributions testable.

CC @vks @dhardy