### PR TITLE
impl TrustedLen is unsafe

### DIFF
--- a/src/distributions/distribution.rs
+++ b/src/distributions/distribution.rs
@@ -160,7 +160,7 @@ where
 }
 
 #[cfg(feature = "nightly")]
-impl<D, R, T> iter::TrustedLen for DistIter<D, R, T>
+unsafe impl<D, R, T> iter::TrustedLen for DistIter<D, R, T>
 where
     D: Distribution<T>,
     R: Rng,

--- a/src/distributions/distribution.rs
+++ b/src/distributions/distribution.rs
@@ -159,14 +159,6 @@ where
 {
 }
 
-#[cfg(feature = "nightly")]
-unsafe impl<D, R, T> iter::TrustedLen for DistIter<D, R, T>
-where
-    D: Distribution<T>,
-    R: Rng,
-{
-}
-
 /// A distribution of values of type `S` derived from the distribution `D`
 /// by mapping its output of type `T` through the closure `F`.
 ///


### PR DESCRIPTION
Implementing `TrustedLen` is now unsafe.

From what I understand, quite a few people are still unhappy about the design since the `unsafe` marker in this case is a promise that `size_hint()` in a *different* impl is accurate, so this may change again.

Anyway, we need to do something to fix our builds, and the alternative is just to remove this (I haven't a clue if it is enabling any important optimisations).