### PR TITLE
Fix benches CI job

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -19,8 +19,8 @@ jobs:
           toolchain: nightly
           components: clippy, rustfmt
       - name: Rustfmt
-        run: cargo fmt --all -- --check
+        run: cargo fmt -- --check
       - name: Clippy
-        run: cargo clippy --all --all-targets -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
       - name: Build
         run: RUSTFLAGS=-Dwarnings cargo build --all-targets

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   benches:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./benches
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
In the previous version the commands were executed for the root workspace, from which the `benches` crate is excluded.