### PR TITLE
Adding "js" feature to be able to compile for wasm32

### DIFF
--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -31,4 +31,4 @@ serde1 = ["serde"] # enables serde for BlockRng wrapper
 
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }
-getrandom = { version = "0.2", optional = true }
+getrandom = { version = "0.2", optional = true, features = ["js"] }


### PR DESCRIPTION
I've added "js" feature for get_random crate in order to be able to compile for wasm32-unknwon-unknown targets :)