### PR TITLE
Use const generics in Dirichlet

### DIFF
--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade Rand
 - Fix Knuth's method so `Poisson` doesn't return -1.0 for small lambda
 - Fix `Poisson` distribution instantiation so it return an error if lambda is infinite
+- `Dirichlet` now uses `const` generics, which means that its size is required at compile time (#1292)
+- The `Dirichlet::new_with_size` constructor was removed (#1292)
 
 ## [0.4.3] - 2021-12-30
 - Fix `no_std` build (#1208)

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -27,6 +27,7 @@ serde1 = ["serde", "rand/serde1"]
 rand = { path = "..", version = "0.9.0", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
+serde_with = { version = "1.14.0", optional = true }
 
 [dev-dependencies]
 rand_pcg = { version = "0.4.0", path = "../rand_pcg" }

--- a/rand_distr/src/dirichlet.rs
+++ b/rand_distr/src/dirichlet.rs
@@ -13,6 +13,8 @@ use num_traits::Float;
 use crate::{Distribution, Exp1, Gamma, Open01, StandardNormal};
 use rand::Rng;
 use core::fmt;
+#[cfg(feature = "serde_with")]
+use serde_with::serde_as;
 
 /// The Dirichlet distribution `Dirichlet(alpha)`.
 ///
@@ -31,8 +33,8 @@ use core::fmt;
 /// println!("{:?} is from a Dirichlet([1.0, 2.0, 3.0]) distribution", samples);
 /// ```
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+#[cfg_attr(feature = "serde_with", serde_as)]
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Dirichlet<F, const N: usize>
 where
     F: Float,
@@ -41,6 +43,7 @@ where
     Open01: Distribution<F>,
 {
     /// Concentration parameters (alpha)
+    #[cfg_attr(feature = "serde_with", serde_as(as = "[_; N]"))]
     alpha: [F; N],
 }
 

--- a/rand_distr/tests/value_stability.rs
+++ b/rand_distr/tests/value_stability.rs
@@ -348,10 +348,10 @@ fn weibull_stability() {
 fn dirichlet_stability() {
     let mut rng = get_rng(223);
     assert_eq!(
-        rng.sample(Dirichlet::new(&[1.0, 2.0, 3.0]).unwrap()),
-        vec![0.12941567177708177, 0.4702121891675036, 0.4003721390554146]
+        rng.sample(Dirichlet::new([1.0, 2.0, 3.0]).unwrap()),
+        [0.12941567177708177, 0.4702121891675036, 0.4003721390554146]
     );
-    assert_eq!(rng.sample(Dirichlet::new_with_size(8.0, 5).unwrap()), vec![
+    assert_eq!(rng.sample(Dirichlet::new([8.0; 5]).unwrap()), [
         0.17684200044809556,
         0.29915953935953055,
         0.1832858056608014,


### PR DESCRIPTION
This is a draft PR for issue #1006.

It is a working `Dirichlet` distribution that takes and returns const arrays, working with rand's current MSRV (1.56) [edit: but apparently not with Serde: serde-rs/serde/issues/1937].

It might still be useful to keep the original dynamic `Dirichlet`, so should I leave alone the original `Dirichlet` distribution and create a new one such as `DirichletConst`?