### PR TITLE
clarify shuffle docs

### DIFF
--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -228,6 +228,7 @@ pub trait SliceRandom {
     /// Shuffle a mutable slice in place.
     ///
     /// For slices of length `n`, complexity is `O(n)`.
+    /// The resulting permutation is picked uniformly from the set of all possible permutations.
     ///
     /// # Example
     ///


### PR DESCRIPTION
Fixes https://github.com/rust-random/rand/issues/1258

In that issue @vks makes a remark about the generator state space. Is that something that should be mentioned here? I am not sure if I fully understand the remark, it seems to be about fundamental limits of finite-state pseudo-random number generators.