### PR TITLE
UniformFloat: allow inclusion of high in all cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Move all benchmarks to new `benches` crate (#1439)
 - Annotate panicking methods with `#[track_caller]` (#1442, #1447)
 - Enable feature `small_rng` by default (#1455)
+- Allow `UniformFloat::new` samples and `UniformFloat::sample_single` to yield `high` (#1462)
 
 ## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -931,9 +931,7 @@ macro_rules! uniform_float_impl {
                 if !(low.all_lt(high)) {
                     return Err(Error::EmptyRange);
                 }
-                let max_rand = <$ty>::splat(
-                    ($u_scalar::MAX >> $bits_to_discard).into_float_with_exponent(0) - 1.0,
-                );
+                let max_rand = <$ty>::splat(1.0 as $f_scalar - $f_scalar::EPSILON);
 
                 let mut scale = high - low;
                 if !(scale.all_finite()) {
@@ -967,9 +965,7 @@ macro_rules! uniform_float_impl {
                 if !low.all_le(high) {
                     return Err(Error::EmptyRange);
                 }
-                let max_rand = <$ty>::splat(
-                    ($u_scalar::MAX >> $bits_to_discard).into_float_with_exponent(0) - 1.0,
-                );
+                let max_rand = <$ty>::splat(1.0 as $f_scalar - $f_scalar::EPSILON);
 
                 let mut scale = (high - low) / max_rand;
                 if !scale.all_finite() {

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -51,7 +51,8 @@
 //! Those methods should include an assertion to check the range is valid (i.e.
 //! `low < high`). The example below merely wraps another back-end.
 //!
-//! The `new`, `new_inclusive` and `sample_single` functions use arguments of
+//! The `new`, `new_inclusive`, `sample_single` and `sample_single_inclusive`
+//! functions use arguments of
 //! type `SampleBorrow<X>` to support passing in values by reference or
 //! by value. In the implementation of these functions, you can choose to
 //! simply use the reference returned by [`SampleBorrow::borrow`], or you can choose
@@ -207,6 +208,11 @@ impl<X: SampleUniform> Uniform<X> {
     /// Create a new `Uniform` instance, which samples uniformly from the half
     /// open range `[low, high)` (excluding `high`).
     ///
+    /// For discrete types (e.g. integers), samples will always be strictly less
+    /// than `high`. For (approximations of) continuous types (e.g. `f32`, `f64`),
+    /// samples may equal `high` due to loss of precision but may not be
+    /// greater than `high`.
+    ///
     /// Fails if `low >= high`, or if `low`, `high` or the range `high - low` is
     /// non-finite. In release mode, only the range is checked.
     pub fn new<B1, B2>(low: B1, high: B2) -> Result<Uniform<X>, Error>
@@ -265,6 +271,11 @@ pub trait UniformSampler: Sized {
 
     /// Construct self, with inclusive lower bound and exclusive upper bound `[low, high)`.
     ///
+    /// For discrete types (e.g. integers), samples will always be strictly less
+    /// than `high`. For (approximations of) continuous types (e.g. `f32`, `f64`),
+    /// samples may equal `high` due to loss of precision but may not be
+    /// greater than `high`.
+    ///
     /// Usually users should not call this directly but prefer to use
     /// [`Uniform::new`].
     fn new<B1, B2>(low: B1, high: B2) -> Result<Self, Error>
@@ -286,6 +297,11 @@ pub trait UniformSampler: Sized {
 
     /// Sample a single value uniformly from a range with inclusive lower bound
     /// and exclusive upper bound `[low, high)`.
+    ///
+    /// For discrete types (e.g. integers), samples will always be strictly less
+    /// than `high`. For (approximations of) continuous types (e.g. `f32`, `f64`),
+    /// samples may equal `high` due to loss of precision but may not be
+    /// greater than `high`.
     ///
     /// By default this is implemented using
     /// `UniformSampler::new(low, high).sample(rng)`. However, for some types

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -1592,10 +1592,9 @@ mod tests {
     #[cfg(all(feature = "std", panic = "unwind"))]
     fn test_float_assertions() {
         use super::SampleUniform;
-        use std::panic::catch_unwind;
-        fn range<T: SampleUniform>(low: T, high: T) {
+        fn range<T: SampleUniform>(low: T, high: T) -> Result<T, Error> {
             let mut rng = crate::test::rng(253);
-            T::Sampler::sample_single(low, high, &mut rng).unwrap();
+            T::Sampler::sample_single(low, high, &mut rng)
         }
 
         macro_rules! t {
@@ -1618,10 +1617,10 @@ mod tests {
                     for lane in 0..<$ty>::LEN {
                         let low = <$ty>::splat(0.0 as $f_scalar).replace(lane, low_scalar);
                         let high = <$ty>::splat(1.0 as $f_scalar).replace(lane, high_scalar);
-                        assert!(catch_unwind(|| range(low, high)).is_err());
+                        assert!(range(low, high).is_err());
                         assert!(Uniform::new(low, high).is_err());
                         assert!(Uniform::new_inclusive(low, high).is_err());
-                        assert!(catch_unwind(|| range(low, low)).is_err());
+                        assert!(range(low, low).is_err());
                         assert!(Uniform::new(low, low).is_err());
                     }
                 }

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -939,7 +939,7 @@ macro_rules! uniform_float_impl {
                 }
 
                 loop {
-                    let mask = (scale * max_rand + low).ge_mask(high);
+                    let mask = (scale * max_rand + low).gt_mask(high);
                     if !mask.any() {
                         break;
                     }
@@ -1461,14 +1461,14 @@ mod tests {
                         let my_incl_uniform = Uniform::new_inclusive(low, high).unwrap();
                         for _ in 0..100 {
                             let v = rng.sample(my_uniform).extract(lane);
-                            assert!(low_scalar <= v && v < high_scalar);
+                            assert!(low_scalar <= v && v <= high_scalar);
                             let v = rng.sample(my_incl_uniform).extract(lane);
                             assert!(low_scalar <= v && v <= high_scalar);
                             let v =
                                 <$ty as SampleUniform>::Sampler::sample_single(low, high, &mut rng)
                                     .unwrap()
                                     .extract(lane);
-                            assert!(low_scalar <= v && v < high_scalar);
+                            assert!(low_scalar <= v && v <= high_scalar);
                             let v = <$ty as SampleUniform>::Sampler::sample_single_inclusive(
                                 low, high, &mut rng,
                             )
@@ -1506,12 +1506,12 @@ mod tests {
                             low_scalar
                         );
 
-                        assert!(max_rng.sample(my_uniform).extract(lane) < high_scalar);
+                        assert!(max_rng.sample(my_uniform).extract(lane) <= high_scalar);
                         assert!(max_rng.sample(my_incl_uniform).extract(lane) <= high_scalar);
                         // sample_single cannot cope with max_rng:
                         // assert!(<$ty as SampleUniform>::Sampler
                         //     ::sample_single(low, high, &mut max_rng).unwrap()
-                        //     .extract(lane) < high_scalar);
+                        //     .extract(lane) <= high_scalar);
                         assert!(
                             <$ty as SampleUniform>::Sampler::sample_single_inclusive(
                                 low,
@@ -1539,7 +1539,7 @@ mod tests {
                                 )
                                 .unwrap()
                                 .extract(lane)
-                                    < high_scalar
+                                    <= high_scalar
                             );
                         }
                     }

--- a/src/distributions/utils.rs
+++ b/src/distributions/utils.rs
@@ -218,9 +218,7 @@ pub(crate) trait FloatSIMDUtils {
     fn all_finite(self) -> bool;
 
     type Mask;
-    fn finite_mask(self) -> Self::Mask;
     fn gt_mask(self, other: Self) -> Self::Mask;
-    fn ge_mask(self, other: Self) -> Self::Mask;
 
     // Decrease all lanes where the mask is `true` to the next lower value
     // representable by the floating-point type. At least one of the lanes
@@ -293,18 +291,8 @@ macro_rules! scalar_float_impl {
             }
 
             #[inline(always)]
-            fn finite_mask(self) -> Self::Mask {
-                self.is_finite()
-            }
-
-            #[inline(always)]
             fn gt_mask(self, other: Self) -> Self::Mask {
                 self > other
-            }
-
-            #[inline(always)]
-            fn ge_mask(self, other: Self) -> Self::Mask {
-                self >= other
             }
 
             #[inline(always)]
@@ -369,18 +357,8 @@ macro_rules! simd_impl {
             }
 
             #[inline(always)]
-            fn finite_mask(self) -> Self::Mask {
-                self.is_finite()
-            }
-
-            #[inline(always)]
             fn gt_mask(self, other: Self) -> Self::Mask {
                 self.simd_gt(other)
-            }
-
-            #[inline(always)]
-            fn ge_mask(self, other: Self) -> Self::Mask {
-                self.simd_ge(other)
             }
 
             #[inline(always)]


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Fix #1299 by removing logic specific to ensuring that we emulate a closed range by excluding `high` from the result.

# Motivation

Fix #1299.

Additional motivation: floating-point types are approximations of continuous (real) numbers. Although one might expect that `rng.gen_range(0f32..1f32)` is strictly less than `1f32`, it can also be seen as an approximation of the real range `[0, 1)` which includes values whose nearest approximation under `f32` is `1f32`.

In general, one can always expect that floating-point numbers may round up/down to the nearest representable value, hence this change is not expected to affect many users.

`sample_single` was changed (see below) as a simplification, and to match the new behaviour of `new`.

# Details

Specific to floats (i.e. `UniformFloat`),

- `new` sets `scale = high - low` (unchanged) then ensures that `low + scale * max_rand <= high` (previously: ensure `< high`)
- `new_inclusive` sets `scale = (high - low) / (1 - ε)` then ensures that `low + scale * max_rand <= high` (unchanged)
- `sample_single` is now equivalent to `sample_single_inclusive` (previously: use rejection sampling to ensure `sample < high`)
- `sample_single_inclusive` is unchanged: it yields `low + (high-low) * Standard.samgle(rng)`

Note: `new` attempts to ensure that `high` may be yielded; `sample_single_inclusive` does not. This has not changed, but is a little surprising.