### PR TITLE
Add serde1 feature on SmallRng

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Annotate panicking methods with `#[track_caller]` (#1442, #1447)
 - Enable feature `small_rng` by default (#1455)
 - Allow `UniformFloat::new` samples and `UniformFloat::sample_single` to yield `high` (#1462)
+- Added a `serde1` feature and added Serialize/Deserialize to `SmallRng` ()
 
 ## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Annotate panicking methods with `#[track_caller]` (#1442, #1447)
 - Enable feature `small_rng` by default (#1455)
 - Allow `UniformFloat::new` samples and `UniformFloat::sample_single` to yield `high` (#1462)
-- Added a `serde1` feature and added Serialize/Deserialize to `SmallRng` (1467)
+- Added a `serde1` feature and added Serialize/Deserialize to `SmallRng` (#1467)
 
 ## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Annotate panicking methods with `#[track_caller]` (#1442, #1447)
 - Enable feature `small_rng` by default (#1455)
 - Allow `UniformFloat::new` samples and `UniformFloat::sample_single` to yield `high` (#1462)
-- Added a `serde1` feature and added Serialize/Deserialize to `SmallRng` ()
+- Added a `serde1` feature and added Serialize/Deserialize to `SmallRng` (1467)
 
 ## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -9,6 +9,8 @@
 //! A small fast RNG
 
 use rand_core::{RngCore, SeedableRng};
+#[cfg(feature = "serde1")]
+use serde::{Deserialize, Serialize};
 
 #[cfg(target_pointer_width = "64")]
 type Rng = super::xoshiro256plusplus::Xoshiro256PlusPlus;

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -75,7 +75,7 @@ type Rng = super::xoshiro128plusplus::Xoshiro128PlusPlus;
 /// [rand_xoshiro]: https://crates.io/crates/rand_xoshiro
 /// [`rand_chacha::ChaCha8Rng`]: https://docs.rs/rand_chacha/latest/rand_chacha/struct.ChaCha8Rng.html
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct SmallRng(Rng);
 
 impl SeedableRng for SmallRng {

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -75,6 +75,7 @@ type Rng = super::xoshiro128plusplus::Xoshiro128PlusPlus;
 /// [rand_xoshiro]: https://crates.io/crates/rand_xoshiro
 /// [`rand_chacha::ChaCha8Rng`]: https://docs.rs/rand_chacha/latest/rand_chacha/struct.ChaCha8Rng.html
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct SmallRng(Rng);
 
 impl SeedableRng for SmallRng {


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary
Added a `serde1` feature and added `Serialize`/`Deserialize` to `SmallRng`

# Motivation
Need to save and load random generator state on simulation to have reproducible generations. Internal implementations of SmallRng (Xoshiro256PlusPlus and Xoshiro128PlusPlus) can handle serde feature. It is strange that wrapper can not afford it.

# Details
Add `#[derive(Serialize, Deserialize)]` to `struct SmallRng`