### PR TITLE
Rename `doc_cfg` to `docsrs` and use `doc_auto_cfg`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [package.metadata.docs.rs]
 # To build locally:
-# RUSTDOCFLAGS="--cfg doc_cfg -Zunstable-options --generate-link-to-definition" cargo +nightly doc --all --all-features --no-deps --open
+# RUSTDOCFLAGS="--cfg docsrs -Zunstable-options --generate-link-to-definition" cargo +nightly doc --all --all-features --no-deps --open
 all-features = true
-rustdoc-args = ["--cfg", "doc_cfg", "-Zunstable-options", "--generate-link-to-definition"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [package.metadata.playground]
 features = ["small_rng", "serde1"]

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -17,9 +17,9 @@ rust-version = "1.61"
 
 [package.metadata.docs.rs]
 # To build locally:
-# RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --all-features --no-deps --open
+# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --open
 all-features = true
-rustdoc-args = ["--cfg", "doc_cfg", "--generate-link-to-definition"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [package.metadata.playground]
 all-features = true

--- a/rand_core/src/blanket_impls.rs
+++ b/rand_core/src/blanket_impls.rs
@@ -44,7 +44,6 @@ impl<'a, R: TryRngCore + ?Sized> TryRngCore for &'a mut R {
 impl<'a, R: TryCryptoRng + ?Sized> TryCryptoRng for &'a mut R {}
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 impl<R: RngCore + ?Sized> RngCore for Box<R> {
     #[inline(always)]
     fn next_u32(&mut self) -> u32 {
@@ -63,11 +62,9 @@ impl<R: RngCore + ?Sized> RngCore for Box<R> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 impl<R: CryptoRng + ?Sized> CryptoRng for Box<R> {}
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 impl<R: TryRngCore + ?Sized> TryRngCore for Box<R> {
     type Error = R::Error;
 
@@ -88,5 +85,4 @@ impl<R: TryRngCore + ?Sized> TryRngCore for Box<R> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 impl<R: TryCryptoRng + ?Sized> TryCryptoRng for Box<R> {}

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -160,7 +160,7 @@ pub fn next_u64_via_fill<R: RngCore + ?Sized>(rng: &mut R) -> u64 {
     u64::from_le_bytes(buf)
 }
 
-/// Implement [`TryRngCore`] for a type implementing [`RngCore`].
+/// Implement [`TryRngCore`][crate::TryRngCore] for a type implementing [`RngCore`].
 ///
 /// Ideally, `rand_core` would define blanket impls for this, but they conflict with blanket impls
 /// for `&mut R` and `Box<R>`, so until specialziation is stabilized, implementer crates
@@ -195,6 +195,10 @@ macro_rules! impl_try_rng_from_rng_core {
 /// Ideally, `rand_core` would define blanket impls for this, but they conflict with blanket impls
 /// for `&mut R` and `Box<R>`, so until specialziation is stabilized, implementer crates
 /// have to implement `TryRngCore` and `TryCryptoRng` directly.
+///
+/// [`TryCryptoRng`]: crate::TryCryptoRng
+/// [`TryRngCore`]: crate::TryRngCore
+/// [`CryptoRng`]: crate::CryptoRng
 #[macro_export]
 macro_rules! impl_try_crypto_rng_from_crypto_rng {
     ($t:ty) => {

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -32,8 +32,7 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
-#![allow(unexpected_cfgs)]
-#![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]
 
 #[cfg(feature = "alloc")]
@@ -446,7 +445,6 @@ pub trait SeedableRng: Sized {
     /// [`getrandom`]: https://docs.rs/getrandom
     /// [`try_from_os_rng`]: SeedableRng::try_from_os_rng
     #[cfg(feature = "getrandom")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "getrandom")))]
     fn from_os_rng() -> Self {
         match Self::try_from_os_rng() {
             Ok(res) => res,
@@ -463,7 +461,6 @@ pub trait SeedableRng: Sized {
     ///
     /// [`getrandom`]: https://docs.rs/getrandom
     #[cfg(feature = "getrandom")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "getrandom")))]
     fn try_from_os_rng() -> Result<Self, getrandom::Error> {
         let mut seed = Self::Seed::default();
         getrandom::getrandom(seed.as_mut())?;

--- a/rand_core/src/os.rs
+++ b/rand_core/src/os.rs
@@ -44,7 +44,6 @@ use getrandom::getrandom;
 /// ```
 ///
 /// [getrandom]: https://crates.io/crates/getrandom
-#[cfg_attr(doc_cfg, doc(cfg(feature = "getrandom")))]
 #[derive(Clone, Copy, Debug, Default)]
 pub struct OsRng;
 

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.61"
 include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--generate-link-to-definition"]
+rustdoc-args = ["--cfg docsrs", "--generate-link-to-definition"]
 
 [features]
 default = ["std"]

--- a/rand_distr/src/binomial.rs
+++ b/rand_distr/src/binomial.rs
@@ -58,7 +58,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 impl Binomial {

--- a/rand_distr/src/cauchy.rs
+++ b/rand_distr/src/cauchy.rs
@@ -58,7 +58,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 impl<F> Cauchy<F>

--- a/rand_distr/src/dirichlet.rs
+++ b/rand_distr/src/dirichlet.rs
@@ -31,7 +31,6 @@ where
 }
 
 /// Error type returned from `DirchletFromGamma::new`.
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DirichletFromGammaError {
     /// Gamma::new(a, 1) failed.
@@ -104,7 +103,6 @@ where
 }
 
 /// Error type returned from `DirchletFromBeta::new`.
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DirichletFromBetaError {
     /// Beta::new(a, b) failed.
@@ -203,7 +201,6 @@ where
 /// let samples = dirichlet.sample(&mut rand::thread_rng());
 /// println!("{:?} is from a Dirichlet([1.0, 2.0, 3.0]) distribution", samples);
 /// ```
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[cfg_attr(feature = "serde_with", serde_as)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Dirichlet<F, const N: usize>
@@ -217,7 +214,6 @@ where
 }
 
 /// Error type returned from `Dirchlet::new`.
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Error {
     /// `alpha.len() < 2`.
@@ -257,7 +253,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 impl<F, const N: usize> Dirichlet<F, N>

--- a/rand_distr/src/exponential.rs
+++ b/rand_distr/src/exponential.rs
@@ -118,7 +118,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 impl<F: Float> Exp<F>

--- a/rand_distr/src/frechet.rs
+++ b/rand_distr/src/frechet.rs
@@ -61,7 +61,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 impl<F> Frechet<F>

--- a/rand_distr/src/gamma.rs
+++ b/rand_distr/src/gamma.rs
@@ -88,7 +88,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -311,7 +310,6 @@ impl fmt::Display for ChiSquaredError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for ChiSquaredError {}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -421,7 +419,6 @@ impl fmt::Display for FisherFError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for FisherFError {}
 
 impl<F> FisherF<F>
@@ -592,7 +589,6 @@ impl fmt::Display for BetaError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for BetaError {}
 
 impl<F> Beta<F>

--- a/rand_distr/src/geometric.rs
+++ b/rand_distr/src/geometric.rs
@@ -53,7 +53,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 impl Geometric {

--- a/rand_distr/src/gumbel.rs
+++ b/rand_distr/src/gumbel.rs
@@ -57,7 +57,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 impl<F> Gumbel<F>

--- a/rand_distr/src/hypergeometric.rs
+++ b/rand_distr/src/hypergeometric.rs
@@ -87,7 +87,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 // evaluate fact(numerator.0)*fact(numerator.1) / fact(denominator.0)*fact(denominator.1)

--- a/rand_distr/src/inverse_gaussian.rs
+++ b/rand_distr/src/inverse_gaussian.rs
@@ -22,7 +22,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 /// The [inverse Gaussian distribution](https://en.wikipedia.org/wiki/Inverse_Gaussian_distribution)

--- a/rand_distr/src/lib.rs
+++ b/rand_distr/src/lib.rs
@@ -21,8 +21,7 @@
 )]
 #![allow(clippy::neg_cmp_op_on_partial_ord)] // suggested fix too verbose
 #![no_std]
-#![allow(unexpected_cfgs)]
-#![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! Generating random samples from probability distributions.
 //!
@@ -102,7 +101,6 @@ pub use rand::distributions::{
 pub use self::binomial::{Binomial, Error as BinomialError};
 pub use self::cauchy::{Cauchy, Error as CauchyError};
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub use self::dirichlet::{Dirichlet, Error as DirichletError};
 pub use self::exponential::{Error as ExpError, Exp, Exp1};
 pub use self::frechet::{Error as FrechetError, Frechet};
@@ -130,13 +128,10 @@ pub use self::unit_sphere::UnitSphere;
 pub use self::weibull::{Error as WeibullError, Weibull};
 pub use self::zipf::{Zeta, ZetaError, Zipf, ZipfError};
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub use rand::distributions::{WeightError, WeightedIndex};
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub use weighted_alias::WeightedAliasIndex;
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub use weighted_tree::WeightedTreeIndex;
 
 pub use num_traits;
@@ -193,10 +188,8 @@ mod test {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub mod weighted_alias;
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub mod weighted_tree;
 
 mod binomial;

--- a/rand_distr/src/normal.rs
+++ b/rand_distr/src/normal.rs
@@ -142,7 +142,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 impl<F> Normal<F>

--- a/rand_distr/src/normal_inverse_gaussian.rs
+++ b/rand_distr/src/normal_inverse_gaussian.rs
@@ -26,7 +26,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 /// The [normal-inverse Gaussian distribution](https://en.wikipedia.org/wiki/Normal-inverse_Gaussian_distribution)

--- a/rand_distr/src/pareto.rs
+++ b/rand_distr/src/pareto.rs
@@ -53,7 +53,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 impl<F> Pareto<F>

--- a/rand_distr/src/pert.rs
+++ b/rand_distr/src/pert.rs
@@ -66,7 +66,6 @@ impl fmt::Display for PertError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for PertError {}
 
 impl<F> Pert<F>

--- a/rand_distr/src/poisson.rs
+++ b/rand_distr/src/poisson.rs
@@ -62,7 +62,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 impl<F> Poisson<F>

--- a/rand_distr/src/skew_normal.rs
+++ b/rand_distr/src/skew_normal.rs
@@ -73,7 +73,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 impl<F> SkewNormal<F>

--- a/rand_distr/src/triangular.rs
+++ b/rand_distr/src/triangular.rs
@@ -64,7 +64,6 @@ impl fmt::Display for TriangularError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for TriangularError {}
 
 impl<F> Triangular<F>

--- a/rand_distr/src/weibull.rs
+++ b/rand_distr/src/weibull.rs
@@ -53,7 +53,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 impl<F> Weibull<F>

--- a/rand_distr/src/weighted_alias.rs
+++ b/rand_distr/src/weighted_alias.rs
@@ -65,7 +65,6 @@ use serde::{Deserialize, Serialize};
 /// [`Vec<u32>`]: Vec
 /// [`Uniform<u32>::sample`]: Distribution::sample
 /// [`Uniform<W>::sample`]: Distribution::sample
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde1",
@@ -279,7 +278,6 @@ where
 /// Trait that must be implemented for weights, that are used with
 /// [`WeightedAliasIndex`]. Currently no guarantees on the correctness of
 /// [`WeightedAliasIndex`] are given for custom implementations of this trait.
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub trait AliasableWeight:
     Sized
     + Copy

--- a/rand_distr/src/weighted_tree.rs
+++ b/rand_distr/src/weighted_tree.rs
@@ -77,14 +77,13 @@ use serde::{Deserialize, Serialize};
 /// ```
 ///
 /// [`WeightedTreeIndex<W>`]: WeightedTreeIndex
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde1",
     serde(bound(serialize = "W: Serialize, W::Sampler: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde1 ",
+    feature = "serde1",
     serde(bound(deserialize = "W: Deserialize<'de>, W::Sampler: Deserialize<'de>"))
 )]
 #[derive(Clone, Default, Debug, PartialEq)]

--- a/rand_distr/src/zipf.rs
+++ b/rand_distr/src/zipf.rs
@@ -73,7 +73,6 @@ impl fmt::Display for ZetaError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for ZetaError {}
 
 impl<F> Zeta<F>
@@ -181,7 +180,6 @@ impl fmt::Display for ZipfError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for ZipfError {}
 
 impl<F> Zipf<F>

--- a/src/distributions/distribution.rs
+++ b/src/distributions/distribution.rs
@@ -186,7 +186,6 @@ where
 /// Sampling a `String` of random characters is not quite the same as collecting
 /// a sequence of chars. This trait contains some helpers.
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub trait DistString {
     /// Append `len` random chars to `string`
     fn append_string<R: Rng + ?Sized>(&self, rng: &mut R, string: &mut String, len: usize);

--- a/src/distributions/float.rs
+++ b/src/distributions/float.rs
@@ -104,8 +104,7 @@ macro_rules! float_impls {
             }
         }
 
-        $(#[cfg($meta)]
-        #[cfg_attr(doc_cfg, doc(cfg($meta)))])?
+        $(#[cfg($meta)])?
         impl Distribution<$ty> for Standard {
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $ty {
                 // Multiply-based method; 24/53 random bits; [0, 1) interval.
@@ -121,8 +120,7 @@ macro_rules! float_impls {
             }
         }
 
-        $(#[cfg($meta)]
-        #[cfg_attr(doc_cfg, doc(cfg($meta)))])?
+        $(#[cfg($meta)])?
         impl Distribution<$ty> for OpenClosed01 {
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $ty {
                 // Multiply-based method; 24/53 random bits; (0, 1] interval.
@@ -139,8 +137,7 @@ macro_rules! float_impls {
             }
         }
 
-        $(#[cfg($meta)]
-        #[cfg_attr(doc_cfg, doc(cfg($meta)))])?
+        $(#[cfg($meta)])?
         impl Distribution<$ty> for Open01 {
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $ty {
                 // Transmute-based method; 23/52 random bits; (0, 1) interval.

--- a/src/distributions/integer.rs
+++ b/src/distributions/integer.rs
@@ -127,7 +127,6 @@ impl_nzint!(NonZeroIsize, NonZeroIsize::new);
 macro_rules! x86_intrinsic_impl {
     ($meta:meta, $($intrinsic:ident),+) => {$(
         #[cfg($meta)]
-        #[cfg_attr(doc_cfg, doc(cfg($meta)))]
         impl Distribution<$intrinsic> for Standard {
             #[inline]
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $intrinsic {
@@ -149,8 +148,6 @@ macro_rules! simd_impl {
         ///
         /// [`simd_support`]: https://github.com/rust-random/rand#crate-features
         #[cfg(feature = "simd_support")]
-        // TODO: as doc_cfg/doc_auto_cfg mature ensure they catch this
-        #[cfg_attr(doc_cfg, doc(cfg(feature = "simd_support")))]
         impl<const LANES: usize> Distribution<Simd<$ty, LANES>> for Standard
         where
             LaneCount<LANES>: SupportedLaneCount,

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -111,7 +111,6 @@ pub mod uniform;
 
 pub use self::bernoulli::{Bernoulli, BernoulliError};
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub use self::distribution::DistString;
 pub use self::distribution::{DistIter, DistMap, Distribution};
 pub use self::float::{Open01, OpenClosed01};

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -96,7 +96,6 @@ impl Distribution<char> for Standard {
 /// Note: the `String` is potentially left with excess capacity; optionally the
 /// user may call `string.shrink_to_fit()` afterwards.
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 impl DistString for Standard {
     fn append_string<R: Rng + ?Sized>(&self, rng: &mut R, s: &mut String, len: usize) {
         // A char is encoded with at most four bytes, thus this reservation is
@@ -127,7 +126,6 @@ impl Distribution<u8> for Alphanumeric {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 impl DistString for Alphanumeric {
     fn append_string<R: Rng + ?Sized>(&self, rng: &mut R, string: &mut String, len: usize) {
         unsafe {
@@ -175,7 +173,6 @@ impl Distribution<bool> for Standard {
 /// [`_mm_blendv_epi8`]: https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_blendv_epi8&ig_expand=514/
 /// [`simd_support`]: https://github.com/rust-random/rand#crate-features
 #[cfg(feature = "simd_support")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "simd_support")))]
 impl<T, const LANES: usize> Distribution<Mask<T, LANES>> for Standard
 where
     T: MaskElement + Default,

--- a/src/distributions/slice.rs
+++ b/src/distributions/slice.rs
@@ -129,7 +129,6 @@ impl std::error::Error for EmptySlice {}
 /// Note: the `String` is potentially left with excess capacity; optionally the
 /// user may call `string.shrink_to_fit()` afterwards.
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 impl<'a> super::DistString for Slice<'a, char> {
     fn append_string<R: crate::Rng + ?Sized>(&self, rng: &mut R, string: &mut String, len: usize) {
         // Get the max char length to minimize extra space.

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -140,7 +140,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 #[cfg(feature = "serde1")]
@@ -676,7 +675,6 @@ macro_rules! uniform_simd_int_impl {
         // implement it manually.
 
         #[cfg(feature = "simd_support")]
-        #[cfg_attr(doc_cfg, doc(cfg(feature = "simd_support")))]
         impl<const LANES: usize> SampleUniform for Simd<$ty, LANES>
         where
             LaneCount<LANES>: SupportedLaneCount,
@@ -688,7 +686,6 @@ macro_rules! uniform_simd_int_impl {
         }
 
         #[cfg(feature = "simd_support")]
-        #[cfg_attr(doc_cfg, doc(cfg(feature = "simd_support")))]
         impl<const LANES: usize> UniformSampler for UniformInt<Simd<$ty, LANES>>
         where
             LaneCount<LANES>: SupportedLaneCount,
@@ -864,7 +861,6 @@ impl UniformSampler for UniformChar {
 /// includes non ascii chars; optionally the user may call
 /// `string.shrink_to_fit()` afterwards.
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 impl super::DistString for Uniform<char> {
     fn append_string<R: Rng + ?Sized>(
         &self,
@@ -912,14 +908,12 @@ pub struct UniformFloat<X> {
 
 macro_rules! uniform_float_impl {
     ($($meta:meta)?, $ty:ty, $uty:ident, $f_scalar:ident, $u_scalar:ident, $bits_to_discard:expr) => {
-        $(#[cfg($meta)]
-        #[cfg_attr(doc_cfg, doc(cfg($meta)))])?
+        $(#[cfg($meta)])?
         impl SampleUniform for $ty {
             type Sampler = UniformFloat<$ty>;
         }
 
-        $(#[cfg($meta)]
-        #[cfg_attr(doc_cfg, doc(cfg($meta)))])?
+        $(#[cfg($meta)])?
         impl UniformSampler for UniformFloat<$ty> {
             type X = $ty;
 

--- a/src/distributions/weighted_index.rs
+++ b/src/distributions/weighted_index.rs
@@ -82,7 +82,6 @@ use serde::{Deserialize, Serialize};
 /// [`RngCore`]: crate::RngCore
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub struct WeightedIndex<X: SampleUniform + PartialOrd> {
     cumulative_weights: Vec<X>,
     total_weight: X,
@@ -702,7 +701,6 @@ mod test {
 }
 
 /// Errors returned by weighted distributions
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WeightError {
     /// The input weight sequence is empty, too long, or wrongly ordered

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,7 @@
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 #![no_std]
 #![cfg_attr(feature = "simd_support", feature(portable_simd))]
-#![allow(unexpected_cfgs)]
-#![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(
     clippy::float_cmp,
     clippy::neg_cmp_op_on_partial_ord,
@@ -157,10 +156,6 @@ use crate::distributions::{Distribution, Standard};
 /// [`Standard`]: distributions::Standard
 /// [`ThreadRng`]: rngs::ThreadRng
 #[cfg(all(feature = "std", feature = "std_rng", feature = "getrandom"))]
-#[cfg_attr(
-    doc_cfg,
-    doc(cfg(all(feature = "std", feature = "std_rng", feature = "getrandom")))
-)]
 #[inline]
 pub fn random<T>() -> T
 where

--- a/src/rngs/mod.rs
+++ b/src/rngs/mod.rs
@@ -121,6 +121,5 @@ pub use self::std::StdRng;
 #[cfg(all(feature = "std", feature = "std_rng", feature = "getrandom"))]
 pub use self::thread::ThreadRng;
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "getrandom")))]
 #[cfg(feature = "getrandom")]
 pub use rand_core::OsRng;

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -38,7 +38,6 @@ type Rng = super::xoshiro128plusplus::Xoshiro128PlusPlus;
 /// [`StdRng`]: crate::rngs::StdRng
 /// [rand_chacha]: https://crates.io/crates/rand_chacha
 /// [rand_xoshiro]: https://crates.io/crates/rand_xoshiro
-#[cfg_attr(doc_cfg, doc(cfg(feature = "small_rng")))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SmallRng(Rng);
 

--- a/src/rngs/std.rs
+++ b/src/rngs/std.rs
@@ -30,7 +30,6 @@ use rand_chacha::ChaCha12Rng as Rng;
 ///
 /// [rand_chacha]: https://crates.io/crates/rand_chacha
 /// [rand issue]: https://github.com/rust-random/rand/issues/932
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std_rng")))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StdRng(Rng);
 

--- a/src/rngs/thread.rs
+++ b/src/rngs/thread.rs
@@ -76,10 +76,6 @@ const THREAD_RNG_RESEED_THRESHOLD: u64 = 1024 * 64;
 ///
 /// [`ReseedingRng`]: crate::rngs::ReseedingRng
 /// [`StdRng`]: crate::rngs::StdRng
-#[cfg_attr(
-    doc_cfg,
-    doc(cfg(all(feature = "std", feature = "std_rng", feature = "getrandom")))
-)]
 #[derive(Clone)]
 pub struct ThreadRng {
     // Rc is explicitly !Send and !Sync
@@ -135,10 +131,6 @@ thread_local!(
 /// println!("A simulated die roll: {}", rng.gen_range(1..=6));
 /// # }
 /// ```
-#[cfg_attr(
-    doc_cfg,
-    doc(cfg(all(feature = "std", feature = "std_rng", feature = "getrandom")))
-)]
 pub fn thread_rng() -> ThreadRng {
     let rng = THREAD_RNG_KEY.with(|t| t.clone());
     ThreadRng { rng }

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -282,7 +282,6 @@ where
 ///
 /// This implementation uses `O(length + amount)` space and `O(length)` time.
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 pub fn sample_weighted<R, F, X>(
     rng: &mut R,
     length: usize,

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -28,7 +28,6 @@
 
 mod coin_flipper;
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub mod index;
 
 mod increasing_uniform;
@@ -122,7 +121,6 @@ pub trait IndexedRandom: Index<usize> {
     /// }
     /// ```
     #[cfg(feature = "alloc")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
     fn choose_multiple<R>(&self, rng: &mut R, amount: usize) -> SliceChooseIter<Self, Self::Output>
     where
         Self::Output: Sized,
@@ -166,7 +164,6 @@ pub trait IndexedRandom: Index<usize> {
     /// [`choose_weighted_mut`]: IndexedMutRandom::choose_weighted_mut
     /// [`distributions::WeightedIndex`]: crate::distributions::WeightedIndex
     #[cfg(feature = "alloc")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
     fn choose_weighted<R, F, B, X>(
         &self,
         rng: &mut R,
@@ -218,7 +215,6 @@ pub trait IndexedRandom: Index<usize> {
     // Note: this is feature-gated on std due to usage of f64::powf.
     // If necessary, we may use alloc+libm as an alternative (see PR #1089).
     #[cfg(feature = "std")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
     fn choose_multiple_weighted<R, F, X>(
         &self,
         rng: &mut R,
@@ -288,7 +284,6 @@ pub trait IndexedMutRandom: IndexedRandom + IndexMut<usize> {
     /// [`choose_weighted`]: IndexedRandom::choose_weighted
     /// [`distributions::WeightedIndex`]: crate::distributions::WeightedIndex
     #[cfg(feature = "alloc")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
     fn choose_weighted_mut<R, F, B, X>(
         &mut self,
         rng: &mut R,
@@ -585,7 +580,6 @@ pub trait IteratorRandom: Iterator + Sized {
     /// Complexity is `O(n)` where `n` is the length of the iterator.
     /// For slices, prefer [`IndexedRandom::choose_multiple`].
     #[cfg(feature = "alloc")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
     fn choose_multiple<R>(mut self, rng: &mut R, amount: usize) -> Vec<Self::Item>
     where
         R: Rng + ?Sized,
@@ -672,7 +666,6 @@ impl<I> IteratorRandom for I where I: Iterator + Sized {}
 /// This struct is created by
 /// [`IndexedRandom::choose_multiple`](trait.IndexedRandom.html#tymethod.choose_multiple).
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[derive(Debug)]
 pub struct SliceChooseIter<'a, S: ?Sized + 'a, T: 'a> {
     slice: &'a S,
@@ -681,7 +674,6 @@ pub struct SliceChooseIter<'a, S: ?Sized + 'a, T: 'a> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 impl<'a, S: Index<usize, Output = T> + ?Sized + 'a, T: 'a> Iterator for SliceChooseIter<'a, S, T> {
     type Item = &'a T;
 
@@ -696,7 +688,6 @@ impl<'a, S: Index<usize, Output = T> + ?Sized + 'a, T: 'a> Iterator for SliceCho
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 impl<'a, S: Index<usize, Output = T> + ?Sized + 'a, T: 'a> ExactSizeIterator
     for SliceChooseIter<'a, S, T>
 {


### PR DESCRIPTION
Renaming the configuration option also allows to enable back the `unexpected_cfgs` lint.

I've checked generated docs and it does not look like using `doc_auto_cfg` instead of explicit `doc_cfg`s causes any issues. The check was by no means exhaustive, but most cases look perfectly good.