### PR TITLE
Prepare 0.9.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
-## [0.9.1] - unreleased
+## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)
 
 ### Generators

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.9.0-alpha.0"
+version = "0.9.0-alpha.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -65,14 +65,14 @@ members = [
 ]
 
 [dependencies]
-rand_core = { path = "rand_core", version = "=0.9.0-alpha.0", default-features = false }
+rand_core = { path = "rand_core", version = "=0.9.0-alpha.1", default-features = false }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
-rand_chacha = { path = "rand_chacha", version = "=0.9.0-alpha.0", default-features = false, optional = true }
+rand_chacha = { path = "rand_chacha", version = "=0.9.0-alpha.1", default-features = false, optional = true }
 zerocopy = { version = "=0.8.0-alpha.6", default-features = false, features = ["simd"] }
 
 [dev-dependencies]
-rand_pcg = { path = "rand_pcg", version = "=0.9.0-alpha.0" }
+rand_pcg = { path = "rand_pcg", version = "=0.9.0-alpha.1" }
 # Only to test serde1
 bincode = "1.2.1"
 rayon = "1.5.3"

--- a/rand_chacha/CHANGELOG.md
+++ b/rand_chacha/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0-alpha.1] - 2024-03-18
+
 ## [0.9.0-alpha.0] - 2024-02-18
 This is a pre-release. To depend on this version, use `rand_chacha = "=0.9.0-alpha.0"` to prevent automatic updates (which can be expected to include breaking changes).
 

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_chacha"
-version = "0.9.0-alpha.0"
+version = "0.9.0-alpha.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers", "The CryptoCorrosion Contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -19,7 +19,7 @@ rust-version = "1.60"
 rustdoc-args = ["--generate-link-to-definition"]
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "=0.9.0-alpha.0" }
+rand_core = { path = "../rand_core", version = "=0.9.0-alpha.1" }
 ppv-lite86 = { version = "0.2.14", default-features = false, features = ["simd"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0-alpha.1] - 2024-03-18
+
 ## [0.9.0-alpha.0] - 2024-02-18
 This is a pre-release. To depend on this version, use `rand_core = "=0.9.0-alpha.0"` to prevent automatic updates (which can be expected to include breaking changes).
 

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.9.0-alpha.0"
+version = "0.9.0-alpha.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0-alpha.1] - 2024-03-18
+- Target `rand` version `0.9.0-alpha.1`
+
 ## [0.5.0-alpha.0] - 2024-02-18
 This is a pre-release. To depend on this version, use `rand_distr = "=0.5.0-alpha.0"` to prevent automatic updates (which can be expected to include breaking changes).
 

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_distr"
-version = "0.5.0-alpha.0"
+version = "0.5.0-alpha.1"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -27,15 +27,15 @@ std_math = ["num-traits/std"]
 serde1 = ["serde", "rand/serde1"]
 
 [dependencies]
-rand = { path = "..", version = "=0.9.0-alpha.0", default-features = false }
+rand = { path = "..", version = "=0.9.0-alpha.1", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 serde_with = { version = "3.6.1", optional = true }
 
 [dev-dependencies]
-rand_pcg = { version = "=0.9.0-alpha.0", path = "../rand_pcg" }
+rand_pcg = { version = "=0.9.0-alpha.1", path = "../rand_pcg" }
 # For inline examples
-rand = { path = "..", version = "=0.9.0-alpha.0", features = ["small_rng"] }
+rand = { path = "..", version = "=0.9.0-alpha.1", features = ["small_rng"] }
 # Histogram implementation for testing uniformity
 average = { version = "0.14", features = [ "std" ] }
 # Special functions for testing distributions

--- a/rand_pcg/CHANGELOG.md
+++ b/rand_pcg/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0-alpha.1] - 2024-03-18
+
 ## [0.9.0-alpha.0] - 2024-02-18
 This is a pre-release. To depend on this version, use `rand_pcg = "=0.9.0-alpha.0"` to prevent automatic updates (which can be expected to include breaking changes).
 

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_pcg"
-version = "0.9.0-alpha.0"
+version = "0.9.0-alpha.1"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -22,7 +22,7 @@ rustdoc-args = ["--generate-link-to-definition"]
 serde1 = ["serde"]
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "=0.9.0-alpha.0" }
+rand_core = { path = "../rand_core", version = "=0.9.0-alpha.1" }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Prepare the next alpha.

@newpavlov I'll leave your latest PR out since it only just landed. I'd also *like* to complete the migration to the `chacha20` trait and reformat as suggested before 0.9. Could you approve this PR?