### PR TITLE
Make `CryptoRngCore` trait imply `CryptoRng` as well

### DIFF
--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -226,7 +226,7 @@ pub trait CryptoRng {}
 ///     buf
 /// }
 /// ```
-pub trait CryptoRngCore: RngCore {
+pub trait CryptoRngCore: CryptoRng + RngCore {
     /// Upcast to an [`RngCore`] trait object.
     fn as_rngcore(&mut self) -> &mut dyn RngCore;
 }


### PR DESCRIPTION
Hi,

I recently had a case where I needed to make an API that takes `&mut dyn (CryptoRng + RngCore)`. I didn't want to make my trait generic because it would greatly complicate some FFI situations.

Since rust doesn't currently allow `dyn (CryptoRng + RngCore)`, I needed to make an extension trait that implies both of these, and, naturally, is implied for any object with both of these traits.

It turns out that `rand` crate already does almost the same thing with `CryptoRngCore` (which is actually what I named my extension trait). 

However the implementation in `rand` crate is slightly different: `CryptoRngCore` implies `RngCore` but not `CryptoRng`.

I can't see right now that there's a compelling use-case for it the way it's implemented right now: any place where I would write `&mut dyn CryptoRngCore` my code would also work if my function takes `&mut dyn RngCore`, since `CryptoRngCore` provides no additional functionality other than a function that converts self to `&mut dyn RngCore`. (But I could have started with that...)

OTOH if `CryptoRngCore` implies both `RngCore` and `CryptoRng` then it's quite useful, because it works around the inability to make `dyn (X + Y)` in rust right now. Then I would just use the upstream version and drop my version.

Let me know what you think. Thank you!