### PR TITLE
Deterministic Rayon monte carlo example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,3 +83,4 @@ libc = { version = "0.2.22", optional = true, default-features = false }
 rand_pcg = { path = "rand_pcg", version = "0.3.0" }
 # Only to test serde1
 bincode = "1.2.1"
+rayon = "1.5.3"

--- a/examples/rayon-monte-carlo.rs
+++ b/examples/rayon-monte-carlo.rs
@@ -33,10 +33,10 @@
 //! map_init to construct one RNG per Rayon batch.
 //!
 //! Instead, we do our own batching, so that a Rayon work item becomes a
-//! batch. Then we can fix our rng stream to the batched work item. This
-//! Then we amortizes the cost of constructing the Rng over BATCH_SIZE trials.
-//! Manually batching also turns out to be faster for the nondeterministic
-//! version of this program as well.
+//! batch. Then we can fix our rng stream to the batched work item.
+//! Batching amortizes the cost of constructing the Rng from a fixed seed
+//! over BATCH_SIZE trials. Manually batching also turns out to be faster
+//! for the nondeterministic version of this program as well.
 
 #![cfg(all(feature = "std", feature = "std_rng"))]
 

--- a/examples/rayon-monte-carlo.rs
+++ b/examples/rayon-monte-carlo.rs
@@ -1,0 +1,67 @@
+// Copyright 2018 Developers of the Rand project.
+// Copyright 2013-2018 The Rust Project Developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! # Monte Carlo estimation of π with a chosen seed and rayon for parallelism
+//!
+//! Imagine that we have a square with sides of length 2 and a unit circle
+//! (radius = 1), both centered at the origin. The areas are:
+//!
+//! ```text
+//!     area of circle  = πr² = π * r * r = π
+//!     area of square  = 2² = 4
+//! ```
+//!
+//! The circle is entirely within the square, so if we sample many points
+//! randomly from the square, roughly π / 4 of them should be inside the circle.
+//!
+//! We can use the above fact to estimate the value of π: pick many points in
+//! the square at random, calculate the fraction that fall within the circle,
+//! and multiply this fraction by 4.
+
+#![cfg(all(feature = "std", feature = "std_rng"))]
+
+use rand::distributions::{Distribution, Uniform};
+use rand_chacha::rand_core::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+use rayon::prelude::*;
+
+static SEED: u64 = 0;
+
+fn main() {
+    let range = Uniform::new(-1.0f64, 1.0);
+
+    let total = 1_000_000;
+    let cha_cha = ChaCha8Rng::seed_from_u64(SEED);
+
+    let in_circle: usize = (0..total)
+        .into_par_iter()
+        .map_init(
+            || cha_cha.clone(),
+            |rng, i| {
+                // ChaCha supports indexing into its stream. We need this because due to work-stealing, 
+                // Rayon does not guarantee that the same work items will be run in the same order
+                // between runs of the program. We can only guarantee determinism by setting the stream 
+                // according to the work number.
+                rng.set_word_pos(i);
+                let a = range.sample(rng);
+                let b = range.sample(rng);
+                if a * a + b * b <= 1.0 {
+                    1
+                } else {
+                    0
+                }
+            },
+        )
+        .reduce(|| 0, |a, b| a + b);
+    // prints something close to 3.14159...
+    println!(
+        "π is approximately {}",
+        4. * (in_circle as f64) / (total as f64)
+    );
+}


### PR DESCRIPTION
It wasn't straightforward to understand how to use Rayon in conjunction with Rand to construct a monte-carlo simulation that

1. Given the same seed, always produces the same output
2. Is efficient. In particular, does not require creating a new RNG per work item.

Spawned from this discussion: https://github.com/rust-random/rand/pull/399