### PR TITLE
Fix redundant import warnings

### DIFF
--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -55,7 +55,6 @@
 
 use crate::impls::{fill_via_u32_chunks, fill_via_u64_chunks};
 use crate::{Error, CryptoRng, RngCore, SeedableRng};
-use core::convert::AsRef;
 use core::fmt;
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};

--- a/rand_core/src/le.rs
+++ b/rand_core/src/le.rs
@@ -11,8 +11,6 @@
 //! Little-Endian order has been chosen for internal usage; this makes some
 //! useful functions available.
 
-use core::convert::TryInto;
-
 /// Reads unsigned 32 bit integers from `src` into `dst`.
 #[inline]
 pub fn read_u32_into(src: &[u8], dst: &mut [u32]) {

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -38,9 +38,6 @@
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![no_std]
 
-use core::convert::AsMut;
-use core::default::Default;
-
 #[cfg(feature = "alloc")] extern crate alloc;
 #[cfg(feature = "std")] extern crate std;
 #[cfg(feature = "alloc")] use alloc::boxed::Box;

--- a/src/distributions/float.rs
+++ b/src/distributions/float.rs
@@ -172,7 +172,6 @@ float_impls! { f64x8, u64x8, f64, u64, 52, 1023 }
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::distributions::utils::FloatAsSIMD;
     use crate::rngs::mock::StepRng;
 
     const EPSILON32: f32 = ::core::f32::EPSILON;

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -281,7 +281,6 @@ where Standard: Distribution<T>
 mod tests {
     use super::*;
     use crate::RngCore;
-    #[cfg(feature = "alloc")] use alloc::string::String;
 
     #[test]
     fn test_misc() {

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -106,7 +106,6 @@
 use core::fmt;
 use core::time::Duration;
 use core::ops::{Range, RangeInclusive};
-use core::convert::TryFrom;
 
 use crate::distributions::float::IntoFloat;
 use crate::distributions::utils::{BoolAsSIMD, FloatAsSIMD, FloatSIMDUtils, IntAsSIMD, WideningMultiply};

--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -11,7 +11,6 @@
 use crate::distributions::uniform::{SampleBorrow, SampleUniform, UniformSampler};
 use crate::distributions::Distribution;
 use crate::Rng;
-use core::cmp::PartialOrd;
 use core::fmt;
 
 // Note that this whole module is only imported if feature="alloc" is enabled.

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -712,8 +712,6 @@ fn gen_index<R: Rng + ?Sized>(rng: &mut R, ubound: usize) -> usize {
 #[cfg(test)]
 mod test {
     use super::*;
-    #[cfg(feature = "alloc")]
-    use crate::Rng;
     #[cfg(all(feature = "alloc", not(feature = "std")))]
     use alloc::vec::Vec;
 


### PR DESCRIPTION
- [ ] Added a `CHANGELOG.md` entry

# Summary
There are some warnings being thrown in the `test (ubuntu-latest, x86_64-unknown-linux-gnu, nightly, minimal_versions)` and `test-miri` GitHub actions due to redundant imports. I thought I would go ahead and remove them.

