### PR TITLE
Relax `Sized` bound on `Distribution<T> for &D`

### DIFF
--- a/src/distributions/distribution.rs
+++ b/src/distributions/distribution.rs
@@ -112,7 +112,7 @@ pub trait Distribution<T> {
     }
 }
 
-impl<'a, T, D: Distribution<T>> Distribution<T> for &'a D {
+impl<'a, T, D: Distribution<T> + ?Sized> Distribution<T> for &'a D {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> T {
         (*self).sample(rng)
     }


### PR DESCRIPTION
I encountered this while trying to type-erase `Distribution`.

This is technically a breaking change, so I don't know if it is allowed.