### PR TITLE
Tweak docs CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,17 +12,25 @@ permissions:
 jobs:
   check-doc:
     name: Check doc
+    env:
+      RUSDOCTFLAGS: "-Dwarnings --cfg docsrs -Zunstable-options --generate-link-to-definition"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
-      - run: cargo install cargo-deadlinks
-      - name: doc (rand)
-        env:
-          RUSTDOCFLAGS: --cfg doc_cfg
-        # --all builds all crates, but with default features for other crates (okay in this case)
-        run: cargo deadlinks --ignore-fragments -- --all --features nightly,serde1,getrandom,small_rng
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+      - name: rand
+        run: cargo doc --all-features --no-deps
+      - name: rand_core
+        run: cargo doc --all-features --package rand_core --no-deps
+      - name: rand_distr
+        run: cargo doc --all-features --package rand_distr --no-deps
+      - name: rand_chacha
+        run: cargo doc --all-features --package rand_chacha --no-deps
+      - name: rand_pcg
+        run: cargo doc --all-features --package rand_pcg --no-deps
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ permissions:
 jobs:
   check-doc:
     name: Check doc
-    env:
-      RUSDOCTFLAGS: "-Dwarnings --cfg docsrs -Zunstable-options --generate-link-to-definition"
     runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: "-Dwarnings --cfg docsrs -Zunstable-options --generate-link-to-definition"
     steps:
       - uses: actions/checkout@v4
       - name: Install toolchain

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -160,7 +160,7 @@ pub fn next_u64_via_fill<R: RngCore + ?Sized>(rng: &mut R) -> u64 {
     u64::from_le_bytes(buf)
 }
 
-/// Implement [`TryRngCore`] for a type implementing [`RngCore`].
+/// Implement [`TryRngCore`][crate::TryRngCore] for a type implementing [`RngCore`].
 ///
 /// Ideally, `rand_core` would define blanket impls for this, but they conflict with blanket impls
 /// for `&mut R` and `Box<R>`, so until specialziation is stabilized, implementer crates

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -160,7 +160,7 @@ pub fn next_u64_via_fill<R: RngCore + ?Sized>(rng: &mut R) -> u64 {
     u64::from_le_bytes(buf)
 }
 
-/// Implement [`TryRngCore`][crate::TryRngCore] for a type implementing [`RngCore`].
+/// Implement [`TryRngCore`] for a type implementing [`RngCore`].
 ///
 /// Ideally, `rand_core` would define blanket impls for this, but they conflict with blanket impls
 /// for `&mut R` and `Box<R>`, so until specialziation is stabilized, implementer crates


### PR DESCRIPTION
The previous job haven't caught bad links in `rand_core`. The new job uses `cargo doc` directly instead of relying on `cargo deadlinks`, which should improve CI times a bit. We will not be able to check liveness of external links this way, but IIUC we did not do it either way.