### PR TITLE
Bump MSRV to 1.56 (Edition 2021)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
             # Test both windows-gnu and windows-msvc; use beta rust on one
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            toolchain: 1.51.0 # MSRV
+            toolchain: 1.56.0 # MSRV
           - os: ubuntu-latest
             deps: sudo apt-get update ; sudo apt install gcc-multilib
             target: i686-unknown-linux-gnu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,9 +166,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@nightly
         with:
-            toolchain: nightly-2021-01-07 # Pinned compiler version due to https://github.com/rust-lang/compiler-builtins/issues/400
             components: rust-src
       - name: Build top-level only
         run: cargo build -Z build-std=core --target=avr-unknown-gnu-atmega328 --no-default-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,16 +161,17 @@ jobs:
       - name: Build top-level only
         run: cargo build --target=thumbv6m-none-eabi --no-default-features
 
-  test-avr:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-            components: rust-src
-      - name: Build top-level only
-        run: cargo build -Z build-std=core --target=avr-unknown-gnu-atmega328 --no-default-features
+  # Disabled due to lack of known working compiler versions (not older than our MSRV)
+  # test-avr:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Install toolchain
+  #       uses: dtolnay/rust-toolchain@nightly
+  #       with:
+  #           components: rust-src
+  #     - name: Build top-level only
+  #       run: cargo build -Z build-std=core --target=avr-unknown-gnu-atmega328 --no-default-features
 
   test-ios:
     runs-on: macos-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.8.5"
+version = "0.9.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -60,17 +60,17 @@ members = [
 ]
 
 [dependencies]
-rand_core = { path = "rand_core", version = "0.6.0" }
+rand_core = { path = "rand_core", version = "0.7.0" }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
-rand_chacha = { path = "rand_chacha", version = "0.3.0", default-features = false, optional = true }
+rand_chacha = { path = "rand_chacha", version = "0.4.0", default-features = false, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 # Used for fork protection (reseeding.rs)
 libc = { version = "0.2.22", optional = true, default-features = false }
 
 [dev-dependencies]
-rand_pcg = { path = "rand_pcg", version = "0.3.0" }
+rand_pcg = { path = "rand_pcg", version = "0.4.0" }
 # Only to test serde1
 bincode = "1.2.1"
 rayon = "1.5.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ Random number generators and other randomness functionality.
 keywords = ["random", "rng"]
 categories = ["algorithms", "no-std"]
 autobenches = true
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand)
 [![API](https://docs.rs/rand/badge.svg)](https://docs.rs/rand)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.51+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.56+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 A Rust library for random number generation, featuring:
 
@@ -95,9 +95,10 @@ Some versions of Rand crates have been yanked ("unreleased"). Where this occurs,
 the crate's CHANGELOG *should* be updated with a rationale, and a search on the
 issue tracker with the keyword `yank` *should* uncover the motivation.
 
-### Rust version requirements (MSRV)
+### Rust version requirements
 
-This version of Rand requires Rustc >= 1.51.0.
+The Minimum Supported Rust Version (MSRV) is `rustc >= 1.56.0`.
+Older releases may work (depending on feature configuration) but are untested.
 
 ## Crate Features
 

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -12,7 +12,8 @@ ChaCha random number generator
 """
 keywords = ["random", "rng", "chacha"]
 categories = ["algorithms", "no-std"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 rand_core = { path = "../rand_core", version = "0.6.0" }

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers", "The CryptoCorrosion Contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "0.6.0" }
+rand_core = { path = "../rand_core", version = "0.7.0" }
 ppv-lite86 = { version = "0.2.14", default-features = false, features = ["simd"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/rand_chacha/README.md
+++ b/rand_chacha/README.md
@@ -5,7 +5,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_chacha)
 [![API](https://docs.rs/rand_chacha/badge.svg)](https://docs.rs/rand_chacha)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.51+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.56+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 A cryptographically secure random number generator that uses the ChaCha
 algorithm.

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -12,7 +12,8 @@ Core random number generator traits and tools for implementation.
 """
 keywords = ["random", "rng"]
 categories = ["algorithms", "no-std"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.6.4"
+version = "0.7.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_core/README.md
+++ b/rand_core/README.md
@@ -5,7 +5,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_core)
 [![API](https://docs.rs/rand_core/badge.svg)](https://docs.rs/rand_core)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.51+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.56+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 Core traits and error types of the [rand] library, plus tools for implementing
 RNGs.

--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -381,13 +381,13 @@ impl<R: BlockRngCore<Item = u64>> RngCore for BlockRng64<R> {
         let mut read_len = 0;
         self.half_used = false;
         while read_len < dest.len() {
-            if self.index as usize >= self.results.as_ref().len() {
+            if self.index >= self.results.as_ref().len() {
                 self.core.generate(&mut self.results);
                 self.index = 0;
             }
 
             let (consumed_u64, filled_u8) = fill_via_u64_chunks(
-                &self.results.as_ref()[self.index as usize..],
+                &self.results.as_ref()[self.index..],
                 &mut dest[read_len..],
             );
 

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_distr"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -24,14 +24,14 @@ std_math = ["num-traits/std"]
 serde1 = ["serde", "rand/serde1"]
 
 [dependencies]
-rand = { path = "..", version = "0.8.0", default-features = false }
+rand = { path = "..", version = "0.9.0", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 
 [dev-dependencies]
-rand_pcg = { version = "0.3.0", path = "../rand_pcg" }
+rand_pcg = { version = "0.4.0", path = "../rand_pcg" }
 # For inline examples
-rand = { path = "..", version = "0.8.0", default-features = false, features = ["std_rng", "std", "small_rng"] }
+rand = { path = "..", version = "0.9.0", default-features = false, features = ["std_rng", "std", "small_rng"] }
 # Histogram implementation for testing uniformity
 average = { version = "0.13", features = [ "std" ] }
 # Special functions for testing distributions

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -12,7 +12,8 @@ Sampling from random number distributions
 """
 keywords = ["random", "rng", "distribution", "probability"]
 categories = ["algorithms", "no-std"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [features]

--- a/rand_distr/README.md
+++ b/rand_distr/README.md
@@ -5,7 +5,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_distr)
 [![API](https://docs.rs/rand_distr/badge.svg)](https://docs.rs/rand_distr)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.51+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.56+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 Implements a full suite of random number distribution sampling routines.
 

--- a/rand_distr/benches/Cargo.toml
+++ b/rand_distr/benches/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.0.0"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 description = "Criterion benchmarks of the rand_distr crate"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 publish = false
 
 [workspace]

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -12,7 +12,8 @@ Selected PCG random number generators
 """
 keywords = ["random", "rng", "pcg"]
 categories = ["algorithms", "no-std"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [features]
 serde1 = ["serde"]

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_pcg"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -19,7 +19,7 @@ rust-version = "1.56"
 serde1 = ["serde"]
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "0.6.0" }
+rand_core = { path = "../rand_core", version = "0.7.0" }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/rand_pcg/README.md
+++ b/rand_pcg/README.md
@@ -5,7 +5,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_pcg)
 [![API](https://docs.rs/rand_pcg/badge.svg)](https://docs.rs/rand_pcg)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.51+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.56+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 Implements a selection of PCG random number generators.
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -19,7 +19,7 @@ where_single_line = true
 # struct_field_align_threshold = 20
 
 # Compatibility:
-edition = "2018"        # we require compatibility back to 1.32.0
+edition = "2021"
 
 # Misc:
 inline_attribute_width = 80

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -340,7 +340,7 @@ where Borrowed: SampleUniform
 {
     #[inline(always)]
     fn borrow(&self) -> &Borrowed {
-        *self
+        self
     }
 }
 

--- a/src/rngs/adapter/reseeding.rs
+++ b/src/rngs/adapter/reseeding.rs
@@ -208,8 +208,8 @@ where
         ReseedingCore {
             inner: rng,
             reseeder,
-            threshold: threshold as i64,
-            bytes_until_reseed: threshold as i64,
+            threshold,
+            bytes_until_reseed: threshold,
             fork_counter: 0,
         }
     }

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -238,7 +238,7 @@ where R: Rng + ?Sized {
 
     if amount < 163 {
         const C: [[f32; 2]; 2] = [[1.6, 8.0 / 45.0], [10.0, 70.0 / 9.0]];
-        let j = if length < 500_000 { 0 } else { 1 };
+        let j = usize::from(length >= 500_000);
         let amount_fp = amount as f32;
         let m4 = C[0][j] * amount_fp;
         // Short-cut: when amount < 12, floyd's is always faster
@@ -249,7 +249,7 @@ where R: Rng + ?Sized {
         }
     } else {
         const C: [f32; 2] = [270.0, 330.0 / 9.0];
-        let j = if length < 500_000 { 0 } else { 1 };
+        let j = usize::from(length >= 500_000);
         if (length as f32) < C[j] * (amount as f32) {
             sample_inplace(rng, length, amount)
         } else {

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -641,7 +641,7 @@ impl<'a, S: Index<usize, Output = T> + ?Sized + 'a, T: 'a> Iterator for SliceCho
 
     fn next(&mut self) -> Option<Self::Item> {
         // TODO: investigate using SliceIndex::get_unchecked when stable
-        self.indices.next().map(|i| &self.slice[i as usize])
+        self.indices.next().map(|i| &self.slice[i])
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {


### PR DESCRIPTION
We recently bumped the MSRV to 1.51 (#1246), but we could bump it further. This version is just over a year old, and the next release will be breaking anyway.

- for: Lets us use `edition = "2021"` and `rust-version = "1.56"`
- for: We currently have a CI failure since one of our dev-dependencies, Rayon, requires 1.56
- against: ...?

This PR also applies a few Clippy recommendations. Tempting to invoke rustfmt too, but there are too many open PRs which would conflict.

The README now notes:

> Older releases may work (depending on feature configuration) but are untested.

**If you object, please reply.**