### PR TITLE
Clarify documentation of `choose_weighted(_mut)` mentioning accurate behavior with floats

### DIFF
--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -65,7 +65,7 @@ use serde::{Serialize, Deserialize};
 ///     println!("{}", choices[dist.sample(&mut rng)]);
 /// }
 ///
-/// let items = [('a', 0), ('b', 3), ('c', 7)];
+/// let items = [('a', 0.0), ('b', 3.0), ('c', 7.0)];
 /// let dist2 = WeightedIndex::new(items.iter().map(|item| item.1)).unwrap();
 /// for _ in 0..100 {
 ///     // 0% chance to print 'a', 30% chance to print 'b', 70% chance to print 'c'

--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -25,8 +25,8 @@ use serde::{Serialize, Deserialize};
 /// Sampling a `WeightedIndex` distribution returns the index of a randomly
 /// selected element from the iterator used when the `WeightedIndex` was
 /// created. The chance of a given element being picked is proportional to the
-/// value of the element. The weights can use any type `X` for which an
-/// implementation of [`Uniform<X>`] exists.
+/// weight of the element. The weights can use any type `X` for which an
+/// implementation of [`Uniform<X>`] exists. The implementation guarantees that elements with zero weight are never picked, even when the weights are floating point numbers.
 ///
 /// # Performance
 ///
@@ -42,7 +42,7 @@ use serde::{Serialize, Deserialize};
 /// weights of type `X`, where `N` is the number of weights. However, since
 /// `Vec` doesn't guarantee a particular growth strategy, additional memory
 /// might be allocated but not used. Since the `WeightedIndex` object also
-/// contains, this might cause additional allocations, though for primitive
+/// contains an instance of `X::Sampler`, this might cause additional allocations, though for primitive
 /// types, [`Uniform<X>`] doesn't allocate any memory.
 ///
 /// Sampling from `WeightedIndex` will result in a single call to

--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -26,7 +26,9 @@ use serde::{Serialize, Deserialize};
 /// selected element from the iterator used when the `WeightedIndex` was
 /// created. The chance of a given element being picked is proportional to the
 /// weight of the element. The weights can use any type `X` for which an
-/// implementation of [`Uniform<X>`] exists. The implementation guarantees that elements with zero weight are never picked, even when the weights are floating point numbers.
+/// implementation of [`Uniform<X>`] exists. The implementation guarantees that
+/// elements with zero weight are never picked, even when the weights are
+/// floating point numbers.
 ///
 /// # Performance
 ///
@@ -42,8 +44,8 @@ use serde::{Serialize, Deserialize};
 /// weights of type `X`, where `N` is the number of weights. However, since
 /// `Vec` doesn't guarantee a particular growth strategy, additional memory
 /// might be allocated but not used. Since the `WeightedIndex` object also
-/// contains an instance of `X::Sampler`, this might cause additional allocations, though for primitive
-/// types, [`Uniform<X>`] doesn't allocate any memory.
+/// contains an instance of `X::Sampler`, this might cause additional allocations,
+/// though for primitive types, [`Uniform<X>`] doesn't allocate any memory.
 ///
 /// Sampling from `WeightedIndex` will result in a single call to
 /// `Uniform<X>::sample` (method of the [`Distribution`] trait), which typically

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -123,21 +123,24 @@ pub trait SliceRandom {
     /// therefore `weight(x) / s`, where `s` is the sum of all `weight(x)`.
     ///
     /// For slices of length `n`, complexity is `O(n)`.
-    /// See also [`choose_weighted_mut`], [`distributions::weighted`].
+    /// For more information about the underlying algorithm, see [`distributions::WeightedIndex`].
+    ///
+    /// See also [`choose_weighted_mut`].
     ///
     /// # Example
     ///
     /// ```
     /// use rand::prelude::*;
     ///
-    /// let choices = [('a', 2), ('b', 1), ('c', 1)];
+    /// let choices = [('a', 2), ('b', 1), ('c', 1), ('d', 0)];
     /// let mut rng = thread_rng();
-    /// // 50% chance to print 'a', 25% chance to print 'b', 25% chance to print 'c'
+    /// // 50% chance to print 'a', 25% chance to print 'b', 25% chance to print 'c',
+    /// // and 'd' will never be printed
     /// println!("{:?}", choices.choose_weighted(&mut rng, |item| item.1).unwrap().0);
     /// ```
     /// [`choose`]: SliceRandom::choose
     /// [`choose_weighted_mut`]: SliceRandom::choose_weighted_mut
-    /// [`distributions::weighted`]: crate::distributions::weighted
+    /// [`distributions::WeightedIndex`]: crate::distributions::WeightedIndex
     #[cfg(feature = "alloc")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
     fn choose_weighted<R, F, B, X>(
@@ -161,11 +164,13 @@ pub trait SliceRandom {
     /// therefore `weight(x) / s`, where `s` is the sum of all `weight(x)`.
     ///
     /// For slices of length `n`, complexity is `O(n)`.
-    /// See also [`choose_weighted`], [`distributions::weighted`].
+    /// For more information about the underlying algorithm, see [`distributions::WeightedIndex`].
+    ///
+    /// See also [`choose_weighted`].
     ///
     /// [`choose_mut`]: SliceRandom::choose_mut
     /// [`choose_weighted`]: SliceRandom::choose_weighted
-    /// [`distributions::weighted`]: crate::distributions::weighted
+    /// [`distributions::WeightedIndex`]: crate::distributions::WeightedIndex
     #[cfg(feature = "alloc")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
     fn choose_weighted_mut<R, F, B, X>(

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -123,7 +123,8 @@ pub trait SliceRandom {
     /// therefore `weight(x) / s`, where `s` is the sum of all `weight(x)`.
     ///
     /// For slices of length `n`, complexity is `O(n)`.
-    /// For more information about the underlying algorithm, see [`distributions::WeightedIndex`].
+    /// For more information about the underlying algorithm,
+    /// see [`distributions::WeightedIndex`].
     ///
     /// See also [`choose_weighted_mut`].
     ///
@@ -164,7 +165,8 @@ pub trait SliceRandom {
     /// therefore `weight(x) / s`, where `s` is the sum of all `weight(x)`.
     ///
     /// For slices of length `n`, complexity is `O(n)`.
-    /// For more information about the underlying algorithm, see [`distributions::WeightedIndex`].
+    /// For more information about the underlying algorithm,
+    /// see [`distributions::WeightedIndex`].
     ///
     /// See also [`choose_weighted`].
     ///


### PR DESCRIPTION
Changes as discussed in [this comment](https://github.com/rust-random/rand/issues/1243#issuecomment-1200317966) in #1243 

 - [x] Updates the choose_weighted (and similar) methods to have links to the WeightedIndex distribution.
 - [x] Removes any links to deprecated modules
 - [x] Explicitly mentions that zero weights (for floats and ints) are handled correctly, ~~perhaps right before the example using weights of zero in the WeightedIndex docs~~.

I added the mention of zero weight in the first paragraph of the documentation.

Additionally
 * I fixed two minor issues in the docs of `WeightedIndex` and
 * changed the example that includes a weight of zero to use floating point numbers.

Feel free to request changes, this is my first contribution to this repository, so I don't really see the big picture.

Closes #1243 