### PR TITLE
Add note about floating point weights in update_weights docs

### DIFF
--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -142,9 +142,10 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
     ///
     /// In case of error, `self` is not modified.
     /// 
+```suggestion
     /// Note: Updating floating-point weights may cause slight inaccuracies in the total weight.
-    ///           This method will not always return `WeightedError::AllWeightsZero` when all weights
-    ///           are zero if using floating-point weights. 
+    ///       This method may not return `WeightedError::AllWeightsZero` when all weights
+    ///       are zero if using floating-point weights. 
     pub fn update_weights(&mut self, new_weights: &[(usize, &X)]) -> Result<(), WeightedError>
     where X: for<'a> ::core::ops::AddAssign<&'a X>
             + for<'a> ::core::ops::SubAssign<&'a X>

--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -141,6 +141,8 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
     /// allocation internally.
     ///
     /// In case of error, `self` is not modified.
+    /// 
+    /// Note: Updating floating-point weights may cause slight inaccuracies in the total weight.
     pub fn update_weights(&mut self, new_weights: &[(usize, &X)]) -> Result<(), WeightedError>
     where X: for<'a> ::core::ops::AddAssign<&'a X>
             + for<'a> ::core::ops::SubAssign<&'a X>

--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -143,6 +143,8 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
     /// In case of error, `self` is not modified.
     /// 
     /// Note: Updating floating-point weights may cause slight inaccuracies in the total weight.
+    ///           This method will not always return `WeightedError::AllWeightsZero` when all weights
+    ///           are zero if using floating-point weights. 
     pub fn update_weights(&mut self, new_weights: &[(usize, &X)]) -> Result<(), WeightedError>
     where X: for<'a> ::core::ops::AddAssign<&'a X>
             + for<'a> ::core::ops::SubAssign<&'a X>

--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -142,7 +142,6 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
     ///
     /// In case of error, `self` is not modified.
     /// 
-```suggestion
     /// Note: Updating floating-point weights may cause slight inaccuracies in the total weight.
     ///       This method may not return `WeightedError::AllWeightsZero` when all weights
     ///       are zero if using floating-point weights. 


### PR DESCRIPTION
## Motivation

To highlight that `update_weights` may not return `WeightedError::AllWeightsZero` when all weights are zero when updating floating-point weights.