### PR TITLE
switch to std::simd, expand SIMD & docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,8 @@ alloc = ["rand_core/alloc"]
 # Option: use getrandom package for seeding
 getrandom = ["rand_core/getrandom"]
 
-# Option (requires nightly): experimental SIMD support
-simd_support = ["packed_simd"]
+# Option (requires nightly Rust): experimental SIMD support
+simd_support = []
 
 # Option (enabled by default): enable StdRng
 std_rng = ["rand_chacha"]
@@ -67,13 +67,6 @@ rand_core = { path = "rand_core", version = "0.6.0" }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 rand_chacha = { path = "rand_chacha", version = "0.3.0", default-features = false, optional = true }
-
-[dependencies.packed_simd]
-# NOTE: so far no version works reliably due to dependence on unstable features
-package = "packed_simd_2"
-version = "0.3.7"
-optional = true
-features = ["into_bits"]
 
 [target.'cfg(unix)'.dependencies]
 # Used for fork protection (reseeding.rs)

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -14,6 +14,7 @@ use core::{fmt, u64};
 
 #[cfg(feature = "serde1")]
 use serde::{Serialize, Deserialize};
+
 /// The Bernoulli distribution.
 ///
 /// This is a special case of the Binomial distribution where `n = 1`.
@@ -147,10 +148,10 @@ mod test {
     use crate::Rng;
 
     #[test]
-    #[cfg(feature="serde1")]
+    #[cfg(feature = "serde1")]
     fn test_serializing_deserializing_bernoulli() {
         let coin_flip = Bernoulli::new(0.5).unwrap();
-        let de_coin_flip : Bernoulli = bincode::deserialize(&bincode::serialize(&coin_flip).unwrap()).unwrap();
+        let de_coin_flip: Bernoulli = bincode::deserialize(&bincode::serialize(&coin_flip).unwrap()).unwrap();
 
         assert_eq!(coin_flip.p_int, de_coin_flip.p_int);
     }

--- a/src/distributions/integer.rs
+++ b/src/distributions/integer.rs
@@ -114,7 +114,7 @@ impl_nzint!(NonZeroU64, NonZeroU64::new);
 impl_nzint!(NonZeroU128, NonZeroU128::new);
 impl_nzint!(NonZeroUsize, NonZeroUsize::new);
 
-macro_rules! intrinsic_impl {
+macro_rules! x86_intrinsic_impl {
     ($($intrinsic:ident),+) => {$(
         /// Available only on x86/64 platforms
         impl Distribution<$intrinsic> for Standard {
@@ -156,12 +156,12 @@ macro_rules! simd_impl {
 simd_impl!(u8, i8, u16, i16, u32, i32, u64, i64, usize, isize);
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-intrinsic_impl!(__m128i, __m256i);
+x86_intrinsic_impl!(__m128i, __m256i);
 #[cfg(all(
     any(target_arch = "x86", target_arch = "x86_64"),
     feature = "simd_support"
 ))]
-intrinsic_impl!(__m512i);
+x86_intrinsic_impl!(__m512i);
 
 #[cfg(test)]
 mod tests {

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -221,7 +221,7 @@ use crate::Rng;
 /// [`Uniform`]: uniform::Uniform
 /// [`Wrapping<T>`]: std::num::Wrapping
 /// [`NonZeroU8`]: std::num::NonZeroU8
-/// [`__m128i`]: https://doc.rust-lang.org/nightly/core/arch/x86/struct.__m128i.html
+/// [`__m128i`]: https://doc.rust-lang.org/core/arch/x86/struct.__m128i.html
 /// [`u32x4`]: std::simd::u32x4
 /// [`f32x4`]: std::simd::f32x4
 /// [`mask32x4`]: std::simd::mask32x4

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -149,8 +149,14 @@ use crate::Rng;
 /// * `bool`: Generates `false` or `true`, each with probability 0.5.
 /// * Floating point types (`f32` and `f64`): Uniformly distributed in the
 ///   half-open range `[0, 1)`. See notes below.
-/// * Wrapping integers (`Wrapping<T>`), besides the type identical to their
+/// * Wrapping integers ([`Wrapping<T>`]), besides the type identical to their
 ///   normal integer variants.
+/// * Non-zero integers ([`NonZeroU8`]), which are like their normal integer
+///   variants but cannot produce zero.
+/// * SIMD types like x86's [`__m128i`], `std::simd`'s [`u32x4`]/[`f32x4`]/
+///   [`mask32x4`] (requires [`simd_support`]), where each lane is distributed
+///   like their scalar `Standard` variants. See the list of `Standard`
+///   implementations for more.
 ///
 /// The `Standard` distribution also supports generation of the following
 /// compound types where all component types are supported:
@@ -213,6 +219,13 @@ use crate::Rng;
 /// CPUs all methods have approximately equal performance).
 ///
 /// [`Uniform`]: uniform::Uniform
+/// [`Wrapping<T>`]: std::num::Wrapping
+/// [`NonZeroU8`]: std::num::NonZeroU8
+/// [`__m128i`]: https://doc.rust-lang.org/nightly/core/arch/x86/struct.__m128i.html
+/// [`u32x4`]: std::simd::u32x4
+/// [`f32x4`]: std::simd::f32x4
+/// [`mask32x4`]: std::simd::mask32x4
+/// [`simd_support`]: https://github.com/rust-random/rand#crate-features
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Standard;

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -174,6 +174,8 @@ where
 {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Mask<T, LANES> {
+        // `MaskElement` must be a signed integer, so this is equivalent
+        // to the scalar `i32 < 0` method
         rng.gen().lanes_lt(Simd::default())
     }
 }

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -163,7 +163,12 @@ impl Distribution<bool> for Standard {
 ///
 /// Since most bits are unused you could also generate only as many bits as you need, i.e.:
 /// ```
-/// let x = u16x8::splat(rng.gen::<u8> as u16);
+/// #![feature(portable_simd)]
+/// use std::simd::*;
+/// use rand::prelude::*;
+/// let mut rng = thread_rng();
+///
+/// let x = u16x8::splat(rng.gen::<u8>() as u16);
 /// let mask = u16x8::splat(1) << u16x8::from([0, 1, 2, 3, 4, 5, 6, 7]);
 /// let rand_mask = (x & mask).simd_eq(mask);
 /// ```

--- a/src/distributions/utils.rs
+++ b/src/distributions/utils.rs
@@ -99,20 +99,20 @@ macro_rules! wmul_impl_large {
                 #[inline(always)]
                 fn wmul(self, b: $ty) -> Self::Output {
                     // needs wrapping multiplication
-                    const LOWER_MASK: $ty = <$ty>::splat(!0 >> $half);
-                    const HALF: $ty = <$ty>::splat($half);
-                    let mut low = (self & LOWER_MASK) * (b & LOWER_MASK);
-                    let mut t = low >> HALF;
-                    low &= LOWER_MASK;
-                    t += (self >> HALF) * (b & LOWER_MASK);
-                    low += (t & LOWER_MASK) << HALF;
-                    let mut high = t >> HALF;
-                    t = low >> HALF;
-                    low &= LOWER_MASK;
-                    t += (b >> HALF) * (self & LOWER_MASK);
-                    low += (t & LOWER_MASK) << HALF;
-                    high += t >> HALF;
-                    high += (self >> HALF) * (b >> HALF);
+                    let lower_mask = <$ty>::splat(!0 >> $half);
+                    let half = <$ty>::splat($half);
+                    let mut low = (self & lower_mask) * (b & lower_mask);
+                    let mut t = low >> half;
+                    low &= lower_mask;
+                    t += (self >> half) * (b & lower_mask);
+                    low += (t & lower_mask) << half;
+                    let mut high = t >> half;
+                    t = low >> half;
+                    low &= lower_mask;
+                    t += (b >> half) * (self & lower_mask);
+                    low += (t & lower_mask) << half;
+                    high += t >> half;
+                    high += (self >> half) * (b >> half);
 
                     (high, low)
                 }
@@ -385,12 +385,12 @@ macro_rules! simd_impl {
 
             #[inline(always)]
             fn all_lt(self, other: Self) -> bool {
-                self.lanes_lt(other).all()
+                self.simd_lt(other).all()
             }
 
             #[inline(always)]
             fn all_le(self, other: Self) -> bool {
-                self.lanes_le(other).all()
+                self.simd_le(other).all()
             }
 
             #[inline(always)]
@@ -405,12 +405,12 @@ macro_rules! simd_impl {
 
             #[inline(always)]
             fn gt_mask(self, other: Self) -> Self::Mask {
-                self.lanes_gt(other)
+                self.simd_gt(other)
             }
 
             #[inline(always)]
             fn ge_mask(self, other: Self) -> Self::Mask {
-                self.lanes_ge(other)
+                self.simd_ge(other)
             }
 
             #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 #![deny(missing_debug_implementations)]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 #![no_std]
-#![cfg_attr(feature = "simd_support", feature(stdsimd))]
+#![cfg_attr(feature = "simd_support", feature(stdsimd, portable_simd))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![allow(
     clippy::float_cmp,


### PR DESCRIPTION
Closes #1232. Should also fix #1162.

The new API is pretty easy and the new trait system made for some convenient generic implementations.

Changes:
* moved `__m128i` & `__m256i` away from `simd_support` feature
* added `__m512i` and some internal AVX512 optimizations
* dropped `u8x2`/`i8x2` types due to lack of support in `std::simd`
* added SIMD types (and `NonZero`) to the list in `Standard` type documentation
* implemented `Distribution<maskNxM> for Standard`, behaves like `rng.gen::<bool>`
* ~~implemented `Distribution<mask64xM> for Bernoulli`, each lane uses the same prob~~

The trait system allows impls to adapt to future SIMD types and doesn't clutter the rendered documentation. Using it in more places would mean some code duplication though.

`__m512i` requires nightly Rust's `stdsimd` feature at the moment so I put it under the `simd_support` feature but `nightly` might make more sense.