### PR TITLE
Add .choices() method to the Slice distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [0.9.1] - unreleased
+- Add the `Slice::choices` method to the Slice distribution (#1402)
+
 ## [0.9.0-alpha.0] - 2024-02-18
 This is a pre-release. To depend on this version, use `rand = "=0.9.0-alpha.0"` to prevent automatic updates (which can be expected to include breaking changes).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
 ## [0.9.1] - unreleased
-- Add the `Slice::choices` method to the Slice distribution (#1402)
+- Add the `Slice::num_choices` method to the Slice distribution (#1402)
 
 ## [0.9.0-alpha.0] - 2024-02-18
 This is a pre-release. To depend on this version, use `rand = "=0.9.0-alpha.0"` to prevent automatic updates (which can be expected to include breaking changes).

--- a/src/distributions/slice.rs
+++ b/src/distributions/slice.rs
@@ -6,6 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::num::NonZeroUsize;
+
 use crate::distributions::{Distribution, Uniform};
 #[cfg(feature = "alloc")]
 use alloc::string::String;
@@ -80,6 +82,13 @@ impl<'a, T> Slice<'a, T> {
                 range: Uniform::new(0, len).unwrap(),
             }),
         }
+    }
+
+    /// Returns the count of choices in this distribution
+    pub fn choices(&self) -> NonZeroUsize {
+        // Safety: at construction time, it was ensured that the slice was
+        // non-empty, as such the length can never be 0.
+        unsafe { NonZeroUsize::new_unchecked(self.slice.len()) }
     }
 }
 

--- a/src/distributions/slice.rs
+++ b/src/distributions/slice.rs
@@ -85,7 +85,7 @@ impl<'a, T> Slice<'a, T> {
     }
 
     /// Returns the count of choices in this distribution
-    pub fn choices(&self) -> NonZeroUsize {
+    pub fn num_choices(&self) -> NonZeroUsize {
         // Safety: at construction time, it was ensured that the slice was
         // non-empty, as such the length can never be 0.
         unsafe { NonZeroUsize::new_unchecked(self.slice.len()) }

--- a/src/distributions/slice.rs
+++ b/src/distributions/slice.rs
@@ -69,26 +69,28 @@ use alloc::string::String;
 pub struct Slice<'a, T> {
     slice: &'a [T],
     range: Uniform<usize>,
+    choices: NonZeroUsize,
 }
 
 impl<'a, T> Slice<'a, T> {
     /// Create a new `Slice` instance which samples uniformly from the slice.
     /// Returns `Err` if the slice is empty.
     pub fn new(slice: &'a [T]) -> Result<Self, EmptySlice> {
-        match slice.len() {
-            0 => Err(EmptySlice),
-            len => Ok(Self {
-                slice,
-                range: Uniform::new(0, len).unwrap(),
-            }),
-        }
+        let len = match NonZeroUsize::new(slice.len()) {
+            None => return Err(EmptySlice),
+            Some(len) => len,
+        };
+
+        Ok(Self {
+            slice,
+            range: Uniform::new(0, len.get()).unwrap(),
+            choices: len,
+        })
     }
 
     /// Returns the count of choices in this distribution
     pub fn num_choices(&self) -> NonZeroUsize {
-        // Safety: at construction time, it was ensured that the slice was
-        // non-empty, as such the length can never be 0.
-        unsafe { NonZeroUsize::new_unchecked(self.slice.len()) }
+        self.choices
     }
 }
 

--- a/src/distributions/slice.rs
+++ b/src/distributions/slice.rs
@@ -69,25 +69,25 @@ use alloc::string::String;
 pub struct Slice<'a, T> {
     slice: &'a [T],
     range: Uniform<usize>,
-    choices: NonZeroUsize,
+    num_choices: NonZeroUsize,
 }
 
 impl<'a, T> Slice<'a, T> {
     /// Create a new `Slice` instance which samples uniformly from the slice.
     /// Returns `Err` if the slice is empty.
     pub fn new(slice: &'a [T]) -> Result<Self, EmptySlice> {
-        let len = NonZeroUsize::new(slice.len()).ok_or(EmptySlice)?;
+        let num_choices = NonZeroUsize::new(slice.len()).ok_or(EmptySlice)?;
 
         Ok(Self {
             slice,
-            range: Uniform::new(0, len.get()).unwrap(),
-            choices: len,
+            range: Uniform::new(0, num_choices.get()).unwrap(),
+            num_choices,
         })
     }
 
     /// Returns the count of choices in this distribution
     pub fn num_choices(&self) -> NonZeroUsize {
-        self.choices
+        self.num_choices
     }
 }
 

--- a/src/distributions/slice.rs
+++ b/src/distributions/slice.rs
@@ -76,10 +76,7 @@ impl<'a, T> Slice<'a, T> {
     /// Create a new `Slice` instance which samples uniformly from the slice.
     /// Returns `Err` if the slice is empty.
     pub fn new(slice: &'a [T]) -> Result<Self, EmptySlice> {
-        let len = match NonZeroUsize::new(slice.len()) {
-            None => return Err(EmptySlice),
-            Some(len) => len,
-        };
+        let len = NonZeroUsize::new(slice.len()).ok_or(EmptySlice)?;
 
         Ok(Self {
             slice,


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Add a `.choices() -> NonZeroUsize` method to the slices distribution

# Motivation

In one of my projects we use a Slice Distribution for the input of a constructor for a type which needs to generate some element of that slice & at the same time a boolean for another variable with the same probability of each element in the Distribution occurring. A simple `1 / distr.choices()` would help us a lot in that regards.

# Details

Adds the `Slices::choices() - NonZeroUsize` method, which returns the count of different choices in the input vector (counting duplicates in that vector as well)
