### PR TITLE
Add WeightedIndex::update_weights_relative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [0.9.1] - unreleased
+- Add `rand::distributions::WeightedIndex::update_weights_relative` (#1403)
+
 ## [0.9.0-alpha.0] - 2024-02-18
 This is a pre-release. To depend on this version, use `rand = "=0.9.0-alpha.0"` to prevent automatic updates (which can be expected to include breaking changes).
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary
This PR adds a new method `update_weights_relative` to the `WeightedIndex` distribution, whose purpose is to update a subset of weights relative to the current values, following a provided mapping function.

# Motivation
Sometimes it is desirable to update a weight in a distribution relative to its current value, for instance subtracting one from the weight of a sampled index in order to achieve drawing without replacement. However, the `update_weights` method requires you to provide the new weights directly, and there is no external way to check the current weight at an index. This means that you have to track the current weights manually:

```rust
let ordinal = thread_rng().sample(&weighted_index);
remaining[ordinal] -= 1; // Lower the weight of the drawn ordinal by one
let new_weight = remaining[ordinal];
if weighted_index.update_weights(&[(ordinal, &new_weight)]).is_err() {
    // all weights are zero
}
```

In this code snippet, `remaining` has the type `[X; len]`, where `X` is the element type of the `WeightedIndex` and `len` is the number of weights in the index.
Keeping this array around externally is tedious, and wastes space, since all the information we need is technically already stored within the index.
It would be nice to instead be able to do something like this, to lower the weight at `ordinal` by 1:

```rust
let ordinal = thread_rng().sample(&weighted_index);
if weighted_index.update_weights_relative(&[(ordinal, &-1)]).is_err() {
    // all weights are zero
}
```

But this only works with signed types - unsigned types would only ever be able to be increased. Furthermore, it seems like an opportunity here to allow not just for addition and subtraction, but for arbitrary mappings via a closure:

```rust
let ordinal = thread_rng().sample(&weighted_index);
if weighted_index.update_weights_relative(&[(ordinal, &1)], |current, relative| current - relative).is_err() {
    // all weights are zero
}
```

Here, we provide a closure describing _in what way_ the provided values should be combined with the current weights: the relative value should be subtracted from the existing weight to yield the new weight.

This yields another potential issue: what if the arithmetic in this closure fails (overflow, underflow, etc)? We could have the closure return an `Option<X>` to account for failures. Then we can do something like this:

```rust
let ordinal = thread_rng().sample(&weighted_index);
if weighted_index.update_weights_relative(&[(ordinal, &1)], |current, relative| current.checked_sub(relative)).is_err() {
    // all weights are zero
}
```

...and the whole method will return a `WeightError` if any of these subtractions underflows.

# Details

The signature of the new `update_weights_relative` method is as follows:
```rust
pub fn update_weights_relative<R>(&mut self, relative_weights: &[(usize, &R)], op: impl Fn(X, &R) -> Option<X>) -> Result<(), WeightError>
    where
        X: for<'a> ::core::ops::AddAssign<&'a X>
            + for<'a> ::core::ops::SubAssign<&'a X>
            + Clone
            + Default
{ ...
```
The generic type parameter `R` allows the provided values to not necessarily be the same type as the values in the `WeightedIndex`, as long as the provided `op` can combine the two into an `X`.

In the error checking phase, `update_weights_relative` follows the same logic as `update_weights`, with a couple differences:
- the provided weights are not required to be `>= zero` like in `update_weights` (they do not even necessarily share `zero`'s type), however `op(old_weight, relative)`, the calculated new weight, must be `>= zero`. If the calculated weight is `None` or `< zero`, `WeightError::InvalidWeight` is returned.
- the new absolute weights are calculated in the initial check for errors. In order to avoid doing this a second time, a `Vec` is allocated to store these new weights until they can be applied. I would like to avoid this allocation but I don't see a way to do so -> suggestions welcome.

After performing the necessary checks (and calculating the new absolute weights), the actual application of the new weights is identical to the `update_weights` method. Therefore, this section of the `update_weights` method has been factored out, and is now called by both methods.

Positive and negative test cases have been added for the new method (and for the existing `update_weights` method).

This is my first contribution to this crate, I appreciate your feedback!