### PR TITLE
Fix failing tests

### DIFF
--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -170,7 +170,8 @@ use crate::Rng;
 /// The [`Standard`] distribution may be implemented for user types as follows:
 ///
 /// ```
-/// # #![allow(dead_code, non_local_definitions)]
+/// # #![allow(dead_code)]
+/// # #![allow(clippy::non_local_definitions)]
 /// use rand::Rng;
 /// use rand::distributions::{Distribution, Standard};
 ///

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -170,7 +170,7 @@ use crate::Rng;
 /// The [`Standard`] distribution may be implemented for user types as follows:
 ///
 /// ```
-/// # #![allow(dead_code)]
+/// # #![allow(dead_code, non_local_definitions)]
 /// use rand::Rng;
 /// use rand::distributions::{Distribution, Standard};
 ///


### PR DESCRIPTION
- [ ] Added a `CHANGELOG.md` entry

# Summary
Two tests are failing on the master branch due to the `non-local-definitions` lint snagging a documentation example. This should fix the tests.
