### PR TITLE
use partition_point in WeightedIndex

### DIFF
--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -229,7 +229,7 @@ where X: SampleUniform + PartialOrd
         use ::core::cmp::Ordering;
         let chosen_weight = self.weight_distribution.sample(rng);
         // Find the first item which has a weight *higher* than the chosen weight.
-        self.cumulative_weights.partition_point(|w| w <= chosen_weight)
+        self.cumulative_weights.partition_point(|&w| w <= chosen_weight)
     }
 }
 

--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -229,7 +229,7 @@ where X: SampleUniform + PartialOrd
         use ::core::cmp::Ordering;
         let chosen_weight = self.weight_distribution.sample(rng);
         // Find the first item which has a weight *higher* than the chosen weight.
-        self.cumulative_weights.partition_point(|&w| w <= chosen_weight)
+        self.cumulative_weights.partition_point(|w| w <= &chosen_weight)
     }
 }
 

--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -229,15 +229,7 @@ where X: SampleUniform + PartialOrd
         use ::core::cmp::Ordering;
         let chosen_weight = self.weight_distribution.sample(rng);
         // Find the first item which has a weight *higher* than the chosen weight.
-        self.cumulative_weights
-            .binary_search_by(|w| {
-                if *w <= chosen_weight {
-                    Ordering::Less
-                } else {
-                    Ordering::Greater
-                }
-            })
-            .unwrap_err()
+        self.cumulative_weights.partition_point(|w| w <= chosen_weight)
     }
 }
 


### PR DESCRIPTION
The minimum Rust version now allows `partition_point` which is exactly what we were doing in `WeightedIndex`