### PR TITLE
Replace tab character with spaces in poisson.rs.

### DIFF
--- a/rand_distr/src/poisson.rs
+++ b/rand_distr/src/poisson.rs
@@ -69,7 +69,7 @@ where F: Float + FloatConst, Standard: Distribution<F>
     /// Construct a new `Poisson` with the given shape parameter
     /// `lambda`.
     pub fn new(lambda: F) -> Result<Poisson<F>, Error> {
-	if !lambda.is_finite() {
+        if !lambda.is_finite() {
             return Err(Error::NonFinite);
         }
         if !(lambda > F::zero()) {


### PR DESCRIPTION
This is the only tab in the file; it is probably best to use spaces consistently.