### PR TITLE
Adding `zeroize` for `BlockRng` and `BlockRng64`

### DIFF
--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -33,3 +33,4 @@ serde1 = ["serde"] # enables serde for BlockRng wrapper
 serde = { version = "1", features = ["derive"], optional = true }
 getrandom = { version = "0.2", optional = true }
 zerocopy = { version = "0.7.20", default-features = false }
+zeroize = { version = "1.7", optional = true }

--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -470,7 +470,7 @@ mod test {
         type Results = [u32; 16];
 
         fn generate(&mut self, results: &mut Self::Results) {
-            for r in results.as_mut() {
+            for r in results {
                 *r = self.counter;
                 self.counter = self.counter.wrapping_add(3511615421);
             }
@@ -520,7 +520,7 @@ mod test {
         type Results = [u64; 8];
 
         fn generate(&mut self, results: &mut Self::Results) {
-            for r in results.as_mut() {
+            for r in results {
                 *r = self.counter;
                 self.counter = self.counter.wrapping_add(2781463553396133981);
             }


### PR DESCRIPTION
Regarding #1348 and #934
This appears to work with my working branch of `chacha20` without any breaking changes for libraries that use a `[Item; N]`. Also, I just discovered that using `-C target-cpu=native` can optimize the code in such a way that the difference between the performance of using pointers and a buffer is about 0.5%... so I think I'm going to close out #1367 