### PR TITLE
Add getters for distribution parameters, closes #1233

### DIFF
--- a/rand_distr/src/binomial.rs
+++ b/rand_distr/src/binomial.rs
@@ -80,7 +80,7 @@ impl Binomial {
     }
 
     /// Returns the probability of success (`p`) of the distribution.
-    pub fn p(&self) -> u64 {
+    pub fn p(&self) -> f64 {
         self.p
     }
 }

--- a/rand_distr/src/binomial.rs
+++ b/rand_distr/src/binomial.rs
@@ -73,6 +73,16 @@ impl Binomial {
         }
         Ok(Binomial { n, p })
     }
+
+    /// Returns the number of trials (`n`) of the distribution.
+    pub fn n(&self) -> u64 {
+        self.n
+    }
+
+    /// Returns the probability of success (`p`) of the distribution.
+    pub fn p(&self) -> u64 {
+        self.p
+    }
 }
 
 /// Convert a `f64` to an `i64`, panicking on overflow.

--- a/rand_distr/src/cauchy.rs
+++ b/rand_distr/src/cauchy.rs
@@ -70,6 +70,16 @@ where F: Float + FloatConst, Standard: Distribution<F>
         }
         Ok(Cauchy { median, scale })
     }
+
+    /// Returns the median (`median`) of the distribution.
+    pub fn median(&self) -> F {
+        self.median
+    }
+
+    /// Returns the scale (`scale`) of the distribution.
+    pub fn scale(&self) -> F {
+        self.scale
+    }
 }
 
 impl<F> Distribution<F> for Cauchy<F>

--- a/rand_distr/src/dirichlet.rs
+++ b/rand_distr/src/dirichlet.rs
@@ -111,6 +111,11 @@ where
             alpha: vec![alpha; size].into_boxed_slice(),
         })
     }
+
+    /// Returns the shape parameter (`alpha`) of the distribution.
+    pub fn alpha(&self) -> Box<[F]> {
+        self.alpha
+    }
 }
 
 impl<F> Distribution<Vec<F>> for Dirichlet<F>

--- a/rand_distr/src/dirichlet.rs
+++ b/rand_distr/src/dirichlet.rs
@@ -114,7 +114,7 @@ where
 
     /// Returns the shape parameter (`alpha`) of the distribution.
     pub fn alpha(&self) -> Box<[F]> {
-        self.alpha
+        self.alpha.clone()
     }
 }
 

--- a/rand_distr/src/dirichlet.rs
+++ b/rand_distr/src/dirichlet.rs
@@ -113,8 +113,8 @@ where
     }
 
     /// Returns the shape parameter (`alpha`) of the distribution.
-    pub fn alpha(&self) -> Box<[F]> {
-        self.alpha.clone()
+    pub fn alpha(&self) -> &[F] {
+        &self.alpha
     }
 }
 

--- a/rand_distr/src/exponential.rs
+++ b/rand_distr/src/exponential.rs
@@ -140,6 +140,11 @@ where F: Float, Exp1: Distribution<F>
             lambda_inverse: F::one() / lambda,
         })
     }
+
+    /// Returns the (inverse of the) shape parameter (`lambda`) of the distribution.
+    pub fn lambda_inverse(&self) -> F {
+        self.lambda_inverse
+    }
 }
 
 impl<F> Distribution<F> for Exp<F>

--- a/rand_distr/src/frechet.rs
+++ b/rand_distr/src/frechet.rs
@@ -86,6 +86,21 @@ where
             shape,
         })
     }
+
+    /// Returns the location (`location`) of the distribution.
+    pub fn location(&self) -> F {
+        self.location
+    }
+
+    /// Returns the scale (`scale`) of the distribution.
+    pub fn scale(&self) -> F {
+        self.scale
+    }
+
+    /// Returns the shape (`shape`) of the distribution.
+    pub fn shape(&self) -> F {
+        self.shape
+    }
 }
 
 impl<F> Distribution<F> for Frechet<F>

--- a/rand_distr/src/gamma.rs
+++ b/rand_distr/src/gamma.rs
@@ -703,19 +703,19 @@ where
     /// Returns the alpha shape (`alpha`) of the distribution.
     pub fn alpha(&self) -> F {
         if self.switched_params {
-            return self.b;
+            self.b
+        } else {
+            self.a
         }
-
-        self.a
     }
 
     /// Returns the beta shape (`beta`) of the distribution.
     pub fn beta(&self) -> F {
         if self.switched_params {
-            return self.a;
+            self.a
+        } else {
+            self.b
         }
-
-        self.b
     }
 }
 

--- a/rand_distr/src/gamma.rs
+++ b/rand_distr/src/gamma.rs
@@ -694,6 +694,24 @@ where
             })
         }
     }
+
+    /// Returns the alpha shape (`alpha`) of the distribution.
+    pub fn alpha(&self) -> F {
+        if self.switched_params {
+            return self.b;
+        }
+
+        self.a
+    }
+
+    /// Returns the beta shape (`beta`) of the distribution.
+    pub fn beta(&self) -> F {
+        if self.switched_params {
+            return self.a;
+        }
+
+        self.b
+    }
 }
 
 impl<F> Distribution<F> for Beta<F>

--- a/rand_distr/src/gamma.rs
+++ b/rand_distr/src/gamma.rs
@@ -544,6 +544,11 @@ where
             dof: n,
         })
     }
+
+    /// Return the degrees-of-freedom (`n`) of the distribution.
+    pub fn n(&self) -> F {
+        self.chi.k()
+    }
 }
 impl<F> Distribution<F> for StudentT<F>
 where

--- a/rand_distr/src/gamma.rs
+++ b/rand_distr/src/gamma.rs
@@ -481,6 +481,16 @@ where
             dof_ratio: n / m,
         })
     }
+
+    /// Returns the m parameter (`m`) of the distribution.
+    pub fn m(&self) -> F {
+        self.numer.k()
+    }
+
+    /// Returns the n parameter (`n`) of the distribution.
+    pub fn n(&self) -> F {
+        self.denom.k()
+    }
 }
 impl<F> Distribution<F> for FisherF<F>
 where

--- a/rand_distr/src/gamma.rs
+++ b/rand_distr/src/gamma.rs
@@ -175,6 +175,30 @@ where
         };
         Ok(Gamma { repr })
     }
+
+    /// Returns the shape parameter (`shape`) of the distribution.
+    pub fn shape(&self) -> F {
+        match self.repr {
+            // By definition of `one`.
+            One(_) => F::one(),
+            // By definition of `small shape`.
+            Small(gamma) => gamma.inv_shape.recip(),
+            // By definition of `large shape`.
+            Large(gamma) => gamma.d + F::from(1. / 3.).unwrap(),
+        }
+    }
+
+    /// Returns the scale parameter (`scale`) of the distribution.
+    pub fn scale(&self) -> F {
+        match self.repr {
+            // By definition of `one`.
+            One(exp) => exp.lambda_inverse().recip(),
+            // By definition of `small shape`.
+            Small(gamma) => gamma.large_shape.scale,
+            // By definition of `large shape`.
+            Large(gamma) => gamma.scale,
+        }
+    }
 }
 
 impl<F> GammaSmallShape<F>

--- a/rand_distr/src/gamma.rs
+++ b/rand_distr/src/gamma.rs
@@ -374,6 +374,16 @@ where
         };
         Ok(ChiSquared { repr })
     }
+
+    /// Returns the degrees-of-freedom (`k`) of the distribution.
+    pub fn k(&self) -> F {
+        match self.repr {
+            DoFExactlyOne => F::one(),
+            // Since `DoFAnythingElse` is computed using Gamma(shape = 0.5 * k, ...),
+            // we revert the operation k = (1. / 0.5) * shape = 2. * shape.
+            DoFAnythingElse(gamma) => F::from(2.).unwrap() * gamma.shape(),
+        }
+    }
 }
 impl<F> Distribution<F> for ChiSquared<F>
 where

--- a/rand_distr/src/geometric.rs
+++ b/rand_distr/src/geometric.rs
@@ -78,6 +78,11 @@ impl Geometric {
             Ok(Geometric { p, pi, k })
         }
     }
+
+    /// Returns the probability of success on each trial (`p`) of the distribution.
+    pub fn p(&self) -> f64 {
+        self.p
+    }
 }
 
 impl Distribution<u64> for Geometric

--- a/rand_distr/src/gumbel.rs
+++ b/rand_distr/src/gumbel.rs
@@ -75,6 +75,16 @@ where
         }
         Ok(Gumbel { location, scale })
     }
+
+    /// Returns the location (`location`) of the distribution.
+    pub fn location(&self) -> F {
+        self.location
+    }
+
+    /// Returns the scale (`scale`) of the distribution.
+    pub fn scale(&self) -> F {
+        self.scale
+    }
 }
 
 impl<F> Distribution<F> for Gumbel<F>

--- a/rand_distr/src/inverse_gaussian.rs
+++ b/rand_distr/src/inverse_gaussian.rs
@@ -58,6 +58,16 @@ where
 
         Ok(Self { mean, shape })
     }
+
+    /// Returns the mean (`μ`) of the distribution.
+    pub fn mean(&self) -> F {
+        self.mean
+    }
+
+    /// Returns the shape (`shape`) of the distribution.
+    pub fn shape(&self) -> F {
+        self.shape
+    }
 }
 
 impl<F> Distribution<F> for InverseGaussian<F>

--- a/rand_distr/src/normal.rs
+++ b/rand_distr/src/normal.rs
@@ -304,6 +304,16 @@ where F: Float, StandardNormal: Distribution<F>
     pub fn from_zscore(&self, zscore: F) -> F {
         self.norm.from_zscore(zscore).exp()
     }
+
+    /// Returns the mean (`μ`) of the distribution.
+    pub fn mean(&self) -> F {
+        self.norm.mean()
+    }
+
+    /// Returns the standard deviation (`σ`) of the distribution.
+    pub fn std_dev(&self) -> F {
+        self.norm.std_dev()
+    }
 }
 
 impl<F> Distribution<F> for LogNormal<F>

--- a/rand_distr/src/normal_inverse_gaussian.rs
+++ b/rand_distr/src/normal_inverse_gaussian.rs
@@ -66,6 +66,25 @@ where
             inverse_gaussian,
         })
     }
+
+    /// Returns the alpha parameter (`alpha`) of the distribution.
+    pub fn alpha(&self) -> F {
+        // By definition:
+        //      gamma = sqrt(alpha^2 - beta^2) with alpha > 0
+        //      mu = 1 / gamma
+        // Therefore:
+        //      mu = 1 / sqrt(alpha^2 - beta^2)
+        //      mu^2 = 1 / (alpha^2 - beta^2)
+        //      1 / mu^2 = alpha^2 - beta^2
+        //      1 / mu^2 + beta^2 = alpha^2
+        //      sqrt(1 / mu^2 + beta^2) = alpha with alpha > 0
+        F::sqrt(self.inverse_gaussian.mean().powi(2).recip() + self.beta.powi(2))
+    }
+
+    /// Returns the beta parameter (`beta`) of the distribution.
+    pub fn beta(&self) -> F {
+        self.beta
+    }
 }
 
 impl<F> Distribution<F> for NormalInverseGaussian<F>

--- a/rand_distr/src/pareto.rs
+++ b/rand_distr/src/pareto.rs
@@ -75,6 +75,16 @@ where F: Float, OpenClosed01: Distribution<F>
             inv_neg_shape: F::from(-1.0).unwrap() / shape,
         })
     }
+
+    /// Returns the scale (`scale`) of the distribution.
+    pub fn scale(&self) -> F {
+        self.scale
+    }
+
+    /// Returns the shape (`shape`) of the distribution.
+    pub fn shape(&self) -> F {
+        self.inv_neg_shape.recip().neg()
+    }
 }
 
 impl<F> Distribution<F> for Pareto<F>

--- a/rand_distr/src/poisson.rs
+++ b/rand_distr/src/poisson.rs
@@ -78,6 +78,11 @@ where F: Float + FloatConst, Standard: Distribution<F>
             magic_val: lambda * log_lambda - crate::utils::log_gamma(F::one() + lambda),
         })
     }
+
+    /// Returns the lambda shape (`lambda`) of the distribution.
+    pub fn lambda(&self) -> F {
+        self.lambda
+    }
 }
 
 impl<F> Distribution<F> for Poisson<F>

--- a/rand_distr/src/triangular.rs
+++ b/rand_distr/src/triangular.rs
@@ -79,6 +79,21 @@ where F: Float, Standard: Distribution<F>
         }
         Ok(Triangular { min, max, mode })
     }
+
+    /// Return the min shape (`min`) of the distribution.
+    pub fn min(&self) -> F {
+        self.min
+    }
+
+    /// Return the min shape (`max`) of the distribution.
+    pub fn max(&self) -> F {
+        self.max
+    }
+
+    /// Return the min shape (`mode`) of the distribution.
+    pub fn mode(&self) -> F {
+        self.mode
+    }
 }
 
 impl<F> Distribution<F> for Triangular<F>

--- a/rand_distr/src/weibull.rs
+++ b/rand_distr/src/weibull.rs
@@ -70,6 +70,16 @@ where F: Float, OpenClosed01: Distribution<F>
             scale,
         })
     }
+
+    /// Returns the scale parameter (`scale`) of the distribution.
+    pub fn scale(&self) -> F {
+        self.scale
+    }
+
+    /// Returns the shape parameter (`shape`) of the distribution.
+    pub fn shape(&self) -> F {
+        self.inv_shape.recip()
+    }
 }
 
 impl<F> Distribution<F> for Weibull<F>

--- a/rand_distr/src/zipf.rs
+++ b/rand_distr/src/zipf.rs
@@ -89,6 +89,11 @@ where F: Float, Standard: Distribution<F>, OpenClosed01: Distribution<F>
             b: two.powf(a_minus_1),
         })
     }
+
+    /// Returns the a parameter (`a`) of the distribution.
+    pub fn a(&self) -> F {
+        self.a_minus_1 + F::one()
+    }
 }
 
 impl<F> Distribution<F> for Zeta<F>

--- a/rand_distr/src/zipf.rs
+++ b/rand_distr/src/zipf.rs
@@ -210,6 +210,35 @@ where F: Float, Standard: Distribution<F> {
         })
     }
 
+    /// Returns the cardinality of the set of elements (`n`) of the distribution.
+    pub fn n(&self) -> F {
+        match self.s != F::one() {
+            true => {
+                // By definition:
+                //      t = (n^(1 - s) - s) * q
+                // Therefore:
+                //      t / q = n^(1 - s) - s
+                //      t / q + s = n^(1 - s)
+                //      (t / q + s)^(1/(1 - s)) = n
+                F::powf(self.t / self.q + self.s, F::recip(F::one() - self.s))
+            },
+            false => {
+                // By definition:
+                //      t = 1 - ln(n)
+                // Therefore:
+                //      t - 1 = - ln(n)
+                //      1 - t = ln(n)
+                //      e^(1 - t) = n
+                F::exp(F::one() - self.t)
+            },
+        }
+    }
+
+    /// Returns the frequency rank exponent (`s`) of the distribution.
+    pub fn s(&self) -> F {
+        self.s
+    }
+
     /// Inverse cumulative density function
     #[inline]
     fn inv_cdf(&self, p: F) -> F {


### PR DESCRIPTION
Add getters for distributions that satisfy (1) and (2) criteria described in #1233, also provide a reference implementation for reverse-computing getters distribution that satisfy only (1), except for `Hypergeometric`, `Pert` and `WeightedAlias`.

This is still a draft since we need to decide what to do for these distribution that satisfy only (1), eventually we can simply revert the commits with the reverse-computing getters and keep the exact getters.

Closes #1233.