### PR TITLE
Poisson returns -1 for small lambda

### DIFF
--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove unused fields from `Gamma`, `NormalInverseGaussian` and `Zipf` distributions (#1184)
   This breaks serialization compatibility with older versions.
 - Upgrade Rand
+- Fix Knuth's method so `Poisson` doesn't return -1.0 for small lambda
 
 ## [0.4.3] - 2021-12-30
 - Fix `no_std` build (#1208)

--- a/rand_distr/src/poisson.rs
+++ b/rand_distr/src/poisson.rs
@@ -163,7 +163,6 @@ mod test {
     fn test_poisson_avg() {
         test_poisson_avg_gen::<f64>(10.0, 0.1);
         test_poisson_avg_gen::<f64>(15.0, 0.1);
-
         
         test_poisson_avg_gen::<f32>(10.0, 0.1);
         test_poisson_avg_gen::<f32>(15.0, 0.1);

--- a/rand_distr/src/poisson.rs
+++ b/rand_distr/src/poisson.rs
@@ -89,8 +89,8 @@ where F: Float + FloatConst, Standard: Distribution<F>
 
         // for low expected values use the Knuth method
         if self.lambda < F::from(12.0).unwrap() {
-            let mut result = F::zero();
-            let mut p = F::one();
+            let mut result = F::one();
+            let mut p = rng.gen::<F>();
             while p > self.exp_lambda {
                 p = p*rng.gen::<F>();
                 result = result + F::one();
@@ -161,10 +161,16 @@ mod test {
 
     #[test]
     fn test_poisson_avg() {
-        test_poisson_avg_gen::<f64>(10.0, 0.5);
-        test_poisson_avg_gen::<f64>(15.0, 0.5);
-        test_poisson_avg_gen::<f32>(10.0, 0.5);
-        test_poisson_avg_gen::<f32>(15.0, 0.5);
+        test_poisson_avg_gen::<f64>(10.0, 0.1);
+        test_poisson_avg_gen::<f64>(15.0, 0.1);
+
+        
+        test_poisson_avg_gen::<f32>(10.0, 0.1);
+        test_poisson_avg_gen::<f32>(15.0, 0.1);
+
+        //Small lambda will use Knuth's method with exp_lambda == 1.0
+        test_poisson_avg_gen::<f32>(0.00000000000000005, 0.1);
+        test_poisson_avg_gen::<f64>(0.00000000000000005, 0.1);
     }
 
     #[test]


### PR DESCRIPTION
Small lambda reveals the current implementation of Knuth's method fails, yielding an output of -1.  It can be fixed with different starting values.