### PR TITLE
Rename `Rng::gen` to `Rng::random`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 ## [Unreleased]
 - Add `rand::distributions::WeightedIndex::{weight, weights, total_weight}` (#1420)
 - Bump the MSRV to 1.61.0
-- Introduce `Rng::random` as an identical alternative to `Rng::gen`, which is now deprecated due to conflicting with a
-  keyword in Rust 2024 (#1435)
+- Rename `Rng::gen` to `Rng::random` to avoid conflict with the new `gen` keyword in Rust 2024 (#1435)
 - Move all benchmarks to new `benches` crate (#1439)
 
 ## [0.9.0-alpha.1] - 2024-03-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 ## [Unreleased]
 - Add `rand::distributions::WeightedIndex::{weight, weights, total_weight}` (#1420)
 - Bump the MSRV to 1.61.0
+- Introduce `Rng::random` as an identical alternative to `Rng::gen`, which is now deprecated due to conflicting with a
+  keyword in Rust 2024 (#1435)
 - Move all benchmarks to new `benches` crate (#1439)
 
 ## [0.9.0-alpha.1] - 2024-03-18

--- a/benches/benches/misc.rs
+++ b/benches/benches/misc.rs
@@ -101,7 +101,7 @@ fn gen_1kb_u16_iter_repeat(b: &mut Bencher) {
     use core::iter;
     let mut rng = Pcg64Mcg::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
-        let v: Vec<u16> = iter::repeat(()).map(|()| rng.gen()).take(512).collect();
+        let v: Vec<u16> = iter::repeat(()).map(|()| rng.random()).take(512).collect();
         v
     });
     b.bytes = 1024;
@@ -122,7 +122,7 @@ fn gen_1kb_u16_gen_array(b: &mut Bencher) {
     let mut rng = Pcg64Mcg::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
         // max supported array length is 32!
-        let v: [[u16; 32]; 16] = rng.gen();
+        let v: [[u16; 32]; 16] = rng.random();
         v
     });
     b.bytes = 1024;
@@ -144,7 +144,7 @@ fn gen_1kb_u64_iter_repeat(b: &mut Bencher) {
     use core::iter;
     let mut rng = Pcg64Mcg::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
-        let v: Vec<u64> = iter::repeat(()).map(|()| rng.gen()).take(128).collect();
+        let v: Vec<u64> = iter::repeat(()).map(|()| rng.random()).take(128).collect();
         v
     });
     b.bytes = 1024;
@@ -165,7 +165,7 @@ fn gen_1kb_u64_gen_array(b: &mut Bencher) {
     let mut rng = Pcg64Mcg::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
         // max supported array length is 32!
-        let v: [[u64; 32]; 4] = rng.gen();
+        let v: [[u64; 32]; 4] = rng.random();
         v
     });
     b.bytes = 1024;

--- a/examples/monty-hall.rs
+++ b/examples/monty-hall.rs
@@ -45,7 +45,7 @@ fn simulate<R: Rng>(random_door: &Uniform<u32>, rng: &mut R) -> SimulationResult
     let open = game_host_open(car, choice, rng);
 
     // Shall we switch?
-    let switch = rng.gen();
+    let switch = rng.random();
     if switch {
         choice = switch_door(choice, open);
     }

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -136,7 +136,7 @@ impl Distribution<bool> for Bernoulli {
         if self.p_int == ALWAYS_TRUE {
             return true;
         }
-        let v: u64 = rng.gen();
+        let v: u64 = rng.random();
         v < self.p_int
     }
 }

--- a/src/distributions/float.rs
+++ b/src/distributions/float.rs
@@ -115,7 +115,7 @@ macro_rules! float_impls {
                 let precision = $fraction_bits + 1;
                 let scale = 1.0 / ((1 as $u_scalar << precision) as $f_scalar);
 
-                let value: $uty = rng.gen();
+                let value: $uty = rng.random();
                 let value = value >> $uty::splat(float_size - precision);
                 $ty::splat(scale) * $ty::cast_from_int(value)
             }
@@ -132,7 +132,7 @@ macro_rules! float_impls {
                 let precision = $fraction_bits + 1;
                 let scale = 1.0 / ((1 as $u_scalar << precision) as $f_scalar);
 
-                let value: $uty = rng.gen();
+                let value: $uty = rng.random();
                 let value = value >> $uty::splat(float_size - precision);
                 // Add 1 to shift up; will not overflow because of right-shift:
                 $ty::splat(scale) * $ty::cast_from_int(value + $uty::splat(1))
@@ -149,7 +149,7 @@ macro_rules! float_impls {
                 use core::$f_scalar::EPSILON;
                 let float_size = mem::size_of::<$f_scalar>() as $u_scalar * 8;
 
-                let value: $uty = rng.gen();
+                let value: $uty = rng.random();
                 let fraction = value >> $uty::splat(float_size - $fraction_bits);
                 fraction.into_float_with_exponent(0) - $ty::splat(1.0 - EPSILON / 2.0)
             }
@@ -192,11 +192,11 @@ mod tests {
 
                 // Standard
                 let mut zeros = StepRng::new(0, 0);
-                assert_eq!(zeros.gen::<$ty>(), $ZERO);
+                assert_eq!(zeros.random::<$ty>(), $ZERO);
                 let mut one = StepRng::new(1 << 8 | 1 << (8 + 32), 0);
-                assert_eq!(one.gen::<$ty>(), $EPSILON / two);
+                assert_eq!(one.random::<$ty>(), $EPSILON / two);
                 let mut max = StepRng::new(!0, 0);
-                assert_eq!(max.gen::<$ty>(), $ty::splat(1.0) - $EPSILON / two);
+                assert_eq!(max.random::<$ty>(), $ty::splat(1.0) - $EPSILON / two);
 
                 // OpenClosed01
                 let mut zeros = StepRng::new(0, 0);
@@ -234,11 +234,11 @@ mod tests {
 
                 // Standard
                 let mut zeros = StepRng::new(0, 0);
-                assert_eq!(zeros.gen::<$ty>(), $ZERO);
+                assert_eq!(zeros.random::<$ty>(), $ZERO);
                 let mut one = StepRng::new(1 << 11, 0);
-                assert_eq!(one.gen::<$ty>(), $EPSILON / two);
+                assert_eq!(one.random::<$ty>(), $EPSILON / two);
                 let mut max = StepRng::new(!0, 0);
-                assert_eq!(max.gen::<$ty>(), $ty::splat(1.0) - $EPSILON / two);
+                assert_eq!(max.random::<$ty>(), $ty::splat(1.0) - $EPSILON / two);
 
                 // OpenClosed01
                 let mut zeros = StepRng::new(0, 0);

--- a/src/distributions/integer.rs
+++ b/src/distributions/integer.rs
@@ -81,7 +81,7 @@ macro_rules! impl_int_from_uint {
         impl Distribution<$ty> for Standard {
             #[inline]
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $ty {
-                rng.gen::<$uty>() as $ty
+                rng.random::<$uty>() as $ty
             }
         }
     };
@@ -99,7 +99,7 @@ macro_rules! impl_nzint {
         impl Distribution<$ty> for Standard {
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $ty {
                 loop {
-                    if let Some(nz) = $new(rng.gen()) {
+                    if let Some(nz) = $new(rng.random()) {
                         break nz;
                     }
                 }

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -11,7 +11,7 @@
 //!
 //! This module is the home of the [`Distribution`] trait and several of its
 //! implementations. It is the workhorse behind some of the convenient
-//! functionality of the [`Rng`] trait, e.g. [`Rng::gen`] and of course
+//! functionality of the [`Rng`] trait, e.g. [`Rng::random`] and of course
 //! [`Rng::sample`].
 //!
 //! Abstractly, a [probability distribution] describes the probability of
@@ -31,13 +31,13 @@
 //! # The `Standard` distribution
 //!
 //! The [`Standard`] distribution is important to mention. This is the
-//! distribution used by [`Rng::gen`] and represents the "default" way to
+//! distribution used by [`Rng::random`] and represents the "default" way to
 //! produce a random value for many different types, including most primitive
 //! types, tuples, arrays, and a few derived types. See the documentation of
 //! [`Standard`] for more details.
 //!
 //! Implementing `Distribution<T>` for [`Standard`] for user types `T` makes it
-//! possible to generate type `T` with [`Rng::gen`], and by extension also
+//! possible to generate type `T` with [`Rng::random`], and by extension also
 //! with the [`random`] function.
 //!
 //! ## Random characters
@@ -181,7 +181,7 @@ use crate::Rng;
 ///
 /// impl Distribution<MyF32> for Standard {
 ///     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> MyF32 {
-///         MyF32 { x: rng.gen() }
+///         MyF32 { x: rng.random() }
 ///     }
 /// }
 /// ```

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -189,7 +189,7 @@ where
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Mask<T, LANES> {
         // `MaskElement` must be a signed integer, so this is equivalent
         // to the scalar `i32 < 0` method
-        let var = rng.gen::<Simd<T, LANES>>();
+        let var = rng.random::<Simd<T, LANES>>();
         var.simd_lt(Simd::default())
     }
 }
@@ -208,7 +208,7 @@ macro_rules! tuple_impl {
                 let out = ($(
                     // use the $tyvar's to get the appropriate number of
                     // repeats (they're not actually needed)
-                    rng.gen::<$tyvar>()
+                    rng.random::<$tyvar>()
                 ,)*);
 
                 // Suppress the unused variable warning for empty tuple
@@ -247,7 +247,7 @@ where Standard: Distribution<T>
         let mut buff: [MaybeUninit<T>; N] = unsafe { MaybeUninit::uninit().assume_init() };
 
         for elem in &mut buff {
-            *elem = MaybeUninit::new(_rng.gen());
+            *elem = MaybeUninit::new(_rng.random());
         }
 
         unsafe { mem::transmute_copy::<_, _>(&buff) }
@@ -260,8 +260,8 @@ where Standard: Distribution<T>
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Option<T> {
         // UFCS is needed here: https://github.com/rust-lang/rust/issues/24066
-        if rng.gen::<bool>() {
-            Some(rng.gen())
+        if rng.random::<bool>() {
+            Some(rng.random())
         } else {
             None
         }
@@ -273,7 +273,7 @@ where Standard: Distribution<T>
 {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Wrapping<T> {
-        Wrapping(rng.gen())
+        Wrapping(rng.random())
     }
 }
 
@@ -300,7 +300,7 @@ mod tests {
         // Test by generating a relatively large number of chars, so we also
         // take the rejection sampling path.
         let word: String = iter::repeat(())
-            .map(|()| rng.gen::<char>())
+            .map(|()| rng.random::<char>())
             .take(1000)
             .collect();
         assert!(!word.is_empty());

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -156,10 +156,10 @@ impl Distribution<bool> for Standard {
 ///
 /// ```ignore
 /// // this may be faster...
-/// let x = unsafe { _mm_blendv_epi8(a.into(), b.into(), rng.gen::<__m128i>()) };
+/// let x = unsafe { _mm_blendv_epi8(a.into(), b.into(), rng.random::<__m128i>()) };
 ///
 /// // ...than this
-/// let x = rng.gen::<mask8x16>().select(b, a);
+/// let x = rng.random::<mask8x16>().select(b, a);
 /// ```
 ///
 /// Since most bits are unused you could also generate only as many bits as you need, i.e.:
@@ -169,7 +169,7 @@ impl Distribution<bool> for Standard {
 /// use rand::prelude::*;
 /// let mut rng = thread_rng();
 ///
-/// let x = u16x8::splat(rng.gen::<u8>() as u16);
+/// let x = u16x8::splat(rng.random::<u8>() as u16);
 /// let mask = u16x8::splat(1) << u16x8::from([0, 1, 2, 3, 4, 5, 6, 7]);
 /// let rand_mask = (x & mask).simd_eq(mask);
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //! }
 //!
 //! let mut rng = rand::thread_rng();
-//! let y: f64 = rng.gen(); // generates a float between 0 and 1
+//! let y: f64 = rng.random(); // generates a float between 0 and 1
 //!
 //! let mut nums: Vec<i32> = (1..100).collect();
 //! nums.shuffle(&mut rng);
@@ -147,7 +147,7 @@ use crate::distributions::{Distribution, Standard};
 /// let mut rng = rand::thread_rng();
 ///
 /// for x in v.iter_mut() {
-///     *x = rng.gen();
+///     *x = rng.random();
 /// }
 /// ```
 ///
@@ -158,7 +158,7 @@ use crate::distributions::{Distribution, Standard};
 #[inline]
 pub fn random<T>() -> T
 where Standard: Distribution<T> {
-    thread_rng().gen()
+    thread_rng().random()
 }
 
 #[cfg(test)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,7 +15,7 @@
 //! ```
 //! use rand::prelude::*;
 //! # let mut r = StdRng::from_rng(thread_rng()).unwrap();
-//! # let _: f32 = r.gen();
+//! # let _: f32 = r.random();
 //! ```
 
 #[doc(no_inline)] pub use crate::distributions::Distribution;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -53,14 +53,6 @@ use core::{mem, slice};
 /// # let v = foo(&mut thread_rng());
 /// ```
 pub trait Rng: RngCore {
-    /// Alias for [`Rng::random`].
-    #[inline]
-    #[deprecated(since="0.9.0", note="This method conflicts with a keyword in Rust 2024. Use `Rng::random` instead.")]
-    fn gen<T>(&mut self) -> T
-    where Standard: Distribution<T> {
-        self.random()
-    }
-
     /// Return a random value via the [`Standard`] distribution.
     ///
     /// # Example
@@ -328,6 +320,14 @@ pub trait Rng: RngCore {
     fn gen_ratio(&mut self, numerator: u32, denominator: u32) -> bool {
         let d = distributions::Bernoulli::from_ratio(numerator, denominator).unwrap();
         self.sample(d)
+    }
+
+    /// Alias for [`Rng::random`].
+    #[inline]
+    #[deprecated(since="0.9.0", note="Renamed to `random` to avoid conflict with the new `gen` keyword in Rust 2024.")]
+    fn gen<T>(&mut self) -> T
+        where Standard: Distribution<T> {
+        self.random()
     }
 }
 

--- a/src/rngs/mock.rs
+++ b/src/rngs/mock.rs
@@ -35,7 +35,7 @@ use serde::{Serialize, Deserialize};
 /// use rand::rngs::mock::StepRng;
 ///
 /// let mut my_rng = StepRng::new(2, 1);
-/// let sample: [u64; 3] = my_rng.gen();
+/// let sample: [u64; 3] = my_rng.random();
 /// assert_eq!(sample, [2, 3, 4]);
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/rngs/reseeding.rs
+++ b/src/rngs/reseeding.rs
@@ -62,10 +62,10 @@ use rand_core::block::{BlockRng, BlockRngCore, CryptoBlockRng};
 /// let prng = ChaCha20Core::from_entropy();
 /// let mut reseeding_rng = ReseedingRng::new(prng, 0, OsRng);
 ///
-/// println!("{}", reseeding_rng.gen::<u64>());
+/// println!("{}", reseeding_rng.random::<u64>());
 ///
 /// let mut cloned_rng = reseeding_rng.clone();
-/// assert!(reseeding_rng.gen::<u64>() != cloned_rng.gen::<u64>());
+/// assert!(reseeding_rng.random::<u64>() != cloned_rng.random::<u64>());
 /// ```
 ///
 /// [`BlockRngCore`]: rand_core::block::BlockRngCore
@@ -283,12 +283,12 @@ mod test {
         let rng = Core::from_rng(&mut zero).unwrap();
         let mut rng1 = ReseedingRng::new(rng, 32 * 4, zero);
 
-        let first: u32 = rng1.gen();
+        let first: u32 = rng1.random();
         for _ in 0..10 {
-            let _ = rng1.gen::<u32>();
+            let _ = rng1.random::<u32>();
         }
 
         let mut rng2 = rng1.clone();
-        assert_eq!(first, rng2.gen::<u32>());
+        assert_eq!(first, rng2.random::<u32>());
     }
 }

--- a/src/rngs/thread.rs
+++ b/src/rngs/thread.rs
@@ -185,7 +185,7 @@ mod test {
     fn test_thread_rng() {
         use crate::Rng;
         let mut r = crate::thread_rng();
-        r.gen::<i32>();
+        r.random::<i32>();
         assert_eq!(r.gen_range(0..1), 0);
     }
 

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -348,7 +348,7 @@ where
     while index < length {
         let weight = weight(index.as_usize()).into();
         if weight > 0.0 {
-            let key = rng.gen::<f64>().powf(1.0 / weight);
+            let key = rng.random::<f64>().powf(1.0 / weight);
             candidates.push(Element { index, key });
         } else if !(weight >= 0.0) {
             return Err(WeightError::InvalidWeight);


### PR DESCRIPTION
Fixes #1435.