### PR TITLE
Rework CryptoRng

### DIFF
--- a/rand_chacha/src/chacha.rs
+++ b/rand_chacha/src/chacha.rs
@@ -13,7 +13,7 @@
 
 use self::core::fmt;
 use crate::guts::ChaCha;
-use rand_core::block::{BlockRng, BlockRngCore};
+use rand_core::block::{BlockRng, BlockRngCore, CryptoBlockRng};
 use rand_core::{CryptoRng, Error, RngCore, SeedableRng};
 
 #[cfg(feature = "serde1")] use serde::{Serialize, Deserialize, Serializer, Deserializer};
@@ -99,7 +99,7 @@ macro_rules! chacha_impl {
             }
         }
 
-        impl CryptoRng for $ChaChaXCore {}
+        impl CryptoBlockRng for $ChaChaXCore {}
 
         /// A cryptographically secure random number generator that uses the ChaCha algorithm.
         ///
@@ -626,12 +626,12 @@ mod test {
 
     #[test]
     fn test_trait_objects() {
-        use rand_core::CryptoRngCore;
+        use rand_core::CryptoRng;
 
-        let rng = &mut ChaChaRng::from_seed(Default::default()) as &mut dyn CryptoRngCore;
-        let r1 = rng.next_u64();
-        let rng: &mut dyn RngCore = rng.as_rngcore();
-        let r2 = rng.next_u64();
-        assert_ne!(r1, r2);
+        let mut rng1 = ChaChaRng::from_seed(Default::default());
+        let rng2 = &mut rng1.clone() as &mut dyn CryptoRng;
+        for _ in 0..1000 {
+            assert_eq!(rng1.next_u64(), rng2.next_u64());
+        }
     }
 }

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -191,8 +191,8 @@ pub trait RngCore {
     }
 }
 
-/// A marker trait used to indicate that an [`RngCore`] or [`BlockRngCore`]
-/// implementation is supposed to be cryptographically secure.
+/// A marker trait used to indicate that an [`RngCore`] implementation is
+/// supposed to be cryptographically secure.
 ///
 /// *Cryptographically secure generators*, also known as *CSPRNGs*, should
 /// satisfy an additional properties over other generators: given the first
@@ -213,36 +213,7 @@ pub trait RngCore {
 /// weaknesses such as seeding from a weak entropy source or leaking state.
 ///
 /// [`BlockRngCore`]: block::BlockRngCore
-pub trait CryptoRng {}
-
-/// An extension trait that is automatically implemented for any type
-/// implementing [`RngCore`] and [`CryptoRng`].
-///
-/// It may be used as a trait object, and supports upcasting to [`RngCore`] via
-/// the [`CryptoRngCore::as_rngcore`] method.
-///
-/// # Example
-///
-/// ```
-/// use rand_core::CryptoRngCore;
-///
-/// #[allow(unused)]
-/// fn make_token(rng: &mut dyn CryptoRngCore) -> [u8; 32] {
-///     let mut buf = [0u8; 32];
-///     rng.fill_bytes(&mut buf);
-///     buf
-/// }
-/// ```
-pub trait CryptoRngCore: CryptoRng + RngCore {
-    /// Upcast to an [`RngCore`] trait object.
-    fn as_rngcore(&mut self) -> &mut dyn RngCore;
-}
-
-impl<T: CryptoRng + RngCore> CryptoRngCore for T {
-    fn as_rngcore(&mut self) -> &mut dyn RngCore {
-        self
-    }
-}
+pub trait CryptoRng: RngCore {}
 
 /// A random number generator that can be explicitly seeded.
 ///

--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -226,7 +226,6 @@ impl<X> Distribution<usize> for WeightedIndex<X>
 where X: SampleUniform + PartialOrd
 {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
-        use ::core::cmp::Ordering;
         let chosen_weight = self.weight_distribution.sample(rng);
         // Find the first item which has a weight *higher* than the chosen weight.
         self.cumulative_weights.partition_point(|w| w <= &chosen_weight)

--- a/src/rngs/adapter/reseeding.rs
+++ b/src/rngs/adapter/reseeding.rs
@@ -12,7 +12,7 @@
 
 use core::mem::size_of;
 
-use rand_core::block::{BlockRng, BlockRngCore};
+use rand_core::block::{BlockRng, BlockRngCore, CryptoBlockRng};
 use rand_core::{CryptoRng, Error, RngCore, SeedableRng};
 
 /// A wrapper around any PRNG that implements [`BlockRngCore`], that adds the
@@ -147,8 +147,8 @@ where
 
 impl<R, Rsdr> CryptoRng for ReseedingRng<R, Rsdr>
 where
-    R: BlockRngCore + SeedableRng + CryptoRng,
-    Rsdr: RngCore + CryptoRng,
+    R: BlockRngCore<Item = u32> + SeedableRng + CryptoBlockRng,
+    Rsdr: CryptoRng,
 {
 }
 
@@ -276,10 +276,10 @@ where
     }
 }
 
-impl<R, Rsdr> CryptoRng for ReseedingCore<R, Rsdr>
+impl<R, Rsdr> CryptoBlockRng for ReseedingCore<R, Rsdr>
 where
-    R: BlockRngCore + SeedableRng + CryptoRng,
-    Rsdr: RngCore + CryptoRng,
+    R: BlockRngCore<Item = u32> + SeedableRng + CryptoBlockRng,
+    Rsdr: CryptoRng,
 {
 }
 


### PR DESCRIPTION
This PR introduces the `CryptoBlockRng` marker trait. It's used instead of `CryptoRng` on block RNGs, which allows us to mark `CryptoRng` as a subtrait of `RngCore` and makes the `CryptoRngCore` trait redundant.

~~Additionally, `try_fill_bytes` is moved to `CryptoRng` and renamed to `crypto_fill_bytes`. The rationale here is that error checks for potential RNG failures are practically exclusive to cryptographic code.~~

~~Unfortunately, this PR also contains a bunch of formatting changes introduced by `cargo fmt`. I think it could be worth to include formatting check into our CI to prevent such changes in future.~~

cc @tarcieri