### PR TITLE
gh-pages action: add id-token write permission

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,23 +14,33 @@ jobs:
   deploy:
     name: GH-pages documentation
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: https://rust-random.github.io/rand/
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@nightly
-      - name: doc (rand)
+
+      - name: Build docs
         env:
           RUSTDOCFLAGS: --cfg doc_cfg
         # --all builds all crates, but with default features for other crates (okay in this case)
         run: |
           cargo doc --all --features nightly,serde1,getrandom,small_rng
           cp utils/redirect.html target/doc/index.html
+
       - name: Setup Pages
         uses: actions/configure-pages@v2
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
           path: './target/doc'
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,5 +1,10 @@
 name: gh-pages
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
@newpavlov these appear to be the recommended permissions (e.g. see https://github.com/actions/deploy-pages/issues/28).
 I also added an environment (https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment). I don't see the need for a separate 'build' job.