### PR TITLE
Add `--generate-link-to-definition` option when building on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [package.metadata.docs.rs]
 # To build locally:
-# RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --all-features --no-deps --open
+# RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --all-features --no-deps --generate-link-to-definition --open
 all-features = true
-rustdoc-args = ["--cfg", "doc_cfg"]
+rustdoc-args = ["--cfg", "doc_cfg", "--generate-link-to-definition"]
 
 [package.metadata.playground]
 features = ["small_rng", "serde1"]

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -15,6 +15,9 @@ categories = ["algorithms", "no-std"]
 edition = "2021"
 rust-version = "1.56"
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]
+
 [dependencies]
 rand_core = { path = "../rand_core", version = "0.7.0" }
 ppv-lite86 = { version = "0.2.14", default-features = false, features = ["simd"] }

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.56"
 # To build locally:
 # RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --all-features --no-deps --open
 all-features = true
-rustdoc-args = ["--cfg", "doc_cfg"]
+rustdoc-args = ["--cfg", "doc_cfg", "--generate-link-to-definition"]
 
 [package.metadata.playground]
 all-features = true

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -16,6 +16,9 @@ edition = "2021"
 rust-version = "1.56"
 include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]
+
 [features]
 default = ["std"]
 std = ["alloc", "rand/std"]

--- a/rand_distr/src/geometric.rs
+++ b/rand_distr/src/geometric.rs
@@ -143,7 +143,8 @@ impl Distribution<u64> for Geometric
 /// 
 /// See [`Geometric`](crate::Geometric) for the general geometric distribution.
 /// 
-/// Implemented via iterated [Rng::gen::<u64>().leading_zeros()].
+/// Implemented via iterated
+/// [`Rng::gen::<u64>().leading_zeros()`](Rng::gen::<u64>().leading_zeros()).
 /// 
 /// # Example
 /// ```

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -15,6 +15,9 @@ categories = ["algorithms", "no-std"]
 edition = "2021"
 rust-version = "1.56"
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]
+
 [features]
 serde1 = ["serde"]
 

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -52,7 +52,7 @@
 //! `low < high`). The example below merely wraps another back-end.
 //!
 //! The `new`, `new_inclusive` and `sample_single` functions use arguments of
-//! type SampleBorrow<X> to support passing in values by reference or
+//! type `SampleBorrow<X>` to support passing in values by reference or
 //! by value. In the implementation of these functions, you can choose to
 //! simply use the reference returned by [`SampleBorrow::borrow`], or you can choose
 //! to copy or clone the value, whatever is appropriate for your type.


### PR DESCRIPTION
This option generates links in source code pages, allowing to jump to definition and to jump back to doc. It makes browsing the source code pages much nicer. You can see it in action [here](https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_middle/lib.rs.html#90).