### PR TITLE
Add path for benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ criterion = { version = "0.4" }
 
 [[bench]]
 name = "uniform"
+path = "benches/uniform.rs"
 harness = false
 
 [[bench]]


### PR DESCRIPTION
I don't *think* this should be necessary, yet apparently it is: https://github.com/rust-lang/cargo/issues/13456