### PR TITLE
Add #[track_caller] to methods which panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Bump the MSRV to 1.61.0
 - Rename `Rng::gen` to `Rng::random` to avoid conflict with the new `gen` keyword in Rust 2024 (#1435)
 - Move all benchmarks to new `benches` crate (#1439)
+- Annotate panicking methods with `#[track_caller]` (#1442)
 
 ## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -385,6 +385,7 @@ pub trait SeedableRng: Sized {
     /// [`getrandom`]: https://docs.rs/getrandom
     #[cfg(feature = "getrandom")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "getrandom")))]
+    #[track_caller]
     fn from_entropy() -> Self {
         let mut seed = Self::Seed::default();
         if let Err(err) = getrandom::getrandom(seed.as_mut()) {


### PR DESCRIPTION
Fixes #1437 

This makes it easier to diagnose problems when the preconditions of these methods are not met.

I think I found most of the cases where we can panic based on bad user input. Let me know if I missed any.

We don't use `#[track_caller]` for the panics originating from failing to initialized `thread_rng` as this is more of a "global" problem than a "local" problem.