### PR TITLE
Simpler and faster implementation of Floyd's F2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [Unreleased API changing release]
+
+### Other
+- Simpler and faster implementation of Floyd's F2 (#1277). This
+  changes some outputs from `rand::seq::index::sample` and
+  `rand::seq::SliceRandom::choose_multiple`.
+
 ## [0.8.5] - 2021-08-20
 ### Fixes
 - Fix build on non-32/64-bit architectures (#1144)

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -725,7 +725,7 @@ mod test {
                 .choose_multiple(&mut r, 8)
                 .cloned()
                 .collect::<Vec<char>>(),
-            &['d', 'm', 'b', 'n', 'c', 'k', 'h', 'e']
+            &['d', 'm', 'n', 'k', 'h', 'e', 'b', 'c']
         );
 
         #[cfg(feature = "alloc")]


### PR DESCRIPTION
The previous implementation used either `Vec::insert` or a second F-Y shuffling phase to achieve fair random order. Instead, use the random numbers already drawn to achieve a fair shuffle.