### PR TITLE
Optimize imports

### DIFF
--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -101,7 +101,7 @@ macro_rules! distr_duration {
                     let x: Duration = distr.sample(&mut rng);
                     accum = accum
                         .checked_add(x)
-                        .unwrap_or(Duration::new(u64::max_value(), 999_999_999));
+                        .unwrap_or(Duration::new(u64::MAX, 999_999_999));
                 }
                 accum
             });
@@ -145,10 +145,10 @@ distr_int!(distr_uniform_isize, isize, Uniform::new(-1060478432isize, 1858574057
 distr_float!(distr_uniform_f32, f32, Uniform::new(2.26f32, 2.319).unwrap());
 distr_float!(distr_uniform_f64, f64, Uniform::new(2.26f64, 2.319).unwrap());
 
-const LARGE_SEC: u64 = u64::max_value() / 1000;
+const LARGE_SEC: u64 = u64::MAX / 1000;
 
 distr_duration!(distr_uniform_duration_largest,
-    Uniform::new_inclusive(Duration::new(0, 0), Duration::new(u64::max_value(), 999_999_999)).unwrap()
+    Uniform::new_inclusive(Duration::new(0, 0), Duration::new(u64::MAX, 999_999_999)).unwrap()
 );
 distr_duration!(distr_uniform_duration_large,
     Uniform::new(Duration::new(0, 0), Duration::new(LARGE_SEC, 1_000_000_000 / 2)).unwrap()
@@ -332,26 +332,26 @@ macro_rules! uniform_single {
 // (32769) will only reject 32769 / 4294967296 samples.
 const HALF_16_BIT_UNSIGNED: u16 = 1 << 15;
 
-uniform_sample!(uniform_u16x1_allm1_new, u16, 0, u16::max_value(), 1);
+uniform_sample!(uniform_u16x1_allm1_new, u16, 0, u16::MAX, 1);
 uniform_sample!(uniform_u16x1_halfp1_new, u16, 0, HALF_16_BIT_UNSIGNED + 1, 1);
 uniform_sample!(uniform_u16x1_half_new, u16, 0, HALF_16_BIT_UNSIGNED, 1);
 uniform_sample!(uniform_u16x1_halfm1_new, u16, 0, HALF_16_BIT_UNSIGNED - 1, 1);
 uniform_sample!(uniform_u16x1_6_new, u16, 0, 6u16, 1);
 
-uniform_single!(uniform_u16x1_allm1_single, u16, 0, u16::max_value(), 1);
+uniform_single!(uniform_u16x1_allm1_single, u16, 0, u16::MAX, 1);
 uniform_single!(uniform_u16x1_halfp1_single, u16, 0, HALF_16_BIT_UNSIGNED + 1, 1);
 uniform_single!(uniform_u16x1_half_single, u16, 0, HALF_16_BIT_UNSIGNED, 1);
 uniform_single!(uniform_u16x1_halfm1_single, u16, 0, HALF_16_BIT_UNSIGNED - 1, 1);
 uniform_single!(uniform_u16x1_6_single, u16, 0, 6u16, 1);
 
-uniform_inclusive!(uniform_u16x10_all_new_inclusive, u16, 0, u16::max_value(), 10);
-uniform_sample!(uniform_u16x10_allm1_new, u16, 0, u16::max_value(), 10);
+uniform_inclusive!(uniform_u16x10_all_new_inclusive, u16, 0, u16::MAX, 10);
+uniform_sample!(uniform_u16x10_allm1_new, u16, 0, u16::MAX, 10);
 uniform_sample!(uniform_u16x10_halfp1_new, u16, 0, HALF_16_BIT_UNSIGNED + 1, 10);
 uniform_sample!(uniform_u16x10_half_new, u16, 0, HALF_16_BIT_UNSIGNED, 10);
 uniform_sample!(uniform_u16x10_halfm1_new, u16, 0, HALF_16_BIT_UNSIGNED - 1, 10);
 uniform_sample!(uniform_u16x10_6_new, u16, 0, 6u16, 10);
 
-uniform_single!(uniform_u16x10_allm1_single, u16, 0, u16::max_value(), 10);
+uniform_single!(uniform_u16x10_allm1_single, u16, 0, u16::MAX, 10);
 uniform_single!(uniform_u16x10_halfp1_single, u16, 0, HALF_16_BIT_UNSIGNED + 1, 10);
 uniform_single!(uniform_u16x10_half_single, u16, 0, HALF_16_BIT_UNSIGNED, 10);
 uniform_single!(uniform_u16x10_halfm1_single, u16, 0, HALF_16_BIT_UNSIGNED - 1, 10);
@@ -360,26 +360,26 @@ uniform_single!(uniform_u16x10_6_single, u16, 0, 6u16, 10);
 
 const HALF_32_BIT_UNSIGNED: u32 = 1 << 31;
 
-uniform_sample!(uniform_u32x1_allm1_new, u32, 0, u32::max_value(), 1);
+uniform_sample!(uniform_u32x1_allm1_new, u32, 0, u32::MAX, 1);
 uniform_sample!(uniform_u32x1_halfp1_new, u32, 0, HALF_32_BIT_UNSIGNED + 1, 1);
 uniform_sample!(uniform_u32x1_half_new, u32, 0, HALF_32_BIT_UNSIGNED, 1);
 uniform_sample!(uniform_u32x1_halfm1_new, u32, 0, HALF_32_BIT_UNSIGNED - 1, 1);
 uniform_sample!(uniform_u32x1_6_new, u32, 0, 6u32, 1);
 
-uniform_single!(uniform_u32x1_allm1_single, u32, 0, u32::max_value(), 1);
+uniform_single!(uniform_u32x1_allm1_single, u32, 0, u32::MAX, 1);
 uniform_single!(uniform_u32x1_halfp1_single, u32, 0, HALF_32_BIT_UNSIGNED + 1, 1);
 uniform_single!(uniform_u32x1_half_single, u32, 0, HALF_32_BIT_UNSIGNED, 1);
 uniform_single!(uniform_u32x1_halfm1_single, u32, 0, HALF_32_BIT_UNSIGNED - 1, 1);
 uniform_single!(uniform_u32x1_6_single, u32, 0, 6u32, 1);
 
-uniform_inclusive!(uniform_u32x10_all_new_inclusive, u32, 0, u32::max_value(), 10);
-uniform_sample!(uniform_u32x10_allm1_new, u32, 0, u32::max_value(), 10);
+uniform_inclusive!(uniform_u32x10_all_new_inclusive, u32, 0, u32::MAX, 10);
+uniform_sample!(uniform_u32x10_allm1_new, u32, 0, u32::MAX, 10);
 uniform_sample!(uniform_u32x10_halfp1_new, u32, 0, HALF_32_BIT_UNSIGNED + 1, 10);
 uniform_sample!(uniform_u32x10_half_new, u32, 0, HALF_32_BIT_UNSIGNED, 10);
 uniform_sample!(uniform_u32x10_halfm1_new, u32, 0, HALF_32_BIT_UNSIGNED - 1, 10);
 uniform_sample!(uniform_u32x10_6_new, u32, 0, 6u32, 10);
 
-uniform_single!(uniform_u32x10_allm1_single, u32, 0, u32::max_value(), 10);
+uniform_single!(uniform_u32x10_allm1_single, u32, 0, u32::MAX, 10);
 uniform_single!(uniform_u32x10_halfp1_single, u32, 0, HALF_32_BIT_UNSIGNED + 1, 10);
 uniform_single!(uniform_u32x10_half_single, u32, 0, HALF_32_BIT_UNSIGNED, 10);
 uniform_single!(uniform_u32x10_halfm1_single, u32, 0, HALF_32_BIT_UNSIGNED - 1, 10);
@@ -387,26 +387,26 @@ uniform_single!(uniform_u32x10_6_single, u32, 0, 6u32, 10);
 
 const HALF_64_BIT_UNSIGNED: u64 = 1 << 63;
 
-uniform_sample!(uniform_u64x1_allm1_new, u64, 0, u64::max_value(), 1);
+uniform_sample!(uniform_u64x1_allm1_new, u64, 0, u64::MAX, 1);
 uniform_sample!(uniform_u64x1_halfp1_new, u64, 0, HALF_64_BIT_UNSIGNED + 1, 1);
 uniform_sample!(uniform_u64x1_half_new, u64, 0, HALF_64_BIT_UNSIGNED, 1);
 uniform_sample!(uniform_u64x1_halfm1_new, u64, 0, HALF_64_BIT_UNSIGNED - 1, 1);
 uniform_sample!(uniform_u64x1_6_new, u64, 0, 6u64, 1);
 
-uniform_single!(uniform_u64x1_allm1_single, u64, 0, u64::max_value(), 1);
+uniform_single!(uniform_u64x1_allm1_single, u64, 0, u64::MAX, 1);
 uniform_single!(uniform_u64x1_halfp1_single, u64, 0, HALF_64_BIT_UNSIGNED + 1, 1);
 uniform_single!(uniform_u64x1_half_single, u64, 0, HALF_64_BIT_UNSIGNED, 1);
 uniform_single!(uniform_u64x1_halfm1_single, u64, 0, HALF_64_BIT_UNSIGNED - 1, 1);
 uniform_single!(uniform_u64x1_6_single, u64, 0, 6u64, 1);
 
-uniform_inclusive!(uniform_u64x10_all_new_inclusive, u64, 0, u64::max_value(), 10);
-uniform_sample!(uniform_u64x10_allm1_new, u64, 0, u64::max_value(), 10);
+uniform_inclusive!(uniform_u64x10_all_new_inclusive, u64, 0, u64::MAX, 10);
+uniform_sample!(uniform_u64x10_allm1_new, u64, 0, u64::MAX, 10);
 uniform_sample!(uniform_u64x10_halfp1_new, u64, 0, HALF_64_BIT_UNSIGNED + 1, 10);
 uniform_sample!(uniform_u64x10_half_new, u64, 0, HALF_64_BIT_UNSIGNED, 10);
 uniform_sample!(uniform_u64x10_halfm1_new, u64, 0, HALF_64_BIT_UNSIGNED - 1, 10);
 uniform_sample!(uniform_u64x10_6_new, u64, 0, 6u64, 10);
 
-uniform_single!(uniform_u64x10_allm1_single, u64, 0, u64::max_value(), 10);
+uniform_single!(uniform_u64x10_allm1_single, u64, 0, u64::MAX, 10);
 uniform_single!(uniform_u64x10_halfp1_single, u64, 0, HALF_64_BIT_UNSIGNED + 1, 10);
 uniform_single!(uniform_u64x10_half_single, u64, 0, HALF_64_BIT_UNSIGNED, 10);
 uniform_single!(uniform_u64x10_halfm1_single, u64, 0, HALF_64_BIT_UNSIGNED - 1, 10);
@@ -414,26 +414,26 @@ uniform_single!(uniform_u64x10_6_single, u64, 0, 6u64, 10);
 
 const HALF_128_BIT_UNSIGNED: u128 = 1 << 127;
 
-uniform_sample!(uniform_u128x1_allm1_new, u128, 0, u128::max_value(), 1);
+uniform_sample!(uniform_u128x1_allm1_new, u128, 0, u128::MAX, 1);
 uniform_sample!(uniform_u128x1_halfp1_new, u128, 0, HALF_128_BIT_UNSIGNED + 1, 1);
 uniform_sample!(uniform_u128x1_half_new, u128, 0, HALF_128_BIT_UNSIGNED, 1);
 uniform_sample!(uniform_u128x1_halfm1_new, u128, 0, HALF_128_BIT_UNSIGNED - 1, 1);
 uniform_sample!(uniform_u128x1_6_new, u128, 0, 6u128, 1);
 
-uniform_single!(uniform_u128x1_allm1_single, u128, 0, u128::max_value(), 1);
+uniform_single!(uniform_u128x1_allm1_single, u128, 0, u128::MAX, 1);
 uniform_single!(uniform_u128x1_halfp1_single, u128, 0, HALF_128_BIT_UNSIGNED + 1, 1);
 uniform_single!(uniform_u128x1_half_single, u128, 0, HALF_128_BIT_UNSIGNED, 1);
 uniform_single!(uniform_u128x1_halfm1_single, u128, 0, HALF_128_BIT_UNSIGNED - 1, 1);
 uniform_single!(uniform_u128x1_6_single, u128, 0, 6u128, 1);
 
-uniform_inclusive!(uniform_u128x10_all_new_inclusive, u128, 0, u128::max_value(), 10);
-uniform_sample!(uniform_u128x10_allm1_new, u128, 0, u128::max_value(), 10);
+uniform_inclusive!(uniform_u128x10_all_new_inclusive, u128, 0, u128::MAX, 10);
+uniform_sample!(uniform_u128x10_allm1_new, u128, 0, u128::MAX, 10);
 uniform_sample!(uniform_u128x10_halfp1_new, u128, 0, HALF_128_BIT_UNSIGNED + 1, 10);
 uniform_sample!(uniform_u128x10_half_new, u128, 0, HALF_128_BIT_UNSIGNED, 10);
 uniform_sample!(uniform_u128x10_halfm1_new, u128, 0, HALF_128_BIT_UNSIGNED - 1, 10);
 uniform_sample!(uniform_u128x10_6_new, u128, 0, 6u128, 10);
 
-uniform_single!(uniform_u128x10_allm1_single, u128, 0, u128::max_value(), 10);
+uniform_single!(uniform_u128x10_allm1_single, u128, 0, u128::MAX, 10);
 uniform_single!(uniform_u128x10_halfp1_single, u128, 0, HALF_128_BIT_UNSIGNED + 1, 10);
 uniform_single!(uniform_u128x10_half_single, u128, 0, HALF_128_BIT_UNSIGNED, 10);
 uniform_single!(uniform_u128x10_halfm1_single, u128, 0, HALF_128_BIT_UNSIGNED - 1, 10);

--- a/benches/misc.rs
+++ b/benches/misc.rs
@@ -23,7 +23,7 @@ fn misc_gen_bool_const(b: &mut Bencher) {
     let mut rng = Pcg32::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
         let mut accum = true;
-        for _ in 0..crate::RAND_BENCH_N {
+        for _ in 0..RAND_BENCH_N {
             accum ^= rng.gen_bool(0.18);
         }
         accum
@@ -36,7 +36,7 @@ fn misc_gen_bool_var(b: &mut Bencher) {
     b.iter(|| {
         let mut accum = true;
         let mut p = 0.18;
-        for _ in 0..crate::RAND_BENCH_N {
+        for _ in 0..RAND_BENCH_N {
             accum ^= rng.gen_bool(p);
             p += 0.0001;
         }
@@ -49,7 +49,7 @@ fn misc_gen_ratio_const(b: &mut Bencher) {
     let mut rng = Pcg32::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
         let mut accum = true;
-        for _ in 0..crate::RAND_BENCH_N {
+        for _ in 0..RAND_BENCH_N {
             accum ^= rng.gen_ratio(2, 3);
         }
         accum
@@ -61,7 +61,7 @@ fn misc_gen_ratio_var(b: &mut Bencher) {
     let mut rng = Pcg32::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
         let mut accum = true;
-        for i in 2..(crate::RAND_BENCH_N as u32 + 2) {
+        for i in 2..(RAND_BENCH_N as u32 + 2) {
             accum ^= rng.gen_ratio(i, i + 1);
         }
         accum
@@ -72,9 +72,9 @@ fn misc_gen_ratio_var(b: &mut Bencher) {
 fn misc_bernoulli_const(b: &mut Bencher) {
     let mut rng = Pcg32::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
-        let d = rand::distributions::Bernoulli::new(0.18).unwrap();
+        let d = Bernoulli::new(0.18).unwrap();
         let mut accum = true;
-        for _ in 0..crate::RAND_BENCH_N {
+        for _ in 0..RAND_BENCH_N {
             accum ^= rng.sample(d);
         }
         accum
@@ -87,7 +87,7 @@ fn misc_bernoulli_var(b: &mut Bencher) {
     b.iter(|| {
         let mut accum = true;
         let mut p = 0.18;
-        for _ in 0..crate::RAND_BENCH_N {
+        for _ in 0..RAND_BENCH_N {
             let d = Bernoulli::new(p).unwrap();
             accum ^= rng.sample(d);
             p += 0.0001;

--- a/benches/seq.rs
+++ b/benches/seq.rs
@@ -47,7 +47,7 @@ fn seq_slice_choose_1_of_1000(b: &mut Bencher) {
         }
         s
     });
-    b.bytes = size_of::<usize>() as u64 * crate::RAND_BENCH_N;
+    b.bytes = size_of::<usize>() as u64 * RAND_BENCH_N;
 }
 
 macro_rules! seq_slice_choose_multiple {

--- a/rand_chacha/src/chacha.rs
+++ b/rand_chacha/src/chacha.rs
@@ -344,7 +344,7 @@ mod test {
 
     #[cfg(feature = "serde1")] use super::{ChaCha20Rng, ChaCha12Rng, ChaCha8Rng};
 
-    type ChaChaRng = super::ChaCha20Rng;
+    type ChaChaRng = ChaCha20Rng;
 
     #[cfg(feature = "serde1")]
     #[test]

--- a/rand_chacha/src/chacha.rs
+++ b/rand_chacha/src/chacha.rs
@@ -344,7 +344,7 @@ mod test {
 
     #[cfg(feature = "serde1")] use super::{ChaCha20Rng, ChaCha12Rng, ChaCha8Rng};
 
-    type ChaChaRng = ChaCha20Rng;
+    type ChaChaRng = super::ChaCha20Rng;
 
     #[cfg(feature = "serde1")]
     #[test]

--- a/rand_distr/src/binomial.rs
+++ b/rand_distr/src/binomial.rs
@@ -77,7 +77,7 @@ impl Binomial {
 
 /// Convert a `f64` to an `i64`, panicking on overflow.
 fn f64_to_i64(x: f64) -> i64 {
-    assert!(x < (core::i64::MAX as f64));
+    assert!(x < (i64::MAX as f64));
     x as i64
 }
 
@@ -117,7 +117,7 @@ impl Distribution<u64> for Binomial {
         // When n*p < 10, so is n*p*q which is the variance, so a result > 110 would be 100 / sqrt(10) = 31 standard deviations away.
         const BINV_MAX_X : u64 = 110;
 
-        if (self.n as f64) * p < BINV_THRESHOLD && self.n <= (core::i32::MAX as u64) {
+        if (self.n as f64) * p < BINV_THRESHOLD && self.n <= (i32::MAX as u64) {
             // Use the BINV algorithm.
             let s = p / q;
             let a = ((self.n + 1) as f64) * s;

--- a/rand_distr/src/cauchy.rs
+++ b/rand_distr/src/cauchy.rs
@@ -137,7 +137,7 @@ mod test {
 
     #[test]
     fn value_stability() {
-        fn gen_samples<F: Float + FloatConst + core::fmt::Debug>(m: F, s: F, buf: &mut [F])
+        fn gen_samples<F: Float + FloatConst + fmt::Debug>(m: F, s: F, buf: &mut [F])
         where Standard: Distribution<F> {
             let distr = Cauchy::new(m, s).unwrap();
             let mut rng = crate::test::rng(353);

--- a/rand_distr/src/frechet.rs
+++ b/rand_distr/src/frechet.rs
@@ -112,13 +112,13 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_infinite_scale() {
-        Frechet::new(0.0, core::f64::INFINITY, 1.0).unwrap();
+        Frechet::new(0.0, f64::INFINITY, 1.0).unwrap();
     }
 
     #[test]
     #[should_panic]
     fn test_nan_scale() {
-        Frechet::new(0.0, core::f64::NAN, 1.0).unwrap();
+        Frechet::new(0.0, f64::NAN, 1.0).unwrap();
     }
 
     #[test]
@@ -130,25 +130,25 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_infinite_shape() {
-        Frechet::new(0.0, 1.0, core::f64::INFINITY).unwrap();
+        Frechet::new(0.0, 1.0, f64::INFINITY).unwrap();
     }
 
     #[test]
     #[should_panic]
     fn test_nan_shape() {
-        Frechet::new(0.0, 1.0, core::f64::NAN).unwrap();
+        Frechet::new(0.0, 1.0, f64::NAN).unwrap();
     }
 
     #[test]
     #[should_panic]
     fn test_infinite_location() {
-        Frechet::new(core::f64::INFINITY, 1.0, 1.0).unwrap();
+        Frechet::new(f64::INFINITY, 1.0, 1.0).unwrap();
     }
 
     #[test]
     #[should_panic]
     fn test_nan_location() {
-        Frechet::new(core::f64::NAN, 1.0, 1.0).unwrap();
+        Frechet::new(f64::NAN, 1.0, 1.0).unwrap();
     }
 
     #[test]

--- a/rand_distr/src/geometric.rs
+++ b/rand_distr/src/geometric.rs
@@ -94,7 +94,7 @@ impl Distribution<u64> for Geometric
             return failures;
         }
         
-        if self.p == 0.0 { return core::u64::MAX; }
+        if self.p == 0.0 { return u64::MAX; }
 
         let Geometric { p, pi, k } = *self;
 
@@ -121,7 +121,7 @@ impl Distribution<u64> for Geometric
         // fewer iterations on average.                 ~ October 28, 2020
         let m = loop {
             let m = rng.gen::<u64>() & ((1 << k) - 1);
-            let p_reject = if m <= core::i32::MAX as u64 {
+            let p_reject = if m <= i32::MAX as u64 {
                 (1.0 - p).powi(m as i32)
             } else {
                 (1.0 - p).powf(m as f64)
@@ -176,9 +176,9 @@ mod test {
 
     #[test]
     fn test_geo_invalid_p() {
-        assert!(Geometric::new(core::f64::NAN).is_err());
-        assert!(Geometric::new(core::f64::INFINITY).is_err());
-        assert!(Geometric::new(core::f64::NEG_INFINITY).is_err());
+        assert!(Geometric::new(f64::NAN).is_err());
+        assert!(Geometric::new(f64::INFINITY).is_err());
+        assert!(Geometric::new(f64::NEG_INFINITY).is_err());
 
         assert!(Geometric::new(-0.5).is_err());
         assert!(Geometric::new(0.0).is_ok());

--- a/rand_distr/src/gumbel.rs
+++ b/rand_distr/src/gumbel.rs
@@ -101,25 +101,25 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_infinite_scale() {
-        Gumbel::new(0.0, core::f64::INFINITY).unwrap();
+        Gumbel::new(0.0, f64::INFINITY).unwrap();
     }
 
     #[test]
     #[should_panic]
     fn test_nan_scale() {
-        Gumbel::new(0.0, core::f64::NAN).unwrap();
+        Gumbel::new(0.0, f64::NAN).unwrap();
     }
 
     #[test]
     #[should_panic]
     fn test_infinite_location() {
-        Gumbel::new(core::f64::INFINITY, 1.0).unwrap();
+        Gumbel::new(f64::INFINITY, 1.0).unwrap();
     }
 
     #[test]
     #[should_panic]
     fn test_nan_location() {
-        Gumbel::new(core::f64::NAN, 1.0).unwrap();
+        Gumbel::new(f64::NAN, 1.0).unwrap();
     }
 
     #[test]

--- a/rand_distr/src/normal.rs
+++ b/rand_distr/src/normal.rs
@@ -348,7 +348,7 @@ mod tests {
     #[test]
     fn test_log_normal_cv() {
         let lnorm = LogNormal::from_mean_cv(0.0, 0.0).unwrap();
-        assert_eq!((lnorm.norm.mean, lnorm.norm.std_dev), (-core::f64::INFINITY, 0.0));
+        assert_eq!((lnorm.norm.mean, lnorm.norm.std_dev), (f64::NEG_INFINITY, 0.0));
 
         let lnorm = LogNormal::from_mean_cv(1.0, 0.0).unwrap();
         assert_eq!((lnorm.norm.mean, lnorm.norm.std_dev), (0.0, 0.0));

--- a/rand_distr/src/skew_normal.rs
+++ b/rand_distr/src/skew_normal.rs
@@ -150,7 +150,7 @@ where
 mod tests {
     use super::*;
 
-    fn test_samples<F: Float + core::fmt::Debug, D: Distribution<F>>(
+    fn test_samples<F: Float + fmt::Debug, D: Distribution<F>>(
         distr: D, zero: F, expected: &[F],
     ) {
         let mut rng = crate::test::rng(213);
@@ -164,7 +164,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn invalid_scale_nan() {
-        SkewNormal::new(0.0, core::f64::NAN, 0.0).unwrap();
+        SkewNormal::new(0.0, f64::NAN, 0.0).unwrap();
     }
 
     #[test]
@@ -182,24 +182,24 @@ mod tests {
     #[test]
     #[should_panic]
     fn invalid_scale_infinite() {
-        SkewNormal::new(0.0, core::f64::INFINITY, 0.0).unwrap();
+        SkewNormal::new(0.0, f64::INFINITY, 0.0).unwrap();
     }
 
     #[test]
     #[should_panic]
     fn invalid_shape_nan() {
-        SkewNormal::new(0.0, 1.0, core::f64::NAN).unwrap();
+        SkewNormal::new(0.0, 1.0, f64::NAN).unwrap();
     }
 
     #[test]
     #[should_panic]
     fn invalid_shape_infinite() {
-        SkewNormal::new(0.0, 1.0, core::f64::INFINITY).unwrap();
+        SkewNormal::new(0.0, 1.0, f64::INFINITY).unwrap();
     }
 
     #[test]
     fn valid_location_nan() {
-        SkewNormal::new(core::f64::NAN, 1.0, 0.0).unwrap();
+        SkewNormal::new(f64::NAN, 1.0, 0.0).unwrap();
     }
 
     #[test]
@@ -220,30 +220,30 @@ mod tests {
             ],
         );
         test_samples(
-            SkewNormal::new(core::f64::INFINITY, 1.0, 0.0).unwrap(),
+            SkewNormal::new(f64::INFINITY, 1.0, 0.0).unwrap(),
             0f64,
             &[
-                core::f64::INFINITY,
-                core::f64::INFINITY,
-                core::f64::INFINITY,
-                core::f64::INFINITY,
+                f64::INFINITY,
+                f64::INFINITY,
+                f64::INFINITY,
+                f64::INFINITY,
             ],
         );
         test_samples(
-            SkewNormal::new(core::f64::NEG_INFINITY, 1.0, 0.0).unwrap(),
+            SkewNormal::new(f64::NEG_INFINITY, 1.0, 0.0).unwrap(),
             0f64,
             &[
-                core::f64::NEG_INFINITY,
-                core::f64::NEG_INFINITY,
-                core::f64::NEG_INFINITY,
-                core::f64::NEG_INFINITY,
+                f64::NEG_INFINITY,
+                f64::NEG_INFINITY,
+                f64::NEG_INFINITY,
+                f64::NEG_INFINITY,
             ],
         );
     }
 
     #[test]
     fn skew_normal_value_location_nan() {
-        let skew_normal = SkewNormal::new(core::f64::NAN, 1.0, 0.0).unwrap();
+        let skew_normal = SkewNormal::new(f64::NAN, 1.0, 0.0).unwrap();
         let mut rng = crate::test::rng(213);
         let mut buf = [0.0; 4];
         for x in &mut buf {

--- a/rand_distr/src/utils.rs
+++ b/rand_distr/src/utils.rs
@@ -100,7 +100,7 @@ where
             (bits >> 12).into_float_with_exponent(1) - 3.0
         } else {
             // Convert to a value in the range [1,2) and subtract to get (0,1)
-            (bits >> 12).into_float_with_exponent(0) - (1.0 - core::f64::EPSILON / 2.0)
+            (bits >> 12).into_float_with_exponent(0) - (1.0 - f64::EPSILON / 2.0)
         };
         let x = u * x_tab[i];
 

--- a/rand_distr/src/weibull.rs
+++ b/rand_distr/src/weibull.rs
@@ -105,7 +105,7 @@ mod tests {
 
     #[test]
     fn value_stability() {
-        fn test_samples<F: Float + core::fmt::Debug, D: Distribution<F>>(
+        fn test_samples<F: Float + fmt::Debug, D: Distribution<F>>(
             distr: D, zero: F, expected: &[F],
         ) {
             let mut rng = crate::test::rng(213);

--- a/rand_distr/src/weighted_alias.rs
+++ b/rand_distr/src/weighted_alias.rs
@@ -86,7 +86,7 @@ impl<W: AliasableWeight> WeightedAliasIndex<W> {
     /// -   [`WeightError::InsufficientNonZero`] when the sum of all weights is zero.
     pub fn new(weights: Vec<W>) -> Result<Self, WeightError> {
         let n = weights.len();
-        if n == 0 || n > ::core::u32::MAX as usize {
+        if n == 0 || n > u32::MAX as usize {
             return Err(WeightError::InvalidInput);
         }
         let n = n as u32;
@@ -139,8 +139,8 @@ impl<W: AliasableWeight> WeightedAliasIndex<W> {
             fn new(size: u32) -> Self {
                 Aliases {
                     aliases: vec![0; size as usize].into_boxed_slice(),
-                    smalls_head: ::core::u32::MAX,
-                    bigs_head: ::core::u32::MAX,
+                    smalls_head: u32::MAX,
+                    bigs_head: u32::MAX,
                 }
             }
 
@@ -167,11 +167,11 @@ impl<W: AliasableWeight> WeightedAliasIndex<W> {
             }
 
             fn smalls_is_empty(&self) -> bool {
-                self.smalls_head == ::core::u32::MAX
+                self.smalls_head == u32::MAX
             }
 
             fn bigs_is_empty(&self) -> bool {
-                self.bigs_head == ::core::u32::MAX
+                self.bigs_head == u32::MAX
             }
 
             fn set_alias(&mut self, idx: u32, alias: u32) {
@@ -378,7 +378,7 @@ mod test {
 
         // Floating point special cases
         assert_eq!(
-            WeightedAliasIndex::new(vec![::core::f32::INFINITY]).unwrap_err(),
+            WeightedAliasIndex::new(vec![f32::INFINITY]).unwrap_err(),
             WeightError::InvalidWeight
         );
         assert_eq!(
@@ -390,11 +390,11 @@ mod test {
             WeightError::InvalidWeight
         );
         assert_eq!(
-            WeightedAliasIndex::new(vec![-::core::f32::INFINITY]).unwrap_err(),
+            WeightedAliasIndex::new(vec![f32::NEG_INFINITY]).unwrap_err(),
             WeightError::InvalidWeight
         );
         assert_eq!(
-            WeightedAliasIndex::new(vec![::core::f32::NAN]).unwrap_err(),
+            WeightedAliasIndex::new(vec![f32::NAN]).unwrap_err(),
             WeightError::InvalidWeight
         );
     }
@@ -416,7 +416,7 @@ mod test {
             WeightError::InvalidWeight
         );
         assert_eq!(
-            WeightedAliasIndex::new(vec![::core::i128::MIN]).unwrap_err(),
+            WeightedAliasIndex::new(vec![i128::MIN]).unwrap_err(),
             WeightError::InvalidWeight
         );
     }
@@ -438,7 +438,7 @@ mod test {
             WeightError::InvalidWeight
         );
         assert_eq!(
-            WeightedAliasIndex::new(vec![::core::i8::MIN]).unwrap_err(),
+            WeightedAliasIndex::new(vec![i8::MIN]).unwrap_err(),
             WeightError::InvalidWeight
         );
     }

--- a/rand_distr/src/zipf.rs
+++ b/rand_distr/src/zipf.rs
@@ -246,7 +246,7 @@ where F: Float, Standard: Distribution<F>
 mod tests {
     use super::*;
 
-    fn test_samples<F: Float + core::fmt::Debug, D: Distribution<F>>(
+    fn test_samples<F: Float + fmt::Debug, D: Distribution<F>>(
         distr: D, zero: F, expected: &[F],
     ) {
         let mut rng = crate::test::rng(213);
@@ -266,7 +266,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn zeta_nan() {
-        Zeta::new(core::f64::NAN).unwrap();
+        Zeta::new(f64::NAN).unwrap();
     }
 
     #[test]
@@ -316,7 +316,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn zipf_nan() {
-        Zipf::new(10, core::f64::NAN).unwrap();
+        Zipf::new(10, f64::NAN).unwrap();
     }
 
     #[test]
@@ -352,7 +352,7 @@ mod tests {
 
     #[test]
     fn zipf_sample_large_n() {
-        let d = Zipf::new(core::u64::MAX, 1.5).unwrap();
+        let d = Zipf::new(u64::MAX, 1.5).unwrap();
         let mut rng = crate::test::rng(2);
         for _ in 0..1000 {
             let r = d.sample(&mut rng);

--- a/rand_distr/tests/pdf.rs
+++ b/rand_distr/tests/pdf.rs
@@ -67,7 +67,7 @@ fn normal() {
     );
     println!(
         "max diff: {:?}",
-        diff.iter().fold(core::f64::NEG_INFINITY, |a, &b| a.max(b))
+        diff.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b))
     );
 
     // Check that the differences are significantly smaller than the expected error.
@@ -86,7 +86,7 @@ fn normal() {
         "max expected_error: {:?}",
         expected_error
             .iter()
-            .fold(core::f64::NEG_INFINITY, |a, &b| a.max(b))
+            .fold(f64::NEG_INFINITY, |a, &b| a.max(b))
     );
     for (&d, &e) in diff.iter().zip(expected_error.iter()) {
         // Difference larger than 4 standard deviations or cutoff
@@ -150,7 +150,7 @@ fn skew_normal() {
     );
     println!(
         "max diff: {:?}",
-        diff.iter().fold(core::f64::NEG_INFINITY, |a, &b| a.max(b))
+        diff.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b))
     );
 
     // Check that the differences are significantly smaller than the expected error.
@@ -169,7 +169,7 @@ fn skew_normal() {
         "max expected_error: {:?}",
         expected_error
             .iter()
-            .fold(core::f64::NEG_INFINITY, |a, &b| a.max(b))
+            .fold(f64::NEG_INFINITY, |a, &b| a.max(b))
     );
     for (&d, &e) in diff.iter().zip(expected_error.iter()) {
         // Difference larger than 4 standard deviations or cutoff

--- a/rand_distr/tests/sparkline.rs
+++ b/rand_distr/tests/sparkline.rs
@@ -71,9 +71,9 @@ pub fn render_f64(data: &[f64], buffer: &mut String) {
         assert!(x.is_finite(), "can only render finite values");
     }
     let max = data.iter().fold(
-        core::f64::NEG_INFINITY, |a, &b| a.max(b));
+        f64::NEG_INFINITY, |a, &b| a.max(b));
     let min = data.iter().fold(
-        core::f64::INFINITY, |a, &b| a.min(b));
+        f64::INFINITY, |a, &b| a.min(b));
     let scale = ((N - 1) as f64) / (max - min);
     for x in data {
         let tick = ((x - min) * scale) as usize;

--- a/rand_distr/tests/value_stability.rs
+++ b/rand_distr/tests/value_stability.rs
@@ -11,7 +11,7 @@ use core::fmt::Debug;
 use rand::Rng;
 use rand_distr::*;
 
-fn get_rng(seed: u64) -> impl rand::Rng {
+fn get_rng(seed: u64) -> impl Rng {
     // For tests, we want a statistically good, fast, reproducible RNG.
     // PCG32 will do fine, and will be easy to embed if we ever need to.
     const INC: u64 = 11634580027462260723;
@@ -80,7 +80,7 @@ fn geometric_stability() {
     test_samples(464, Geometric::new(0.95).unwrap(), &[0, 0, 0, 0, 1, 0, 0, 0]);
 
     // expect non-random behaviour for series of pre-determined trials
-    test_samples(464, Geometric::new(0.0).unwrap(), &[u64::max_value(); 100][..]);
+    test_samples(464, Geometric::new(0.0).unwrap(), &[u64::MAX; 100][..]);
     test_samples(464, Geometric::new(1.0).unwrap(), &[0; 100][..]);
 }
 

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -10,7 +10,7 @@
 
 use crate::distributions::Distribution;
 use crate::Rng;
-use core::{fmt, u64};
+use core::fmt;
 
 #[cfg(feature = "serde1")]
 use serde::{Serialize, Deserialize};
@@ -82,7 +82,7 @@ impl fmt::Display for BernoulliError {
 }
 
 #[cfg(feature = "std")]
-impl ::std::error::Error for BernoulliError {}
+impl std::error::Error for BernoulliError {}
 
 impl Bernoulli {
     /// Construct a new `Bernoulli` with the given probability of success `p`.
@@ -145,7 +145,6 @@ impl Distribution<bool> for Bernoulli {
 mod test {
     use super::Bernoulli;
     use crate::distributions::Distribution;
-    use crate::Rng;
 
     #[test]
     #[cfg(feature = "serde1")]

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -145,6 +145,7 @@ impl Distribution<bool> for Bernoulli {
 mod test {
     use super::Bernoulli;
     use crate::distributions::Distribution;
+    use crate::Rng;
 
     #[test]
     #[cfg(feature = "serde1")]

--- a/src/distributions/distribution.rs
+++ b/src/distributions/distribution.rs
@@ -78,7 +78,7 @@ pub trait Distribution<T> {
         DistIter {
             distr: self,
             rng,
-            phantom: ::core::marker::PhantomData,
+            phantom: core::marker::PhantomData,
         }
     }
 
@@ -107,7 +107,7 @@ pub trait Distribution<T> {
         DistMap {
             distr: self,
             func,
-            phantom: ::core::marker::PhantomData,
+            phantom: core::marker::PhantomData,
         }
     }
 }
@@ -129,7 +129,7 @@ impl<'a, T, D: Distribution<T> + ?Sized> Distribution<T> for &'a D {
 pub struct DistIter<D, R, T> {
     distr: D,
     rng: R,
-    phantom: ::core::marker::PhantomData<T>,
+    phantom: core::marker::PhantomData<T>,
 }
 
 impl<D, R, T> Iterator for DistIter<D, R, T>
@@ -148,7 +148,7 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (usize::max_value(), None)
+        (usize::MAX, None)
     }
 }
 
@@ -168,7 +168,7 @@ where
 pub struct DistMap<D, F, T, S> {
     distr: D,
     func: F,
-    phantom: ::core::marker::PhantomData<fn(T) -> S>,
+    phantom: core::marker::PhantomData<fn(T) -> S>,
 }
 
 impl<D, F, T, S> Distribution<S> for DistMap<D, F, T, S>

--- a/src/distributions/float.rs
+++ b/src/distributions/float.rs
@@ -181,8 +181,8 @@ mod tests {
     use super::*;
     use crate::rngs::mock::StepRng;
 
-    const EPSILON32: f32 = ::core::f32::EPSILON;
-    const EPSILON64: f64 = ::core::f64::EPSILON;
+    const EPSILON32: f32 = f32::EPSILON;
+    const EPSILON64: f64 = f64::EPSILON;
 
     macro_rules! test_f32 {
         ($fnn:ident, $ty:ident, $ZERO:expr, $EPSILON:expr) => {

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -327,7 +327,7 @@ pub trait UniformSampler: Sized {
 impl<X: SampleUniform> TryFrom<Range<X>> for Uniform<X> {
     type Error = Error;
 
-    fn try_from(r: ::core::ops::Range<X>) -> Result<Uniform<X>, Error> {
+    fn try_from(r: Range<X>) -> Result<Uniform<X>, Error> {
         Uniform::new(r.start, r.end)
     }
 }
@@ -1526,14 +1526,14 @@ mod tests {
 
     #[test]
     fn test_float_overflow() {
-        assert_eq!(Uniform::try_from(::core::f64::MIN..::core::f64::MAX), Err(Error::NonFinite));
+        assert_eq!(Uniform::try_from(f64::MIN..f64::MAX), Err(Error::NonFinite));
     }
 
     #[test]
     #[should_panic]
     fn test_float_overflow_single() {
         let mut rng = crate::test::rng(252);
-        rng.gen_range(::core::f64::MIN..::core::f64::MAX);
+        rng.gen_range(f64::MIN..f64::MAX);
     }
 
     #[test]
@@ -1604,7 +1604,7 @@ mod tests {
             (Duration::new(0, 100), Duration::new(1, 50)),
             (
                 Duration::new(0, 0),
-                Duration::new(u64::max_value(), 999_999_999),
+                Duration::new(u64::MAX, 999_999_999),
             ),
         ];
         for &(low, high) in v.iter() {
@@ -1706,7 +1706,7 @@ mod tests {
 
     #[test]
     fn value_stability() {
-        fn test_samples<T: SampleUniform + Copy + core::fmt::Debug + PartialEq>(
+        fn test_samples<T: SampleUniform + Copy + fmt::Debug + PartialEq>(
             lb: T, ub: T, expected_single: &[T], expected_multiple: &[T],
         ) where Uniform<T>: Distribution<T> {
             let mut rng = crate::test::rng(897);

--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -163,8 +163,8 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
     /// as an alternative where an update is `O(log N)`.
     pub fn update_weights(&mut self, new_weights: &[(usize, &X)]) -> Result<(), WeightError>
     where
-        X: for<'a> ::core::ops::AddAssign<&'a X>
-            + for<'a> ::core::ops::SubAssign<&'a X>
+        X: for<'a> core::ops::AddAssign<&'a X>
+            + for<'a> core::ops::SubAssign<&'a X>
             + Clone
             + Default,
     {
@@ -278,7 +278,7 @@ where
 
 impl<'a, X> Iterator for WeightedIndexIter<'a, X>
 where
-    X: for<'b> ::core::ops::SubAssign<&'b X>
+    X: for<'b> core::ops::SubAssign<&'b X>
         + SampleUniform
         + PartialOrd
         + Clone,
@@ -315,7 +315,7 @@ impl<X: SampleUniform + PartialOrd + Clone> WeightedIndex<X> {
     /// ```
     pub fn weight(&self, index: usize) -> Option<X>
     where
-        X: for<'a> ::core::ops::SubAssign<&'a X>
+        X: for<'a> core::ops::SubAssign<&'a X>
     {
         let mut weight = if index < self.cumulative_weights.len() {
             self.cumulative_weights[index].clone()
@@ -348,7 +348,7 @@ impl<X: SampleUniform + PartialOrd + Clone> WeightedIndex<X> {
     /// ```
     pub fn weights(&self) -> WeightedIndexIter<'_, X>
     where
-        X: for<'a> ::core::ops::SubAssign<&'a X>
+        X: for<'a> core::ops::SubAssign<&'a X>
     {
         WeightedIndexIter {
             weighted_index: self,
@@ -451,22 +451,22 @@ mod test {
     #[test]
     fn test_accepting_nan() {
         assert_eq!(
-            WeightedIndex::new(&[core::f32::NAN, 0.5]).unwrap_err(),
+            WeightedIndex::new(&[f32::NAN, 0.5]).unwrap_err(),
             WeightError::InvalidWeight,
         );
         assert_eq!(
-            WeightedIndex::new(&[core::f32::NAN]).unwrap_err(),
+            WeightedIndex::new(&[f32::NAN]).unwrap_err(),
             WeightError::InvalidWeight,
         );
         assert_eq!(
-            WeightedIndex::new(&[0.5, core::f32::NAN]).unwrap_err(),
+            WeightedIndex::new(&[0.5, f32::NAN]).unwrap_err(),
             WeightError::InvalidWeight,
         );
 
         assert_eq!(
             WeightedIndex::new(&[0.5, 7.0])
                 .unwrap()
-                .update_weights(&[(0, &core::f32::NAN)])
+                .update_weights(&[(0, &f32::NAN)])
                 .unwrap_err(),
             WeightError::InvalidWeight,
         )

--- a/src/rngs/reseeding.rs
+++ b/src/rngs/reseeding.rs
@@ -181,8 +181,6 @@ where
 {
     /// Create a new `ReseedingCore`.
     fn new(rng: R, threshold: u64, reseeder: Rsdr) -> Self {
-        fork::register_fork_handler();
-
         // Because generating more values than `i64::MAX` takes centuries on
         // current hardware, we just clamp to that value.
         // Also we set a threshold of 0, which indicates no limit, to that

--- a/src/rngs/reseeding.rs
+++ b/src/rngs/reseeding.rs
@@ -12,8 +12,8 @@
 
 use core::mem::size_of_val;
 
-use rand_core::block::{BlockRng, BlockRngCore, CryptoBlockRng};
 use rand_core::{CryptoRng, Error, RngCore, SeedableRng};
+use rand_core::block::{BlockRng, BlockRngCore, CryptoBlockRng};
 
 /// A wrapper around any PRNG that implements [`BlockRngCore`], that adds the
 /// ability to reseed it.
@@ -181,18 +181,18 @@ where
 {
     /// Create a new `ReseedingCore`.
     fn new(rng: R, threshold: u64, reseeder: Rsdr) -> Self {
-        use ::core::i64::MAX;
+        fork::register_fork_handler();
 
         // Because generating more values than `i64::MAX` takes centuries on
         // current hardware, we just clamp to that value.
         // Also we set a threshold of 0, which indicates no limit, to that
         // value.
         let threshold = if threshold == 0 {
-            MAX
-        } else if threshold <= MAX as u64 {
+            i64::MAX
+        } else if threshold <= i64::MAX as u64 {
             threshold as i64
         } else {
-            MAX
+            i64::MAX
         };
 
         ReseedingCore {
@@ -246,16 +246,70 @@ impl<R, Rsdr> CryptoBlockRng for ReseedingCore<R, Rsdr>
 where
     R: BlockRngCore<Item = u32> + SeedableRng + CryptoBlockRng,
     Rsdr: CryptoRng,
-{
+{}
+
+#[cfg(all(unix, not(target_os = "emscripten")))]
+mod fork {
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Once;
+
+    // Fork protection
+    //
+    // We implement fork protection on Unix using `pthread_atfork`.
+    // When the process is forked, we increment `RESEEDING_RNG_FORK_COUNTER`.
+    // Every `ReseedingRng` stores the last known value of the static in
+    // `fork_counter`. If the cached `fork_counter` is less than
+    // `RESEEDING_RNG_FORK_COUNTER`, it is time to reseed this RNG.
+    //
+    // If reseeding fails, we don't deal with this by setting a delay, but just
+    // don't update `fork_counter`, so a reseed is attempted as soon as
+    // possible.
+
+    static RESEEDING_RNG_FORK_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    pub fn get_fork_counter() -> usize {
+        RESEEDING_RNG_FORK_COUNTER.load(Ordering::Relaxed)
+    }
+
+    extern "C" fn fork_handler() {
+        // Note: fetch_add is defined to wrap on overflow
+        // (which is what we want).
+        RESEEDING_RNG_FORK_COUNTER.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn register_fork_handler() {
+        static REGISTER: Once = Once::new();
+        REGISTER.call_once(|| {
+            // Bump the counter before and after forking (see #1169):
+            let ret = unsafe { libc::pthread_atfork(
+                Some(fork_handler),
+                Some(fork_handler),
+                Some(fork_handler),
+            ) };
+            if ret != 0 {
+                panic!("libc::pthread_atfork failed with code {}", ret);
+            }
+        });
+    }
 }
+
+#[cfg(not(all(unix, not(target_os = "emscripten"))))]
+mod fork {
+    pub fn get_fork_counter() -> usize {
+        0
+    }
+    pub fn register_fork_handler() {}
+}
+
 
 #[cfg(feature = "std_rng")]
 #[cfg(test)]
 mod test {
-    use super::ReseedingRng;
+    use crate::{Rng, SeedableRng};
     use crate::rngs::mock::StepRng;
     use crate::rngs::std::Core;
-    use crate::{Rng, SeedableRng};
+
+    use super::ReseedingRng;
 
     #[test]
     fn test_reseeding() {

--- a/src/rngs/reseeding.rs
+++ b/src/rngs/reseeding.rs
@@ -248,60 +248,6 @@ where
     Rsdr: CryptoRng,
 {}
 
-#[cfg(all(unix, not(target_os = "emscripten")))]
-mod fork {
-    use core::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Once;
-
-    // Fork protection
-    //
-    // We implement fork protection on Unix using `pthread_atfork`.
-    // When the process is forked, we increment `RESEEDING_RNG_FORK_COUNTER`.
-    // Every `ReseedingRng` stores the last known value of the static in
-    // `fork_counter`. If the cached `fork_counter` is less than
-    // `RESEEDING_RNG_FORK_COUNTER`, it is time to reseed this RNG.
-    //
-    // If reseeding fails, we don't deal with this by setting a delay, but just
-    // don't update `fork_counter`, so a reseed is attempted as soon as
-    // possible.
-
-    static RESEEDING_RNG_FORK_COUNTER: AtomicUsize = AtomicUsize::new(0);
-
-    pub fn get_fork_counter() -> usize {
-        RESEEDING_RNG_FORK_COUNTER.load(Ordering::Relaxed)
-    }
-
-    extern "C" fn fork_handler() {
-        // Note: fetch_add is defined to wrap on overflow
-        // (which is what we want).
-        RESEEDING_RNG_FORK_COUNTER.fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub fn register_fork_handler() {
-        static REGISTER: Once = Once::new();
-        REGISTER.call_once(|| {
-            // Bump the counter before and after forking (see #1169):
-            let ret = unsafe { libc::pthread_atfork(
-                Some(fork_handler),
-                Some(fork_handler),
-                Some(fork_handler),
-            ) };
-            if ret != 0 {
-                panic!("libc::pthread_atfork failed with code {}", ret);
-            }
-        });
-    }
-}
-
-#[cfg(not(all(unix, not(target_os = "emscripten"))))]
-mod fork {
-    pub fn get_fork_counter() -> usize {
-        0
-    }
-    pub fn register_fork_handler() {}
-}
-
-
 #[cfg(feature = "std_rng")]
 #[cfg(test)]
 mod test {

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -224,7 +224,7 @@ where R: Rng + ?Sized {
     if amount > length {
         panic!("`amount` of samples must be less than or equal to `length`");
     }
-    if length > (::core::u32::MAX as usize) {
+    if length > (u32::MAX as usize) {
         // We never want to use inplace here, but could use floyd's alg
         // Lazy version: always use the cache alg.
         return sample_rejection(rng, length, amount);
@@ -282,10 +282,10 @@ where
     F: Fn(usize) -> X,
     X: Into<f64>,
 {
-    if length > (core::u32::MAX as usize) {
+    if length > (u32::MAX as usize) {
         sample_efraimidis_spirakis(rng, length, weight, amount)
     } else {
-        assert!(amount <= core::u32::MAX as usize);
+        assert!(amount <= u32::MAX as usize);
         let amount = amount as u32;
         let length = length as u32;
         sample_efraimidis_spirakis(rng, length, weight, amount)

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -127,7 +127,7 @@ pub trait IndexedRandom: Index<usize> {
         Self::Output: Sized,
         R: Rng + ?Sized,
     {
-        let amount = ::core::cmp::min(amount, self.len());
+        let amount = core::cmp::min(amount, self.len());
         SliceChooseIter {
             slice: self,
             _phantom: Default::default(),
@@ -173,7 +173,7 @@ pub trait IndexedRandom: Index<usize> {
         R: Rng + ?Sized,
         F: Fn(&Self::Output) -> B,
         B: SampleBorrow<X>,
-        X: SampleUniform + Weight + ::core::cmp::PartialOrd<X>,
+        X: SampleUniform + Weight + PartialOrd<X>,
     {
         use crate::distributions::{Distribution, WeightedIndex};
         let distr = WeightedIndex::new((0..self.len()).map(|idx| weight(&self[idx])))?;
@@ -226,7 +226,7 @@ pub trait IndexedRandom: Index<usize> {
         F: Fn(&Self::Output) -> X,
         X: Into<f64>,
     {
-        let amount = ::core::cmp::min(amount, self.len());
+        let amount = core::cmp::min(amount, self.len());
         Ok(SliceChooseIter {
             slice: self,
             _phantom: Default::default(),
@@ -291,7 +291,7 @@ pub trait IndexedMutRandom: IndexedRandom + IndexMut<usize> {
         R: Rng + ?Sized,
         F: Fn(&Self::Output) -> B,
         B: SampleBorrow<X>,
-        X: SampleUniform + Weight + ::core::cmp::PartialOrd<X>,
+        X: SampleUniform + Weight + PartialOrd<X>,
     {
         use crate::distributions::{Distribution, WeightedIndex};
         let distr = WeightedIndex::new((0..self.len()).map(|idx| weight(&self[idx])))?;
@@ -424,7 +424,7 @@ pub trait IteratorRandom: Iterator + Sized {
             };
         }
 
-        let mut coin_flipper = coin_flipper::CoinFlipper::new(rng);
+        let mut coin_flipper = CoinFlipper::new(rng);
         let mut consumed = 0;
 
         // Continue until the iterator is exhausted
@@ -669,7 +669,7 @@ impl<I> IteratorRandom for I where I: Iterator + Sized {}
 #[derive(Debug)]
 pub struct SliceChooseIter<'a, S: ?Sized + 'a, T: 'a> {
     slice: &'a S,
-    _phantom: ::core::marker::PhantomData<T>,
+    _phantom: core::marker::PhantomData<T>,
     indices: index::IndexVecIntoIter,
 }
 
@@ -703,7 +703,7 @@ impl<'a, S: Index<usize, Output = T> + ?Sized + 'a, T: 'a> ExactSizeIterator
 // platforms.
 #[inline]
 fn gen_index<R: Rng + ?Sized>(rng: &mut R, ubound: usize) -> usize {
-    if ubound <= (core::u32::MAX as usize) {
+    if ubound <= (u32::MAX as usize) {
         rng.gen_range(0..ubound as u32) as usize
     } else {
         rng.gen_range(0..ubound)
@@ -804,7 +804,7 @@ mod test {
 
         fn next(&mut self) -> Option<Self::Item> {
             if self.chunk_remaining == 0 {
-                self.chunk_remaining = ::core::cmp::min(self.chunk_size, self.iter.len());
+                self.chunk_remaining = core::cmp::min(self.chunk_size, self.iter.len());
             }
             self.chunk_remaining = self.chunk_remaining.saturating_sub(1);
 
@@ -838,7 +838,7 @@ mod test {
 
         fn size_hint(&self) -> (usize, Option<usize>) {
             (
-                ::core::cmp::min(self.iter.len(), self.window_size),
+                core::cmp::min(self.iter.len(), self.window_size),
                 if self.hint_total_size {
                     Some(self.iter.len())
                 } else {
@@ -1344,12 +1344,12 @@ mod test {
         assert_eq!(r.unwrap().count(), 0);
 
         // Case 5: NaN weights
-        let choices = [('a', core::f64::NAN), ('b', 1.0), ('c', 1.0)];
+        let choices = [('a', f64::NAN), ('b', 1.0), ('c', 1.0)];
         let r = choices.choose_multiple_weighted(&mut rng, 2, |item| item.1);
         assert_eq!(r.unwrap_err(), WeightError::InvalidWeight);
 
         // Case 6: +infinity weights
-        let choices = [('a', core::f64::INFINITY), ('b', 1.0), ('c', 1.0)];
+        let choices = [('a', f64::INFINITY), ('b', 1.0), ('c', 1.0)];
         for _ in 0..100 {
             let result = choices
                 .choose_multiple_weighted(&mut rng, 2, |item| item.1)
@@ -1360,7 +1360,7 @@ mod test {
         }
 
         // Case 7: -infinity weights
-        let choices = [('a', core::f64::NEG_INFINITY), ('b', 1.0), ('c', 1.0)];
+        let choices = [('a', f64::NEG_INFINITY), ('b', 1.0), ('c', 1.0)];
         let r = choices.choose_multiple_weighted(&mut rng, 2, |item| item.1);
         assert_eq!(r.unwrap_err(), WeightError::InvalidWeight);
 


### PR DESCRIPTION
# Summary
This PR fixes some instances of redundant or deprecated path prefixes in the codebase.
This is a new PR after I screwed up the git history of #1422, sorry about that.

# Motivation
Code style.

# Details
- Some numeric constants are currently imported from `core`, such as  `core::u64::MAX` or `core::f64::EPSILON`. Clippy suggests that these be changed to the newer associated constants on the types themselves, e.g. `u64::MAX` and `f64::EPSILON`. Also, method calls like `u64::max_value()` have likewise been replaced with `u64::MAX`.
- Some types are currently fully qualified despite a matching import. These redundant prefixes have been removed.
- Some paths are currently prefixed with `::` unnecessarily, which has been removed.
- Instances of `-f64::INFINITY` have been replaced with `f64::NEG_INFINITY`.