### PR TITLE
Fix `clippy::doc_markdown` warnings.

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+# Don't warn about these identifiers when using clippy::doc_markdown.
+doc-valid-idents = ["ChaCha", "ChaCha12", "SplitMix64", "ZiB", ".."]

--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -276,7 +276,7 @@ impl<R: CryptoBlockRng + BlockRngCore<Item = u32>> CryptoRng for BlockRng<R> {}
 /// then the other half is then consumed, however both [`next_u64`] and
 /// [`fill_bytes`] discard the rest of any half-consumed `u64`s when called.
 ///
-/// [`fill_bytes`] `] consume a whole number of `u64` values. If the requested length
+/// [`fill_bytes`] consumes a whole number of `u64` values. If the requested length
 /// is not a multiple of 8, some bytes will be discarded.
 ///
 /// [`next_u32`]: RngCore::next_u32

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -189,7 +189,7 @@ where
     }
 }
 
-/// Implement `Distribution<(A, B, C, ...)> for Standard, using the list of
+/// Implement `Distribution<(A, B, C, ...)> for Standard`, using the list of
 /// identifiers
 macro_rules! tuple_impl {
     ($($tyvar:ident)*) => {

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -371,8 +371,8 @@ impl<X: SampleUniform> TryFrom<RangeInclusive<X>> for Uniform<X> {
 }
 
 /// Helper trait similar to [`Borrow`] but implemented
-/// only for SampleUniform and references to SampleUniform in
-/// order to resolve ambiguity issues.
+/// only for [`SampleUniform`] and references to [`SampleUniform`]
+/// in order to resolve ambiguity issues.
 ///
 /// [`Borrow`]: std::borrow::Borrow
 pub trait SampleBorrow<Borrowed> {

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -339,7 +339,7 @@ where
 /// which will be called once for each index.
 ///
 /// This implementation uses the algorithm described by Efraimidis and Spirakis
-/// in this paper: https://doi.org/10.1016/j.ipl.2005.11.003
+/// in this paper: <https://doi.org/10.1016/j.ipl.2005.11.003>
 /// It uses `O(length + amount)` space and `O(length)` time.
 ///
 /// Error cases:


### PR DESCRIPTION
- [ ] Added a `CHANGELOG.md` entry

# Summary
Warnings from `clippy::doc_markdown` were fixed.

# Motivation
We want to have better, more consistent documentation.

# Details
Warnings were fixed.

Also, add a `clippy.toml` to suppress some warnings about things that aren't identifiers.
