### PR TITLE
Rng::gen_index; no usize for Standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Allow `UniformFloat::new` samples and `UniformFloat::sample_single` to yield `high` (#1462)
 - Fix portability of `rand::distributions::Slice` (#1469)
 - Rename `rand::distributions` to `rand::distr` (#1470)
+- Add `Rng::gen_index` (#1471)
+- Remove support for generating `isize` and `usize` values with `Standard`, `Uniform` and `Fill` and usage as a `WeightedAliasIndex` weight (#1471)
 
 ## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Allow `UniformFloat::new` samples and `UniformFloat::sample_single` to yield `high` (#1462)
 - Fix portability of `rand::distributions::Slice` (#1469)
 - Rename `rand::distributions` to `rand::distr` (#1470)
-- Add `Rng::gen_index` (#1471)
+- Add `Rng::gen_index` and `UniformUsize` (#1471)
 - Remove support for generating `isize` and `usize` values with `Standard`, `Uniform` and `Fill` and usage as a `WeightedAliasIndex` weight (#1471)
 
 ## [0.9.0-alpha.1] - 2024-03-18

--- a/benches/benches/base_distributions.rs
+++ b/benches/benches/base_distributions.rs
@@ -136,11 +136,6 @@ distr_int!(distr_uniform_i16, i16, Uniform::new(-500i16, 2000).unwrap());
 distr_int!(distr_uniform_i32, i32, Uniform::new(-200_000_000i32, 800_000_000).unwrap());
 distr_int!(distr_uniform_i64, i64, Uniform::new(3i64, 123_456_789_123).unwrap());
 distr_int!(distr_uniform_i128, i128, Uniform::new(-123_456_789_123i128, 123_456_789_123_456_789).unwrap());
-distr_int!(distr_uniform_usize16, usize, Uniform::new(0usize, 0xb9d7).unwrap());
-distr_int!(distr_uniform_usize32, usize, Uniform::new(0usize, 0x548c0f43).unwrap());
-#[cfg(target_pointer_width = "64")]
-distr_int!(distr_uniform_usize64, usize, Uniform::new(0usize, 0x3a42714f2bf927a8).unwrap());
-distr_int!(distr_uniform_isize, isize, Uniform::new(-1060478432isize, 1858574057).unwrap());
 
 distr_float!(distr_uniform_f32, f32, Uniform::new(2.26f32, 2.319).unwrap());
 distr_float!(distr_uniform_f64, f64, Uniform::new(2.26f64, 2.319).unwrap());

--- a/rand_distr/src/weighted_alias.rs
+++ b/rand_distr/src/weighted_alias.rs
@@ -359,13 +359,11 @@ macro_rules! impl_weight_for_int {
 
 impl_weight_for_float!(f64);
 impl_weight_for_float!(f32);
-impl_weight_for_int!(usize);
 impl_weight_for_int!(u128);
 impl_weight_for_int!(u64);
 impl_weight_for_int!(u32);
 impl_weight_for_int!(u16);
 impl_weight_for_int!(u8);
-impl_weight_for_int!(isize);
 impl_weight_for_int!(i128);
 impl_weight_for_int!(i64);
 impl_weight_for_int!(i32);

--- a/src/distr/integer.rs
+++ b/src/distr/integer.rs
@@ -19,8 +19,8 @@ use core::arch::x86_64::__m512i;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::{__m128i, __m256i};
 use core::num::{
-    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
-    NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
+    NonZeroU32, NonZeroU64, NonZeroU8,
 };
 #[cfg(feature = "simd_support")]
 use core::simd::*;
@@ -63,20 +63,6 @@ impl Distribution<u128> for Standard {
     }
 }
 
-impl Distribution<usize> for Standard {
-    #[inline]
-    #[cfg(any(target_pointer_width = "32", target_pointer_width = "16"))]
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
-        rng.next_u32() as usize
-    }
-
-    #[inline]
-    #[cfg(target_pointer_width = "64")]
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
-        rng.next_u64() as usize
-    }
-}
-
 macro_rules! impl_int_from_uint {
     ($ty:ty, $uty:ty) => {
         impl Distribution<$ty> for Standard {
@@ -93,7 +79,6 @@ impl_int_from_uint! { i16, u16 }
 impl_int_from_uint! { i32, u32 }
 impl_int_from_uint! { i64, u64 }
 impl_int_from_uint! { i128, u128 }
-impl_int_from_uint! { isize, usize }
 
 macro_rules! impl_nzint {
     ($ty:ty, $new:path) => {
@@ -114,14 +99,12 @@ impl_nzint!(NonZeroU16, NonZeroU16::new);
 impl_nzint!(NonZeroU32, NonZeroU32::new);
 impl_nzint!(NonZeroU64, NonZeroU64::new);
 impl_nzint!(NonZeroU128, NonZeroU128::new);
-impl_nzint!(NonZeroUsize, NonZeroUsize::new);
 
 impl_nzint!(NonZeroI8, NonZeroI8::new);
 impl_nzint!(NonZeroI16, NonZeroI16::new);
 impl_nzint!(NonZeroI32, NonZeroI32::new);
 impl_nzint!(NonZeroI64, NonZeroI64::new);
 impl_nzint!(NonZeroI128, NonZeroI128::new);
-impl_nzint!(NonZeroIsize, NonZeroIsize::new);
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 macro_rules! x86_intrinsic_impl {
@@ -163,7 +146,7 @@ macro_rules! simd_impl {
 }
 
 #[cfg(feature = "simd_support")]
-simd_impl!(u8, i8, u16, i16, u32, i32, u64, i64, usize, isize);
+simd_impl!(u8, i8, u16, i16, u32, i32, u64, i64);
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 x86_intrinsic_impl!(
@@ -191,14 +174,12 @@ mod tests {
     fn test_integers() {
         let mut rng = crate::test::rng(806);
 
-        rng.sample::<isize, _>(Standard);
         rng.sample::<i8, _>(Standard);
         rng.sample::<i16, _>(Standard);
         rng.sample::<i32, _>(Standard);
         rng.sample::<i64, _>(Standard);
         rng.sample::<i128, _>(Standard);
 
-        rng.sample::<usize, _>(Standard);
         rng.sample::<u8, _>(Standard);
         rng.sample::<u16, _>(Standard);
         rng.sample::<u32, _>(Standard);
@@ -237,17 +218,6 @@ mod tests {
                 296930161868957086625409848350820761097,
                 145644820879247630242265036535529306392,
                 111087889832015897993126088499035356354,
-            ],
-        );
-        #[cfg(any(target_pointer_width = "32", target_pointer_width = "16"))]
-        test_samples(0usize, &[2220326409, 2575017975, 2018088303]);
-        #[cfg(target_pointer_width = "64")]
-        test_samples(
-            0usize,
-            &[
-                11059617991457472009,
-                16096616328739788143,
-                1487364411147516184,
             ],
         );
 

--- a/src/distr/slice.rs
+++ b/src/distr/slice.rs
@@ -8,39 +8,10 @@
 
 use core::num::NonZeroUsize;
 
-use crate::distr::{Distribution, Uniform};
-use crate::Rng;
+use crate::distr::uniform::{UniformSampler, UniformUsize};
+use crate::distr::Distribution;
 #[cfg(feature = "alloc")]
 use alloc::string::String;
-
-#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
-compile_error!("unsupported pointer width");
-
-#[derive(Debug, Clone, Copy)]
-enum UniformUsize {
-    U32(Uniform<u32>),
-    #[cfg(target_pointer_width = "64")]
-    U64(Uniform<u64>),
-}
-
-impl UniformUsize {
-    pub fn new(ubound: usize) -> Result<Self, super::uniform::Error> {
-        #[cfg(target_pointer_width = "64")]
-        if ubound > (u32::MAX as usize) {
-            return Uniform::new(0, ubound as u64).map(UniformUsize::U64);
-        }
-
-        Uniform::new(0, ubound as u32).map(UniformUsize::U32)
-    }
-
-    pub fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
-        match self {
-            UniformUsize::U32(uu) => uu.sample(rng) as usize,
-            #[cfg(target_pointer_width = "64")]
-            UniformUsize::U64(uu) => uu.sample(rng) as usize,
-        }
-    }
-}
 
 /// A distribution to sample items uniformly from a slice.
 ///
@@ -110,7 +81,7 @@ impl<'a, T> Slice<'a, T> {
 
         Ok(Self {
             slice,
-            range: UniformUsize::new(num_choices.get()).unwrap(),
+            range: UniformUsize::new(0, num_choices.get()).unwrap(),
             num_choices,
         })
     }

--- a/src/distr/uniform.rs
+++ b/src/distr/uniform.rs
@@ -112,7 +112,7 @@ pub use float::UniformFloat;
 #[path = "uniform_int.rs"]
 mod int;
 #[doc(inline)]
-pub use int::UniformInt;
+pub use int::{UniformInt, UniformUsize};
 
 #[path = "uniform_other.rs"]
 mod other;

--- a/src/distr/uniform_int.rs
+++ b/src/distr/uniform_int.rs
@@ -258,12 +258,10 @@ uniform_int_impl! { i16, u16, u32 }
 uniform_int_impl! { i32, u32, u32 }
 uniform_int_impl! { i64, u64, u64 }
 uniform_int_impl! { i128, u128, u128 }
-uniform_int_impl! { isize, usize, usize }
 uniform_int_impl! { u8, u8, u32 }
 uniform_int_impl! { u16, u16, u32 }
 uniform_int_impl! { u32, u32, u32 }
 uniform_int_impl! { u64, u64, u64 }
-uniform_int_impl! { usize, usize, usize }
 uniform_int_impl! { u128, u128, u128 }
 
 #[cfg(feature = "simd_support")]
@@ -476,7 +474,7 @@ mod tests {
                 );)*
             }};
         }
-        t!(i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, i128, u128);
+        t!(i8, i16, i32, i64, u8, u16, u32, u64, i128, u128);
 
         #[cfg(feature = "simd_support")]
         {

--- a/src/distr/utils.rs
+++ b/src/distr/utils.rs
@@ -124,26 +124,6 @@ macro_rules! wmul_impl_large {
 }
 wmul_impl_large! { u128, 64 }
 
-macro_rules! wmul_impl_usize {
-    ($ty:ty) => {
-        impl WideningMultiply for usize {
-            type Output = (usize, usize);
-
-            #[inline(always)]
-            fn wmul(self, x: usize) -> Self::Output {
-                let (high, low) = (self as $ty).wmul(x as $ty);
-                (high as usize, low as usize)
-            }
-        }
-    };
-}
-#[cfg(target_pointer_width = "16")]
-wmul_impl_usize! { u16 }
-#[cfg(target_pointer_width = "32")]
-wmul_impl_usize! { u32 }
-#[cfg(target_pointer_width = "64")]
-wmul_impl_usize! { u64 }
-
 #[cfg(feature = "simd_support")]
 mod simd_wmul {
     use super::*;

--- a/src/distr/weighted_index.rs
+++ b/src/distr/weighted_index.rs
@@ -696,7 +696,7 @@ mod test {
     #[test]
     fn overflow() {
         assert_eq!(
-            WeightedIndex::new([2, usize::MAX]),
+            WeightedIndex::new([2, u32::MAX]),
             Err(WeightError::Overflow)
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,13 +179,13 @@ mod test {
     #[test]
     #[cfg(all(feature = "std", feature = "std_rng", feature = "getrandom"))]
     fn test_random() {
-        let _n: usize = random();
+        let _n: u64 = random();
         let _f: f32 = random();
         let _o: Option<Option<i8>> = random();
         #[allow(clippy::type_complexity)]
         let _many: (
             (),
-            (usize, isize, Option<(u32, (bool,))>),
+            Option<(u32, (bool,))>,
             (u8, i8, u16, i16, u32, i32, u64, i64),
             (f32, (f64, (f64,))),
         ) = random();

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -136,6 +136,37 @@ pub trait Rng: RngCore {
         range.sample_single(self).unwrap()
     }
 
+    /// Generate a random `usize` value in the given range.
+    ///
+    /// This differs from [`Rng::gen_range`] in that the result is expected to
+    /// be portable across 32-bit and 64-bit targets. This is achieved by using
+    /// 32-bit sampling whenever possible (this also improves performance in
+    /// some benchmarks, depending on the generator).
+    ///
+    /// The `SampleIndex` trait is *intentionally* private (it not intended to
+    /// support generics externally). The trait supports types
+    /// [`RangeTo`](core::ops::RangeTo), [`Range`](core::ops::Range),
+    /// [`RangeInclusive`](core::ops::RangeInclusive) and
+    /// [`RangeToInclusive`](core::ops::RangeToInclusive) with
+    /// type parameter `Idx = usize`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rand::{thread_rng, Rng};
+    ///
+    /// let mut rng = thread_rng();
+    ///
+    /// let arr = ["a", "b", "c"];
+    /// println!("{}", arr[rng.gen_index(..arr.len())]);
+    ///
+    /// let _ = rng.gen_index(..=9);
+    /// ```
+    #[inline]
+    fn gen_index(&mut self, range: impl private::SampleIndex) -> usize {
+        range.sample_index(self)
+    }
+
     /// Generate values via an iterator
     ///
     /// This is a just a wrapper over [`Rng::sample_iter`] using
@@ -319,6 +350,59 @@ pub trait Rng: RngCore {
 }
 
 impl<R: RngCore + ?Sized> Rng for R {}
+
+mod private {
+    use super::Rng;
+    use crate::distr::uniform::{UniformInt, UniformSampler};
+    use core::ops::{Range, RangeInclusive, RangeTo, RangeToInclusive};
+    pub trait SampleIndex {
+        fn sample_index<R: Rng + ?Sized>(self, rng: &mut R) -> usize;
+    }
+
+    impl SampleIndex for RangeTo<usize> {
+        #[inline]
+        fn sample_index<R: Rng + ?Sized>(self, rng: &mut R) -> usize {
+            let RangeTo { end } = self;
+            (0..end).sample_index(rng)
+        }
+    }
+
+    impl SampleIndex for Range<usize> {
+        #[inline]
+        fn sample_index<R: Rng + ?Sized>(self, rng: &mut R) -> usize {
+            let Range { start, end } = self;
+            assert!(end != 0, "cannot sample empty range");
+            (start..=end - 1).sample_index(rng)
+        }
+    }
+
+    impl SampleIndex for RangeToInclusive<usize> {
+        #[inline]
+        fn sample_index<R: Rng + ?Sized>(self, rng: &mut R) -> usize {
+            let RangeToInclusive { end } = self;
+            (0..=end).sample_index(rng)
+        }
+    }
+
+    impl SampleIndex for RangeInclusive<usize> {
+        #[inline]
+        fn sample_index<R: Rng + ?Sized>(self, rng: &mut R) -> usize {
+            let (start, end) = self.into_inner();
+            assert!(start <= end);
+            if end <= (u32::MAX as usize) {
+                UniformInt::<u32>::sample_single_inclusive(start as u32, end as u32, rng).unwrap()
+                    as usize
+            } else {
+                #[cfg(not(target_pointer_width = "64"))]
+                unreachable!();
+
+                #[cfg(target_pointer_width = "64")]
+                return UniformInt::<u64>::sample_single_inclusive(start as u64, end as u64, rng)
+                    .unwrap() as usize;
+            }
+        }
+    }
+}
 
 /// Types which may be filled with random data
 ///

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -486,8 +486,8 @@ macro_rules! impl_fill {
     }
 }
 
-impl_fill!(u16, u32, u64, usize, u128,);
-impl_fill!(i8, i16, i32, i64, isize, i128,);
+impl_fill!(u16, u32, u64, u128,);
+impl_fill!(i8, i16, i32, i64, i128,);
 
 impl<T, const N: usize> Fill for [T; N]
 where

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -23,6 +23,9 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "std")]
 use std::collections::HashSet;
 
+#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
+compile_error!("unsupported pointer width");
+
 /// A vector of indices.
 ///
 /// Multiple internal representations are possible.
@@ -31,6 +34,7 @@ use std::collections::HashSet;
 pub enum IndexVec {
     #[doc(hidden)]
     U32(Vec<u32>),
+    #[cfg(target_pointer_width = "64")]
     #[doc(hidden)]
     USize(Vec<usize>),
 }
@@ -41,6 +45,7 @@ impl IndexVec {
     pub fn len(&self) -> usize {
         match *self {
             IndexVec::U32(ref v) => v.len(),
+            #[cfg(target_pointer_width = "64")]
             IndexVec::USize(ref v) => v.len(),
         }
     }
@@ -50,6 +55,7 @@ impl IndexVec {
     pub fn is_empty(&self) -> bool {
         match *self {
             IndexVec::U32(ref v) => v.is_empty(),
+            #[cfg(target_pointer_width = "64")]
             IndexVec::USize(ref v) => v.is_empty(),
         }
     }
@@ -62,6 +68,7 @@ impl IndexVec {
     pub fn index(&self, index: usize) -> usize {
         match *self {
             IndexVec::U32(ref v) => v[index] as usize,
+            #[cfg(target_pointer_width = "64")]
             IndexVec::USize(ref v) => v[index],
         }
     }
@@ -71,6 +78,7 @@ impl IndexVec {
     pub fn into_vec(self) -> Vec<usize> {
         match self {
             IndexVec::U32(v) => v.into_iter().map(|i| i as usize).collect(),
+            #[cfg(target_pointer_width = "64")]
             IndexVec::USize(v) => v,
         }
     }
@@ -80,6 +88,7 @@ impl IndexVec {
     pub fn iter(&self) -> IndexVecIter<'_> {
         match *self {
             IndexVec::U32(ref v) => IndexVecIter::U32(v.iter()),
+            #[cfg(target_pointer_width = "64")]
             IndexVec::USize(ref v) => IndexVecIter::USize(v.iter()),
         }
     }
@@ -94,6 +103,7 @@ impl IntoIterator for IndexVec {
     fn into_iter(self) -> IndexVecIntoIter {
         match self {
             IndexVec::U32(v) => IndexVecIntoIter::U32(v.into_iter()),
+            #[cfg(target_pointer_width = "64")]
             IndexVec::USize(v) => IndexVecIntoIter::USize(v.into_iter()),
         }
     }
@@ -104,10 +114,13 @@ impl PartialEq for IndexVec {
         use self::IndexVec::*;
         match (self, other) {
             (U32(v1), U32(v2)) => v1 == v2,
+            #[cfg(target_pointer_width = "64")]
             (USize(v1), USize(v2)) => v1 == v2,
+            #[cfg(target_pointer_width = "64")]
             (U32(v1), USize(v2)) => {
                 (v1.len() == v2.len()) && (v1.iter().zip(v2.iter()).all(|(x, y)| *x as usize == *y))
             }
+            #[cfg(target_pointer_width = "64")]
             (USize(v1), U32(v2)) => {
                 (v1.len() == v2.len()) && (v1.iter().zip(v2.iter()).all(|(x, y)| *x == *y as usize))
             }
@@ -122,6 +135,7 @@ impl From<Vec<u32>> for IndexVec {
     }
 }
 
+#[cfg(target_pointer_width = "64")]
 impl From<Vec<usize>> for IndexVec {
     #[inline]
     fn from(v: Vec<usize>) -> Self {
@@ -225,8 +239,12 @@ where
         panic!("`amount` of samples must be less than or equal to `length`");
     }
     if length > (u32::MAX as usize) {
+        #[cfg(target_pointer_width = "32")]
+        unreachable!();
+
         // We never want to use inplace here, but could use floyd's alg
         // Lazy version: always use the cache alg.
+        #[cfg(target_pointer_width = "64")]
         return sample_rejection(rng, length, amount);
     }
     let amount = amount as u32;
@@ -285,6 +303,10 @@ where
     X: Into<f64>,
 {
     if length > (u32::MAX as usize) {
+        #[cfg(target_pointer_width = "32")]
+        unreachable!();
+
+        #[cfg(target_pointer_width = "64")]
         sample_efraimidis_spirakis(rng, length, weight, amount)
     } else {
         assert!(amount <= u32::MAX as usize);
@@ -463,6 +485,7 @@ impl UInt for u32 {
     }
 }
 
+#[cfg(target_pointer_width = "64")]
 impl UInt for usize {
     #[inline]
     fn zero() -> Self {
@@ -521,20 +544,10 @@ mod test {
     #[test]
     #[cfg(feature = "serde1")]
     fn test_serialization_index_vec() {
-        let some_index_vec = IndexVec::from(vec![254_usize, 234, 2, 1]);
+        let some_index_vec = IndexVec::from(vec![254_u32, 234, 2, 1]);
         let de_some_index_vec: IndexVec =
             bincode::deserialize(&bincode::serialize(&some_index_vec).unwrap()).unwrap();
-        match (some_index_vec, de_some_index_vec) {
-            (IndexVec::U32(a), IndexVec::U32(b)) => {
-                assert_eq!(a, b);
-            }
-            (IndexVec::USize(a), IndexVec::USize(b)) => {
-                assert_eq!(a, b);
-            }
-            _ => {
-                panic!("failed to seralize/deserialize `IndexVec`")
-            }
-        }
+        assert_eq!(some_index_vec, de_some_index_vec);
     }
 
     #[test]
@@ -610,7 +623,7 @@ mod test {
                         assert!((i as usize) < len);
                     }
                 }
-                IndexVec::USize(_) => panic!("expected `IndexVec::U32`"),
+                _ => panic!("expected `IndexVec::U32`"),
             }
         }
 

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -36,7 +36,7 @@ pub enum IndexVec {
     U32(Vec<u32>),
     #[cfg(target_pointer_width = "64")]
     #[doc(hidden)]
-    USize(Vec<usize>),
+    U64(Vec<u64>),
 }
 
 impl IndexVec {
@@ -46,7 +46,7 @@ impl IndexVec {
         match *self {
             IndexVec::U32(ref v) => v.len(),
             #[cfg(target_pointer_width = "64")]
-            IndexVec::USize(ref v) => v.len(),
+            IndexVec::U64(ref v) => v.len(),
         }
     }
 
@@ -56,7 +56,7 @@ impl IndexVec {
         match *self {
             IndexVec::U32(ref v) => v.is_empty(),
             #[cfg(target_pointer_width = "64")]
-            IndexVec::USize(ref v) => v.is_empty(),
+            IndexVec::U64(ref v) => v.is_empty(),
         }
     }
 
@@ -69,7 +69,7 @@ impl IndexVec {
         match *self {
             IndexVec::U32(ref v) => v[index] as usize,
             #[cfg(target_pointer_width = "64")]
-            IndexVec::USize(ref v) => v[index],
+            IndexVec::U64(ref v) => v[index] as usize,
         }
     }
 
@@ -79,7 +79,7 @@ impl IndexVec {
         match self {
             IndexVec::U32(v) => v.into_iter().map(|i| i as usize).collect(),
             #[cfg(target_pointer_width = "64")]
-            IndexVec::USize(v) => v,
+            IndexVec::U64(v) => v.into_iter().map(|i| i as usize).collect(),
         }
     }
 
@@ -89,7 +89,7 @@ impl IndexVec {
         match *self {
             IndexVec::U32(ref v) => IndexVecIter::U32(v.iter()),
             #[cfg(target_pointer_width = "64")]
-            IndexVec::USize(ref v) => IndexVecIter::USize(v.iter()),
+            IndexVec::U64(ref v) => IndexVecIter::U64(v.iter()),
         }
     }
 }
@@ -104,7 +104,7 @@ impl IntoIterator for IndexVec {
         match self {
             IndexVec::U32(v) => IndexVecIntoIter::U32(v.into_iter()),
             #[cfg(target_pointer_width = "64")]
-            IndexVec::USize(v) => IndexVecIntoIter::USize(v.into_iter()),
+            IndexVec::U64(v) => IndexVecIntoIter::U64(v.into_iter()),
         }
     }
 }
@@ -115,14 +115,14 @@ impl PartialEq for IndexVec {
         match (self, other) {
             (U32(v1), U32(v2)) => v1 == v2,
             #[cfg(target_pointer_width = "64")]
-            (USize(v1), USize(v2)) => v1 == v2,
+            (U64(v1), U64(v2)) => v1 == v2,
             #[cfg(target_pointer_width = "64")]
-            (U32(v1), USize(v2)) => {
-                (v1.len() == v2.len()) && (v1.iter().zip(v2.iter()).all(|(x, y)| *x as usize == *y))
+            (U32(v1), U64(v2)) => {
+                (v1.len() == v2.len()) && (v1.iter().zip(v2.iter()).all(|(x, y)| *x as u64 == *y))
             }
             #[cfg(target_pointer_width = "64")]
-            (USize(v1), U32(v2)) => {
-                (v1.len() == v2.len()) && (v1.iter().zip(v2.iter()).all(|(x, y)| *x == *y as usize))
+            (U64(v1), U32(v2)) => {
+                (v1.len() == v2.len()) && (v1.iter().zip(v2.iter()).all(|(x, y)| *x == *y as u64))
             }
         }
     }
@@ -136,10 +136,10 @@ impl From<Vec<u32>> for IndexVec {
 }
 
 #[cfg(target_pointer_width = "64")]
-impl From<Vec<usize>> for IndexVec {
+impl From<Vec<u64>> for IndexVec {
     #[inline]
-    fn from(v: Vec<usize>) -> Self {
-        IndexVec::USize(v)
+    fn from(v: Vec<u64>) -> Self {
+        IndexVec::U64(v)
     }
 }
 
@@ -149,7 +149,7 @@ pub enum IndexVecIter<'a> {
     #[doc(hidden)]
     U32(slice::Iter<'a, u32>),
     #[doc(hidden)]
-    USize(slice::Iter<'a, usize>),
+    U64(slice::Iter<'a, u64>),
 }
 
 impl<'a> Iterator for IndexVecIter<'a> {
@@ -160,7 +160,7 @@ impl<'a> Iterator for IndexVecIter<'a> {
         use self::IndexVecIter::*;
         match *self {
             U32(ref mut iter) => iter.next().map(|i| *i as usize),
-            USize(ref mut iter) => iter.next().cloned(),
+            U64(ref mut iter) => iter.next().map(|i| *i as usize),
         }
     }
 
@@ -168,7 +168,7 @@ impl<'a> Iterator for IndexVecIter<'a> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         match *self {
             IndexVecIter::U32(ref v) => v.size_hint(),
-            IndexVecIter::USize(ref v) => v.size_hint(),
+            IndexVecIter::U64(ref v) => v.size_hint(),
         }
     }
 }
@@ -181,7 +181,7 @@ pub enum IndexVecIntoIter {
     #[doc(hidden)]
     U32(vec::IntoIter<u32>),
     #[doc(hidden)]
-    USize(vec::IntoIter<usize>),
+    U64(vec::IntoIter<u64>),
 }
 
 impl Iterator for IndexVecIntoIter {
@@ -192,7 +192,7 @@ impl Iterator for IndexVecIntoIter {
         use self::IndexVecIntoIter::*;
         match *self {
             U32(ref mut v) => v.next().map(|i| i as usize),
-            USize(ref mut v) => v.next(),
+            U64(ref mut v) => v.next().map(|i| i as usize),
         }
     }
 
@@ -201,7 +201,7 @@ impl Iterator for IndexVecIntoIter {
         use self::IndexVecIntoIter::*;
         match *self {
             U32(ref v) => v.size_hint(),
-            USize(ref v) => v.size_hint(),
+            U64(ref v) => v.size_hint(),
         }
     }
 }
@@ -245,7 +245,7 @@ where
         // We never want to use inplace here, but could use floyd's alg
         // Lazy version: always use the cache alg.
         #[cfg(target_pointer_width = "64")]
-        return sample_rejection(rng, length, amount);
+        return sample_rejection(rng, length as u64, amount as u64);
     }
     let amount = amount as u32;
     let length = length as u32;
@@ -307,7 +307,11 @@ where
         unreachable!();
 
         #[cfg(target_pointer_width = "64")]
-        sample_efraimidis_spirakis(rng, length, weight, amount)
+        {
+            let amount = amount as u64;
+            let length = length as u64;
+            sample_efraimidis_spirakis(rng, length, weight, amount)
+        }
     } else {
         assert!(amount <= u32::MAX as usize);
         let amount = amount as u32;
@@ -486,7 +490,7 @@ impl UInt for u32 {
 }
 
 #[cfg(target_pointer_width = "64")]
-impl UInt for usize {
+impl UInt for u64 {
     #[inline]
     fn zero() -> Self {
         0
@@ -499,7 +503,7 @@ impl UInt for usize {
 
     #[inline]
     fn as_usize(self) -> usize {
-        self
+        self as usize
     }
 }
 

--- a/src/seq/iterator.rs
+++ b/src/seq/iterator.rs
@@ -9,7 +9,6 @@
 //! `IteratorRandom`
 
 use super::coin_flipper::CoinFlipper;
-use super::gen_index;
 #[allow(unused)]
 use super::IndexedRandom;
 use crate::Rng;
@@ -71,7 +70,7 @@ pub trait IteratorRandom: Iterator + Sized {
             return match lower {
                 0 => None,
                 1 => self.next(),
-                _ => self.nth(gen_index(rng, lower)),
+                _ => self.nth(rng.gen_index(..lower)),
             };
         }
 
@@ -81,7 +80,7 @@ pub trait IteratorRandom: Iterator + Sized {
         // Continue until the iterator is exhausted
         loop {
             if lower > 1 {
-                let ix = gen_index(coin_flipper.rng, lower + consumed);
+                let ix = coin_flipper.rng.gen_index(..lower + consumed);
                 let skip = if ix < lower {
                     result = self.nth(ix);
                     lower - (ix + 1)
@@ -204,7 +203,7 @@ pub trait IteratorRandom: Iterator + Sized {
 
         // Continue, since the iterator was not exhausted
         for (i, elem) in self.enumerate() {
-            let k = gen_index(rng, i + 1 + amount);
+            let k = rng.gen_index(..i + 1 + amount);
             if let Some(slot) = buf.get_mut(k) {
                 *slot = elem;
             }
@@ -240,7 +239,7 @@ pub trait IteratorRandom: Iterator + Sized {
         // If the iterator stops once, then so do we.
         if reservoir.len() == amount {
             for (i, elem) in self.enumerate() {
-                let k = gen_index(rng, i + 1 + amount);
+                let k = rng.gen_index(..i + 1 + amount);
                 if let Some(slot) = reservoir.get_mut(k) {
                     *slot = elem;
                 }

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -53,7 +53,11 @@ fn gen_index<R: Rng + ?Sized>(rng: &mut R, ubound: usize) -> usize {
     if ubound <= (u32::MAX as usize) {
         rng.gen_range(0..ubound as u32) as usize
     } else {
-        rng.gen_range(0..ubound)
+        #[cfg(target_pointer_width = "32")]
+        unreachable!();
+
+        #[cfg(target_pointer_width = "64")]
+        return rng.gen_range(0..ubound as u64) as usize;
     }
 }
 

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -43,27 +43,8 @@ pub use iterator::IteratorRandom;
 pub use slice::SliceChooseIter;
 pub use slice::{IndexedMutRandom, IndexedRandom, SliceRandom};
 
-use crate::Rng;
-
-// Sample a number uniformly between 0 and `ubound`. Uses 32-bit sampling where
-// possible, primarily in order to produce the same output on 32-bit and 64-bit
-// platforms.
-#[inline]
-fn gen_index<R: Rng + ?Sized>(rng: &mut R, ubound: usize) -> usize {
-    if ubound <= (u32::MAX as usize) {
-        rng.gen_range(0..ubound as u32) as usize
-    } else {
-        #[cfg(target_pointer_width = "32")]
-        unreachable!();
-
-        #[cfg(target_pointer_width = "64")]
-        return rng.gen_range(0..ubound as u64) as usize;
-    }
-}
-
 /// Low-level API for sampling indices
 pub mod index {
-    use super::gen_index;
     use crate::Rng;
 
     #[cfg(feature = "alloc")]
@@ -88,7 +69,7 @@ pub mod index {
         // Floyd's algorithm
         let mut indices = [0; N];
         for (i, j) in (len - N..len).enumerate() {
-            let t = gen_index(rng, j + 1);
+            let t = rng.gen_index(..j + 1);
             if let Some(pos) = indices[0..i].iter().position(|&x| x == t) {
                 indices[pos] = j;
             }

--- a/src/seq/slice.rs
+++ b/src/seq/slice.rs
@@ -9,7 +9,7 @@
 //! `IndexedRandom`, `IndexedMutRandom`, `SliceRandom`
 
 use super::increasing_uniform::IncreasingUniform;
-use super::{gen_index, index};
+use super::index;
 #[cfg(feature = "alloc")]
 use crate::distr::uniform::{SampleBorrow, SampleUniform};
 #[cfg(feature = "alloc")]
@@ -57,7 +57,7 @@ pub trait IndexedRandom: Index<usize> {
         if self.is_empty() {
             None
         } else {
-            Some(&self[gen_index(rng, self.len())])
+            Some(&self[rng.gen_index(..self.len())])
         }
     }
 
@@ -253,7 +253,7 @@ pub trait IndexedMutRandom: IndexedRandom + IndexMut<usize> {
             None
         } else {
             let len = self.len();
-            Some(&mut self[gen_index(rng, len)])
+            Some(&mut self[rng.gen_index(..len)])
         }
     }
 
@@ -404,7 +404,7 @@ impl<T> SliceRandom for [T] {
             }
         } else {
             for i in m..self.len() {
-                let index = gen_index(rng, i + 1);
+                let index = rng.gen_index(..i + 1);
                 self.swap(i, index);
             }
         }

--- a/tests/gen_index.rs
+++ b/tests/gen_index.rs
@@ -1,0 +1,13 @@
+// An external test assures that the usage of a private trait by Rng::gen_index
+// does not cause issues with intended usages.
+
+use rand::Rng;
+
+#[test]
+fn sample_index() {
+    let mut rng = rand::thread_rng();
+    assert!(rng.gen_index(..4) < 4);
+    assert_eq!(rng.gen_index(..=0), 0);
+    assert_eq!(rng.gen_index(0..1), 0);
+    assert!(rng.gen_index(0..=9) < 10);
+}

--- a/tests/gen_index.rs
+++ b/tests/gen_index.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 
 #[test]
 fn sample_index() {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rngs::mock::StepRng::new(0, 579682777108047081);
     assert!(rng.gen_index(..4) < 4);
     assert_eq!(rng.gen_index(..=0), 0);
     assert_eq!(rng.gen_index(0..1), 0);


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Follows #1470, hence the first commit of *this* PR is "cfg-gate IndexVec::USize".

# Motivation

Solve #1399 by removing support for sampling `usize`, `isize` through the usual methods.

# Details

This is potentially the most drastic and problematic approach, but seems to work fine at least for `rand`'s tests. Specifically, it removes:

- `Standard` distribution support for `usize`, `isize` and non-zero and SIMD variants
- `Uniform` distribution support for the same types
- Support for `Fill`-ing `[usize]`, `[isize]`
- Adds `Rng::gen_index`
- `WeightedAliasIndex` no longer supports `isize` or `usize` weights

This is meant for discussion. Potentially we could also use in a release with the option to add back support for the above types (this would be non-breaking).

`fn Rng::gen_index` supports various range types over `usize` using a *private* trait bound. Unorthodox and it's *possible* that the lack of ability for downstream crates to write generics over this would be an issue, but that is really not an intended feature. (We could also simplify this down to just `RangeTo`; that's all that `rand` uses anyway.)

We might also want to expose `UniformUsize` (used in `rand::distr::slice`), probably under `rand::distr::uniform` (alongside `UniformInt`, possibly without implementing `SampleUniform` though that is an option).