### PR TITLE
Uniform float improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,8 @@ harness = false
 name = "shuffle"
 path = "benches/shuffle.rs"
 harness = false
+
+[[bench]]
+name = "uniform_float"
+path = "benches/uniform_float.rs"
+harness = false

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -1400,6 +1400,9 @@ mod tests {
                             let v = <$ty as SampleUniform>::Sampler
                                 ::sample_single(low, high, &mut rng).unwrap().extract(lane);
                             assert!(low_scalar <= v && v < high_scalar);
+                            let v = <$ty as SampleUniform>::Sampler
+                                ::sample_single_inclusive(low, high, &mut rng).unwrap().extract(lane);
+                            assert!(low_scalar <= v && v <= high_scalar);
                         }
 
                         assert_eq!(
@@ -1412,8 +1415,19 @@ mod tests {
                         assert_eq!(<$ty as SampleUniform>::Sampler
                             ::sample_single(low, high, &mut zero_rng).unwrap()
                             .extract(lane), low_scalar);
+                        assert_eq!(<$ty as SampleUniform>::Sampler
+                            ::sample_single_inclusive(low, high, &mut zero_rng).unwrap()
+                            .extract(lane), low_scalar);
+
                         assert!(max_rng.sample(my_uniform).extract(lane) < high_scalar);
                         assert!(max_rng.sample(my_incl_uniform).extract(lane) <= high_scalar);
+                        // sample_single cannot cope with max_rng:
+                        // assert!(<$ty as SampleUniform>::Sampler
+                        //     ::sample_single(low, high, &mut max_rng).unwrap()
+                        //     .extract(lane) < high_scalar);
+                        assert!(<$ty as SampleUniform>::Sampler
+                            ::sample_single_inclusive(low, high, &mut max_rng).unwrap()
+                            .extract(lane) <= high_scalar);
 
                         // Don't run this test for really tiny differences between high and low
                         // since for those rounding might result in selecting high for a very

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -199,7 +199,8 @@ use serde::{Serialize, Deserialize};
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde1", serde(bound(serialize = "X::Sampler: Serialize")))]
 #[cfg_attr(feature = "serde1", serde(bound(deserialize = "X::Sampler: Deserialize<'de>")))]
-pub struct Uniform<X: SampleUniform>(X::Sampler);
+// HACK: internals are public for benches
+pub struct Uniform<X: SampleUniform>(pub X::Sampler);
 
 impl<X: SampleUniform> Uniform<X> {
     /// Create a new `Uniform` instance, which samples uniformly from the half


### PR DESCRIPTION
- Add a (possibly overcomplicated) benchmark for uniform float sampling
- Add a couple extra tests
- Add an explicit impl of `sample_single_inclusive` (~20% perf increase)
