### PR TITLE
Use cfg(panic = unwind) instead of a check for wasm32 to see if unwinding is supported

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: mips-unknown-linux-gnu
+            target: powerpc-unknown-linux-gnu
             toolchain: stable
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             variant: MSRV
-            toolchain: 1.56.0
+            toolchain: 1.60.0
           - os: ubuntu-latest
             deps: sudo apt-get update ; sudo apt install gcc-multilib
             target: i686-unknown-linux-gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["random", "rng"]
 categories = ["algorithms", "no-std"]
 autobenches = true
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand)
 [![API](https://docs.rs/rand/badge.svg)](https://docs.rs/rand)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.56+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.60+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 A Rust library for random number generation, featuring:
 
@@ -97,7 +97,7 @@ issue tracker with the keyword `yank` *should* uncover the motivation.
 
 ### Rust version requirements
 
-The Minimum Supported Rust Version (MSRV) is `rustc >= 1.56.0`.
+The Minimum Supported Rust Version (MSRV) is `rustc >= 1.60.0`.
 Older releases may work (depending on feature configuration) but are untested.
 
 ## Crate Features

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -13,7 +13,7 @@ ChaCha random number generator
 keywords = ["random", "rng", "chacha"]
 categories = ["algorithms", "no-std"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--generate-link-to-definition"]

--- a/rand_chacha/README.md
+++ b/rand_chacha/README.md
@@ -5,7 +5,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_chacha)
 [![API](https://docs.rs/rand_chacha/badge.svg)](https://docs.rs/rand_chacha)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.56+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.60+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 A cryptographically secure random number generator that uses the ChaCha
 algorithm.

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -13,7 +13,7 @@ Core random number generator traits and tools for implementation.
 keywords = ["random", "rng"]
 categories = ["algorithms", "no-std"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/rand_core/README.md
+++ b/rand_core/README.md
@@ -5,7 +5,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_core)
 [![API](https://docs.rs/rand_core/badge.svg)](https://docs.rs/rand_core)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.56+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.60+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 Core traits and error types of the [rand] library, plus tools for implementing
 RNGs.

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -13,7 +13,7 @@ Sampling from random number distributions
 keywords = ["random", "rng", "distribution", "probability"]
 categories = ["algorithms", "no-std"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [package.metadata.docs.rs]

--- a/rand_distr/README.md
+++ b/rand_distr/README.md
@@ -5,7 +5,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_distr)
 [![API](https://docs.rs/rand_distr/badge.svg)](https://docs.rs/rand_distr)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.56+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.60+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 Implements a full suite of random number distribution sampling routines.
 

--- a/rand_distr/benches/Cargo.toml
+++ b/rand_distr/benches/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 description = "Criterion benchmarks of the rand_distr crate"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 publish = false
 
 [workspace]

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -13,7 +13,7 @@ Selected PCG random number generators
 keywords = ["random", "rng", "pcg"]
 categories = ["algorithms", "no-std"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--generate-link-to-definition"]

--- a/rand_pcg/README.md
+++ b/rand_pcg/README.md
@@ -5,7 +5,7 @@
 [![Book](https://img.shields.io/badge/book-master-yellow.svg)](https://rust-random.github.io/book/)
 [![API](https://img.shields.io/badge/api-master-yellow.svg)](https://rust-random.github.io/rand/rand_pcg)
 [![API](https://docs.rs/rand_pcg/badge.svg)](https://docs.rs/rand_pcg)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.56+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.60+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 
 Implements a selection of PCG random number generators.
 

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -1536,11 +1536,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(
-        feature = "std",
-        not(target_arch = "wasm32"),
-        not(target_arch = "asmjs")
-    ))]
+    #[cfg(all(feature = "std", panic = "unwind"))]
     fn test_float_assertions() {
         use super::SampleUniform;
         use std::panic::catch_unwind;


### PR DESCRIPTION
This allows the test to run on a future wasm target with exception support as well as running the test suite with panic=abort on non-wasm targets.