### PR TITLE
Update zerocopy; trim unused methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ rand_core = { path = "rand_core", version = "0.7.0", default-features = false }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 rand_chacha = { path = "rand_chacha", version = "0.4.0", default-features = false, optional = true }
-zerocopy = { version = "0.7.20", default-features = false, features = ["simd"] }
+zerocopy = { version = "=0.8.0-alpha.5", default-features = false, features = ["simd"] }
 
 [target.'cfg(unix)'.dependencies]
 # Used for fork protection (reseeding.rs)

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -32,4 +32,4 @@ serde1 = ["serde"] # enables serde for BlockRng wrapper
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }
 getrandom = { version = "0.2", optional = true }
-zerocopy = { version = "0.7.20", default-features = false }
+zerocopy = { version = "=0.8.0-alpha.5", default-features = false }

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -19,7 +19,7 @@
 
 use crate::RngCore;
 use core::cmp::min;
-use zerocopy::AsBytes;
+use zerocopy::{IntoBytes, NoCell};
 
 /// Implement `next_u64` via `next_u32`, little-endian order.
 pub fn next_u64_via_u32<R: RngCore + ?Sized>(rng: &mut R) -> u64 {
@@ -53,7 +53,7 @@ pub fn fill_bytes_via_next<R: RngCore + ?Sized>(rng: &mut R, dest: &mut [u8]) {
     }
 }
 
-trait Observable: AsBytes + Copy {
+trait Observable: IntoBytes + NoCell + Copy {
     fn to_le(self) -> Self;
 }
 impl Observable for u32 {

--- a/rand_distr/tests/pdf.rs
+++ b/rand_distr/tests/pdf.rs
@@ -9,7 +9,7 @@
 #![allow(clippy::float_cmp)]
 
 use average::Histogram;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
 use rand_distr::{Normal, SkewNormal};
 
 const HIST_LEN: usize = 100;

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -1250,6 +1250,7 @@ impl UniformSampler for UniformDuration {
 mod tests {
     use super::*;
     use crate::rngs::mock::StepRng;
+    use crate::distributions::utils::FloatSIMDScalarUtils;
 
     #[test]
     #[cfg(feature = "serde1")]

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -115,10 +115,6 @@ use crate::distributions::Distribution;
 use crate::distributions::Standard;
 use crate::{Rng, RngCore};
 
-#[cfg(not(feature = "std"))]
-#[allow(unused_imports)] // rustc doesn't detect that this is actually used
-use crate::distributions::utils::Float;
-
 #[cfg(feature = "simd_support")] use core::simd::prelude::*;
 #[cfg(feature = "simd_support")] use core::simd::{LaneCount, SupportedLaneCount};
 

--- a/src/distributions/utils.rs
+++ b/src/distributions/utils.rs
@@ -238,16 +238,6 @@ pub(crate) trait FloatSIMDScalarUtils: FloatSIMDUtils {
     fn extract(self, index: usize) -> Self::Scalar;
 }
 
-/// Implement functions available in std builds but missing from core primitives
-#[cfg(not(std))]
-// False positive: We are following `std` here.
-#[allow(clippy::wrong_self_convention)]
-pub(crate) trait Float: Sized {
-    fn is_nan(self) -> bool;
-    fn is_infinite(self) -> bool;
-    fn is_finite(self) -> bool;
-}
-
 /// Implement functions on f32/f64 to give them APIs similar to SIMD types
 pub(crate) trait FloatAsSIMD: Sized {
     const LEN: usize = 1;
@@ -269,8 +259,6 @@ impl IntAsSIMD for u64 {}
 
 pub(crate) trait BoolAsSIMD: Sized {
     fn any(self) -> bool;
-    fn all(self) -> bool;
-    fn none(self) -> bool;
 }
 
 impl BoolAsSIMD for bool {
@@ -278,38 +266,10 @@ impl BoolAsSIMD for bool {
     fn any(self) -> bool {
         self
     }
-
-    #[inline(always)]
-    fn all(self) -> bool {
-        self
-    }
-
-    #[inline(always)]
-    fn none(self) -> bool {
-        !self
-    }
 }
 
 macro_rules! scalar_float_impl {
     ($ty:ident, $uty:ident) => {
-        #[cfg(not(std))]
-        impl Float for $ty {
-            #[inline]
-            fn is_nan(self) -> bool {
-                self != self
-            }
-
-            #[inline]
-            fn is_infinite(self) -> bool {
-                self == ::core::$ty::INFINITY || self == ::core::$ty::NEG_INFINITY
-            }
-
-            #[inline]
-            fn is_finite(self) -> bool {
-                !(self.is_nan() || self.is_infinite())
-            }
-        }
-
         impl FloatSIMDUtils for $ty {
             type Mask = bool;
             type UInt = $uty;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 #![deny(missing_debug_implementations)]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 #![no_std]
-#![cfg_attr(feature = "simd_support", feature(stdsimd, portable_simd))]
+#![cfg_attr(feature = "simd_support", feature(portable_simd))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![allow(
     clippy::float_cmp,


### PR DESCRIPTION
- Remove mention of `stdsimd` (obsolete)
- cfg-gate or remove methods no longer needed (outside of tests)
- Update to `zerocopy` version `=0.8.0-alpha.5`. Usually we don't bother using pre-release versions, but this is causing a lot of test failures.