### PR TITLE
Rename `serde1` feature to `serde`.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,7 +30,7 @@ jobs:
           RUSTDOCFLAGS: --cfg doc_cfg
         # --all builds all crates, but with default features for other crates (okay in this case)
         run: |
-          cargo doc --all --features nightly,serde1,getrandom,small_rng
+          cargo doc --all --features nightly,serde,getrandom,small_rng
           cp utils/redirect.html target/doc/index.html
           rm target/doc/.lock
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
           cargo test --target ${{ matrix.target }} --examples
       - name: Test rand (all stable features)
         run: |
-          cargo test --target ${{ matrix.target }} --features=serde1,log,small_rng
+          cargo test --target ${{ matrix.target }} --features=serde,log,small_rng
       - name: Test rand_core
         run: |
           cargo test --target ${{ matrix.target }} --manifest-path rand_core/Cargo.toml
@@ -103,13 +103,13 @@ jobs:
           cargo test --target ${{ matrix.target }} --manifest-path rand_core/Cargo.toml --no-default-features --features=alloc,getrandom
       - name: Test rand_distr
         run: |
-          cargo test --target ${{ matrix.target }} --manifest-path rand_distr/Cargo.toml --features=serde1
+          cargo test --target ${{ matrix.target }} --manifest-path rand_distr/Cargo.toml --features=serde
           cargo test --target ${{ matrix.target }} --manifest-path rand_distr/Cargo.toml --no-default-features
           cargo test --target ${{ matrix.target }} --manifest-path rand_distr/Cargo.toml --no-default-features --features=std,std_math
       - name: Test rand_pcg
-        run: cargo test --target ${{ matrix.target }} --manifest-path rand_pcg/Cargo.toml --features=serde1
+        run: cargo test --target ${{ matrix.target }} --manifest-path rand_pcg/Cargo.toml --features=serde
       - name: Test rand_chacha
-        run: cargo test --target ${{ matrix.target }} --manifest-path rand_chacha/Cargo.toml --features=serde1
+        run: cargo test --target ${{ matrix.target }} --manifest-path rand_chacha/Cargo.toml --features=serde
 
   test-cross:
     runs-on: ${{ matrix.os }}
@@ -138,11 +138,11 @@ jobs:
       - name: Test
         run: |
           # all stable features:
-          cross test --no-fail-fast --target ${{ matrix.target }} --features=serde1,log,small_rng
+          cross test --no-fail-fast --target ${{ matrix.target }} --features=serde,log,small_rng
           cross test --no-fail-fast --target ${{ matrix.target }} --examples
           cross test --no-fail-fast --target ${{ matrix.target }} --manifest-path rand_core/Cargo.toml
-          cross test --no-fail-fast --target ${{ matrix.target }} --manifest-path rand_distr/Cargo.toml --features=serde1
-          cross test --no-fail-fast --target ${{ matrix.target }} --manifest-path rand_pcg/Cargo.toml --features=serde1
+          cross test --no-fail-fast --target ${{ matrix.target }} --manifest-path rand_distr/Cargo.toml --features=serde
+          cross test --no-fail-fast --target ${{ matrix.target }} --manifest-path rand_pcg/Cargo.toml --features=serde
           cross test --no-fail-fast --target ${{ matrix.target }} --manifest-path rand_chacha/Cargo.toml
 
   test-miri:
@@ -159,10 +159,10 @@ jobs:
           cargo miri test --no-default-features --lib --tests
           cargo miri test --features=log,small_rng
           cargo miri test --manifest-path rand_core/Cargo.toml
-          cargo miri test --manifest-path rand_core/Cargo.toml --features=serde1
+          cargo miri test --manifest-path rand_core/Cargo.toml --features=serde
           cargo miri test --manifest-path rand_core/Cargo.toml --no-default-features
           #cargo miri test --manifest-path rand_distr/Cargo.toml # no unsafe and lots of slow tests
-          cargo miri test --manifest-path rand_pcg/Cargo.toml --features=serde1
+          cargo miri test --manifest-path rand_pcg/Cargo.toml --features=serde
           cargo miri test --manifest-path rand_chacha/Cargo.toml --no-default-features
 
   test-no-std:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Allow `UniformFloat::new` samples and `UniformFloat::sample_single` to yield `high` (#1462)
 - Fix portability of `rand::distributions::Slice` (#1469)
 - Rename `rand::distributions` to `rand::distr` (#1470)
+- The `serde1` feature has been renamed `serde` (#1477)
 
 ## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [package.metadata.playground]
-features = ["small_rng", "serde1"]
+features = ["small_rng", "serde"]
 
 [features]
 # Meta-features:
 default = ["std", "std_rng", "getrandom", "small_rng"]
 nightly = [] # some additions requiring nightly Rust
-serde1 = ["serde", "rand_core/serde1"]
+serde = ["dep:serde", "rand_core/serde"]
 
 # Option (enabled by default): without "std" rand uses libcore; this option
 # enables functionality expected to be available on a standard platform.
@@ -74,6 +74,6 @@ zerocopy = { version = "0.7.33", default-features = false, features = ["simd"] }
 
 [dev-dependencies]
 rand_pcg = { path = "rand_pcg", version = "=0.9.0-alpha.1" }
-# Only to test serde1
+# Only to test serde
 bincode = "1.2.1"
 rayon = "1.7"

--- a/rand_chacha/CHANGELOG.md
+++ b/rand_chacha/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- The `serde1` feature has been renamed `serde` (#1477)
+
 ## [0.9.0-alpha.1] - 2024-03-18
 
 ## [0.9.0-alpha.0] - 2024-02-18

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -25,7 +25,7 @@ ppv-lite86 = { version = "0.2.14", default-features = false, features = ["simd"]
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
-# Only to test serde1
+# Only to test serde
 serde_json = "1.0"
 rand_core = { path = "../rand_core", version = "=0.9.0-alpha.1", features = ["getrandom"] }
 
@@ -33,4 +33,4 @@ rand_core = { path = "../rand_core", version = "=0.9.0-alpha.1", features = ["ge
 default = ["std"]
 getrandom = ["rand_core/getrandom"]
 std = ["ppv-lite86/std", "rand_core/std"]
-serde1 = ["serde"]
+serde = ["dep:serde"]

--- a/rand_chacha/src/chacha.rs
+++ b/rand_chacha/src/chacha.rs
@@ -18,7 +18,7 @@ use crate::guts::ChaCha;
 use rand_core::block::{BlockRng, BlockRngCore, CryptoBlockRng};
 use rand_core::{CryptoRng, RngCore, SeedableRng};
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 // NB. this must remain consistent with some currently hard-coded numbers in this module
@@ -276,7 +276,7 @@ macro_rules! chacha_impl {
         }
         impl Eq for $ChaChaXRng {}
 
-        #[cfg(feature = "serde1")]
+        #[cfg(feature = "serde")]
         impl Serialize for $ChaChaXRng {
             fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
             where
@@ -285,7 +285,7 @@ macro_rules! chacha_impl {
                 $abst::$ChaChaXRng::from(self).serialize(s)
             }
         }
-        #[cfg(feature = "serde1")]
+        #[cfg(feature = "serde")]
         impl<'de> Deserialize<'de> for $ChaChaXRng {
             fn deserialize<D>(d: D) -> Result<Self, D::Error>
             where
@@ -296,14 +296,14 @@ macro_rules! chacha_impl {
         }
 
         mod $abst {
-            #[cfg(feature = "serde1")]
+            #[cfg(feature = "serde")]
             use serde::{Deserialize, Serialize};
 
             // The abstract state of a ChaCha stream, independent of implementation choices. The
             // comparison and serialization of this object is considered a semver-covered part of
             // the API.
             #[derive(Debug, PartialEq, Eq)]
-            #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+            #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
             pub(crate) struct $ChaChaXRng {
                 seed: [u8; 32],
                 stream: u64,
@@ -362,12 +362,12 @@ chacha_impl!(
 mod test {
     use rand_core::{RngCore, SeedableRng};
 
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     use super::{ChaCha12Rng, ChaCha20Rng, ChaCha8Rng};
 
     type ChaChaRng = super::ChaCha20Rng;
 
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_chacha_serde_roundtrip() {
         let seed = [
@@ -405,7 +405,7 @@ mod test {
     // However testing for equivalence of serialized data is difficult, and there shouldn't be any
     // reason we need to violate the stronger-than-needed condition, e.g. by changing the field
     // definition order.
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_chacha_serde_format_stability() {
         let j = r#"{"seed":[4,8,15,16,23,42,4,8,15,16,23,42,4,8,15,16,23,42,4,8,15,16,23,42,4,8,15,16,23,42,4,8],"stream":27182818284,"word_pos":314159265359}"#;

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Bump the MSRV to 1.61.0
+- The `serde1` feature has been renamed `serde` (#1477)
 
 ## [0.9.0-alpha.1] - 2024-03-18
 

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -27,7 +27,7 @@ all-features = true
 [features]
 std = ["alloc", "getrandom?/std"]
 alloc = []  # enables Vec and Box support without std
-serde1 = ["serde"] # enables serde for BlockRng wrapper
+serde = ["dep:serde"] # enables serde for BlockRng wrapper
 
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }

--- a/rand_core/README.md
+++ b/rand_core/README.md
@@ -67,7 +67,7 @@ problems where one crate implicitly requires `rand_core` with `std` support and
 another crate requires `rand` *without* `std` support. However, the `rand` crate
 continues to enable `std` support by default, both for itself and `rand_core`.
 
-The `serde1` feature can be used to derive `Serialize` and `Deserialize` for RNG
+The `serde` feature can be used to derive `Serialize` and `Deserialize` for RNG
 implementations that use the `BlockRng` or `BlockRng64` wrappers.
 
 

--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -56,7 +56,7 @@
 use crate::impls::{fill_via_u32_chunks, fill_via_u64_chunks};
 use crate::{CryptoRng, RngCore, SeedableRng, TryRngCore};
 use core::fmt;
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A trait for RNGs which do not generate random numbers individually, but in
@@ -116,9 +116,9 @@ pub trait CryptoBlockRng: BlockRngCore {}
 /// [`next_u64`]: RngCore::next_u64
 /// [`fill_bytes`]: RngCore::fill_bytes
 #[derive(Clone)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde1",
+    feature = "serde",
     serde(
         bound = "for<'x> R: Serialize + Deserialize<'x> + Sized, for<'x> R::Results: Serialize + Deserialize<'x>"
     )
@@ -283,7 +283,7 @@ impl<R: CryptoBlockRng + BlockRngCore<Item = u32>> CryptoRng for BlockRng<R> {}
 /// [`next_u64`]: RngCore::next_u64
 /// [`fill_bytes`]: RngCore::fill_bytes
 #[derive(Clone)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BlockRng64<R: BlockRngCore + ?Sized> {
     results: R::Results,
     index: usize,

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- The `serde1` feature has been renamed `serde` (#1477)
+
 ### Added
 - Add plots for `rand_distr` distributions to documentation (#1434)
 - Add `PertBuilder`, fix case where mode ≅ mean (#1452)

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -29,7 +29,7 @@ alloc = ["rand/alloc"]
 # feature (default-enabled) will have the same effect.
 std_math = ["num-traits/std"]
 
-serde1 = ["serde", "rand/serde1"]
+serde = ["dep:serde", "rand/serde"]
 
 [dependencies]
 rand = { path = "..", version = "=0.9.0-alpha.1", default-features = false }

--- a/rand_distr/README.md
+++ b/rand_distr/README.md
@@ -35,7 +35,7 @@ can be enabled. (Note that any other crate depending on `num-traits` with the
 -   `alloc` (enabled by default): required for some distributions when not using
     `std` (in particular, `Dirichlet` and `WeightedAliasIndex`).
 -   `std_math`: see above on portability and libm
--   `serde1`: implement (de)seriaialization using `serde`
+-   `serde`: implement (de)seriaialization using `serde`
 
 ## Links
 

--- a/rand_distr/src/beta.rs
+++ b/rand_distr/src/beta.rs
@@ -13,7 +13,7 @@ use crate::{Distribution, Open01};
 use core::fmt;
 use num_traits::Float;
 use rand::Rng;
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// The algorithm used for sampling the Beta distribution.
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 /// Communications of the ACM 21, 317-322.
 /// https://doi.org/10.1145/359460.359482
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 enum BetaAlgorithm<N> {
     BB(BB<N>),
     BC(BC<N>),
@@ -33,7 +33,7 @@ enum BetaAlgorithm<N> {
 
 /// Algorithm BB for `min(alpha, beta) > 1`.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 struct BB<N> {
     alpha: N,
     beta: N,
@@ -42,7 +42,7 @@ struct BB<N> {
 
 /// Algorithm BC for `min(alpha, beta) <= 1`.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 struct BC<N> {
     alpha: N,
     beta: N,
@@ -77,7 +77,7 @@ struct BC<N> {
 /// println!("{} is from a Beta(2, 5) distribution", v);
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Beta<F>
 where
     F: Float,
@@ -91,7 +91,7 @@ where
 
 /// Error type returned from [`Beta::new`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Error {
     /// `alpha <= 0` or `nan`.
     AlphaTooSmall,

--- a/rand_distr/src/binomial.rs
+++ b/rand_distr/src/binomial.rs
@@ -44,7 +44,7 @@ use rand::Rng;
 /// println!("{} is from a binomial distribution", v);
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Binomial {
     /// Number of trials.
     n: u64,

--- a/rand_distr/src/cauchy.rs
+++ b/rand_distr/src/cauchy.rs
@@ -54,7 +54,7 @@ use rand::Rng;
 /// Note that at least for `f32`, results are not fully portable due to minor
 /// differences in the target system's *tan* implementation, `tanf`.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cauchy<F>
 where
     F: Float + FloatConst,

--- a/rand_distr/src/chi_squared.rs
+++ b/rand_distr/src/chi_squared.rs
@@ -15,7 +15,7 @@ use crate::{Distribution, Exp1, Gamma, Open01, StandardNormal};
 use core::fmt;
 use num_traits::Float;
 use rand::Rng;
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// The [chi-squared distribution](https://en.wikipedia.org/wiki/Chi-squared_distribution) `χ²(k)`.
@@ -45,7 +45,7 @@ use serde::{Deserialize, Serialize};
 /// println!("{} is from a χ²(11) distribution", v)
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ChiSquared<F>
 where
     F: Float,
@@ -58,7 +58,7 @@ where
 
 /// Error type returned from [`ChiSquared::new`] and [`StudentT::new`](crate::StudentT::new).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Error {
     /// `0.5 * k <= 0` or `nan`.
     DoFTooSmall,
@@ -78,7 +78,7 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 enum ChiSquaredRepr<F>
 where
     F: Float,

--- a/rand_distr/src/dirichlet.rs
+++ b/rand_distr/src/dirichlet.rs
@@ -92,7 +92,7 @@ where
 }
 
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct DirichletFromBeta<F, const N: usize>
 where
     F: Float,

--- a/rand_distr/src/exponential.rs
+++ b/rand_distr/src/exponential.rs
@@ -49,7 +49,7 @@ use rand::Rng;
 ///       https://www.doornik.com/research/ziggurat.pdf).
 ///       Nuffield College, Oxford
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Exp1;
 
 impl Distribution<f32> for Exp1 {
@@ -120,7 +120,7 @@ impl Distribution<f64> for Exp1 {
 /// println!("{} is from a Exp(2) distribution", v);
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Exp<F>
 where
     F: Float,

--- a/rand_distr/src/fisher_f.rs
+++ b/rand_distr/src/fisher_f.rs
@@ -13,7 +13,7 @@ use crate::{ChiSquared, Distribution, Exp1, Open01, StandardNormal};
 use core::fmt;
 use num_traits::Float;
 use rand::Rng;
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// The [Fisher F-distribution](https://en.wikipedia.org/wiki/F-distribution) `F(m, n)`.
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 /// println!("{} is from an F(2, 32) distribution", v)
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct FisherF<F>
 where
     F: Float,
@@ -55,7 +55,7 @@ where
 
 /// Error type returned from [`FisherF::new`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Error {
     /// `m <= 0` or `nan`.
     MTooSmall,

--- a/rand_distr/src/frechet.rs
+++ b/rand_distr/src/frechet.rs
@@ -44,7 +44,7 @@ use rand::Rng;
 /// println!("{}", val);
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Frechet<F>
 where
     F: Float,

--- a/rand_distr/src/gamma.rs
+++ b/rand_distr/src/gamma.rs
@@ -15,7 +15,7 @@ use crate::{Distribution, Exp, Exp1, Open01, StandardNormal};
 use core::fmt;
 use num_traits::Float;
 use rand::Rng;
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// The [Gamma distribution](https://en.wikipedia.org/wiki/Gamma_distribution) `Gamma(k, θ)`.
@@ -63,7 +63,7 @@ use serde::{Deserialize, Serialize};
 ///       (September 2000), 363-372.
 ///       DOI:[10.1145/358407.358414](https://doi.acm.org/10.1145/358407.358414)
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Gamma<F>
 where
     F: Float,
@@ -99,7 +99,7 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 enum GammaRepr<F>
 where
     F: Float,
@@ -127,7 +127,7 @@ where
 /// See `Gamma` for sampling from a Gamma distribution with general
 /// shape parameters.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 struct GammaSmallShape<F>
 where
     F: Float,
@@ -143,7 +143,7 @@ where
 /// See `Gamma` for sampling from a Gamma distribution with general
 /// shape parameters.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 struct GammaLargeShape<F>
 where
     F: Float,

--- a/rand_distr/src/geometric.rs
+++ b/rand_distr/src/geometric.rs
@@ -39,7 +39,7 @@ use rand::Rng;
 /// println!("{} is from a Geometric(0.25) distribution", v);
 /// ```
 #[derive(Copy, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Geometric {
     p: f64,
     pi: f64,
@@ -176,7 +176,7 @@ impl Distribution<u64> for Geometric {
 /// Implemented via iterated
 /// [`Rng::gen::<u64>().leading_zeros()`](Rng::gen::<u64>().leading_zeros()).
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StandardGeometric;
 
 impl Distribution<u64> for StandardGeometric {

--- a/rand_distr/src/gumbel.rs
+++ b/rand_distr/src/gumbel.rs
@@ -42,7 +42,7 @@ use rand::Rng;
 /// println!("{}", val);
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Gumbel<F>
 where
     F: Float,

--- a/rand_distr/src/hypergeometric.rs
+++ b/rand_distr/src/hypergeometric.rs
@@ -8,7 +8,7 @@ use rand::distr::uniform::Uniform;
 use rand::Rng;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 enum SamplingMethod {
     InverseTransform {
         initial_p: f64,
@@ -58,7 +58,7 @@ enum SamplingMethod {
 /// println!("{} is from a hypergeometric distribution", v);
 /// ```
 #[derive(Copy, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Hypergeometric {
     n1: u64,
     n2: u64,

--- a/rand_distr/src/inverse_gaussian.rs
+++ b/rand_distr/src/inverse_gaussian.rs
@@ -48,7 +48,7 @@ impl std::error::Error for Error {}
 /// println!("{} is from a inverse Gaussian(1, 2) distribution", v);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InverseGaussian<F>
 where
     F: Float,

--- a/rand_distr/src/normal.rs
+++ b/rand_distr/src/normal.rs
@@ -45,7 +45,7 @@ use rand::Rng;
 ///       https://www.doornik.com/research/ziggurat.pdf).
 ///       Nuffield College, Oxford
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StandardNormal;
 
 impl Distribution<f32> for StandardNormal {
@@ -143,7 +143,7 @@ impl Distribution<f64> for StandardNormal {
 ///       https://www.doornik.com/research/ziggurat.pdf).
 ///       Nuffield College, Oxford
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Normal<F>
 where
     F: Float,
@@ -270,7 +270,7 @@ where
 /// println!("{} is from an ln N(2, 9) distribution", v)
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LogNormal<F>
 where
     F: Float,

--- a/rand_distr/src/normal_inverse_gaussian.rs
+++ b/rand_distr/src/normal_inverse_gaussian.rs
@@ -49,7 +49,7 @@ impl std::error::Error for Error {}
 /// println!("{} is from a normal-inverse Gaussian(2, 1) distribution", v);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NormalInverseGaussian<F>
 where
     F: Float,

--- a/rand_distr/src/pareto.rs
+++ b/rand_distr/src/pareto.rs
@@ -36,7 +36,7 @@ use rand::Rng;
 /// println!("{}", val);
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pareto<F>
 where
     F: Float,

--- a/rand_distr/src/pert.rs
+++ b/rand_distr/src/pert.rs
@@ -38,7 +38,7 @@ use rand::Rng;
 ///
 /// [`Triangular`]: crate::Triangular
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pert<F>
 where
     F: Float,

--- a/rand_distr/src/poisson.rs
+++ b/rand_distr/src/poisson.rs
@@ -40,7 +40,7 @@ use rand::Rng;
 /// println!("{} is from a Poisson(2) distribution", v);
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Poisson<F>
 where
     F: Float + FloatConst,

--- a/rand_distr/src/skew_normal.rs
+++ b/rand_distr/src/skew_normal.rs
@@ -57,7 +57,7 @@ use rand::Rng;
 /// [`Normal`]: struct.Normal.html
 /// [A Method to Simulate the Skew Normal Distribution]: https://dx.doi.org/10.4236/am.2014.513201
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SkewNormal<F>
 where
     F: Float,

--- a/rand_distr/src/student_t.rs
+++ b/rand_distr/src/student_t.rs
@@ -13,7 +13,7 @@ use crate::{ChiSquared, ChiSquaredError};
 use crate::{Distribution, Exp1, Open01, StandardNormal};
 use num_traits::Float;
 use rand::Rng;
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// The [Student t-distribution](https://en.wikipedia.org/wiki/Student%27s_t-distribution) `t(ν)`.
@@ -46,7 +46,7 @@ use serde::{Deserialize, Serialize};
 /// println!("{} is from a t(11) distribution", v)
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct StudentT<F>
 where
     F: Float,

--- a/rand_distr/src/triangular.rs
+++ b/rand_distr/src/triangular.rs
@@ -39,7 +39,7 @@ use rand::Rng;
 ///
 /// [`Pert`]: crate::Pert
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Triangular<F>
 where
     F: Float,

--- a/rand_distr/src/unit_ball.rs
+++ b/rand_distr/src/unit_ball.rs
@@ -36,7 +36,7 @@ use rand::Rng;
 /// println!("{:?} is from the unit ball.", v)
 /// ```
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnitBall;
 
 impl<F: Float + SampleUniform> Distribution<[F; 3]> for UnitBall {

--- a/rand_distr/src/unit_circle.rs
+++ b/rand_distr/src/unit_circle.rs
@@ -39,7 +39,7 @@ use rand::Rng;
 ///       NBS Appl. Math. Ser., No. 12. Washington, DC: U.S. Government Printing
 ///       Office, pp. 36-38.
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnitCircle;
 
 impl<F: Float + SampleUniform> Distribution<[F; 2]> for UnitCircle {

--- a/rand_distr/src/unit_disc.rs
+++ b/rand_distr/src/unit_disc.rs
@@ -35,7 +35,7 @@ use rand::Rng;
 /// println!("{:?} is from the unit Disc.", v)
 /// ```
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnitDisc;
 
 impl<F: Float + SampleUniform> Distribution<[F; 2]> for UnitDisc {

--- a/rand_distr/src/unit_sphere.rs
+++ b/rand_distr/src/unit_sphere.rs
@@ -40,7 +40,7 @@ use rand::Rng;
 ///       Sphere.*](https://doi.org/10.1214/aoms/1177692644)
 ///       Ann. Math. Statist. 43, no. 2, 645--646.
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnitSphere;
 
 impl<F: Float + SampleUniform> Distribution<[F; 3]> for UnitSphere {

--- a/rand_distr/src/weibull.rs
+++ b/rand_distr/src/weibull.rs
@@ -34,7 +34,7 @@ use rand::Rng;
 /// println!("{}", val);
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Weibull<F>
 where
     F: Float,

--- a/rand_distr/src/weighted_alias.rs
+++ b/rand_distr/src/weighted_alias.rs
@@ -16,7 +16,7 @@ use core::fmt;
 use core::iter::Sum;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 use rand::Rng;
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A distribution using weighted sampling to pick a discretely selected item.
@@ -65,13 +65,13 @@ use serde::{Deserialize, Serialize};
 /// [`Vec<u32>`]: Vec
 /// [`Uniform<u32>::sample`]: Distribution::sample
 /// [`Uniform<W>::sample`]: Distribution::sample
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde1",
+    feature = "serde",
     serde(bound(serialize = "W: Serialize, W::Sampler: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde1",
+    feature = "serde",
     serde(bound(deserialize = "W: Deserialize<'de>, W::Sampler: Deserialize<'de>"))
 )]
 pub struct WeightedAliasIndex<W: AliasableWeight> {

--- a/rand_distr/src/weighted_tree.rs
+++ b/rand_distr/src/weighted_tree.rs
@@ -17,7 +17,7 @@ use alloc::vec::Vec;
 use rand::distr::uniform::{SampleBorrow, SampleUniform};
 use rand::distr::Weight;
 use rand::Rng;
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A distribution using weighted sampling to pick a discretely selected item.
@@ -77,13 +77,13 @@ use serde::{Deserialize, Serialize};
 /// ```
 ///
 /// [`WeightedTreeIndex<W>`]: WeightedTreeIndex
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    feature = "serde1",
+    feature = "serde",
     serde(bound(serialize = "W: Serialize, W::Sampler: Serialize"))
 )]
 #[cfg_attr(
-    feature = "serde1",
+    feature = "serde",
     serde(bound(deserialize = "W: Deserialize<'de>, W::Sampler: Deserialize<'de>"))
 )]
 #[derive(Clone, Default, Debug, PartialEq)]

--- a/rand_pcg/CHANGELOG.md
+++ b/rand_pcg/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- The `serde1` feature has been renamed `serde` (#1477)
+
 ## [0.9.0-alpha.1] - 2024-03-18
 
 ## [0.9.0-alpha.0] - 2024-02-18

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition"]
 
 [features]
-serde1 = ["serde"]
+serde = ["dep:serde"]
 getrandom = ["rand_core/getrandom"]
 
 [dependencies]

--- a/rand_pcg/README.md
+++ b/rand_pcg/README.md
@@ -29,7 +29,7 @@ Links:
 
 `rand_pcg` is `no_std` compatible by default.
 
-The `serde1` feature includes implementations of `Serialize` and `Deserialize`
+The `serde` feature includes implementations of `Serialize` and `Deserialize`
 for the included RNGs.
 
 ## License

--- a/rand_pcg/src/pcg128.rs
+++ b/rand_pcg/src/pcg128.rs
@@ -15,7 +15,7 @@ const MULTIPLIER: u128 = 0x2360_ED05_1FC6_5DA4_4385_DF64_9FCC_F645;
 
 use core::fmt;
 use rand_core::{impls, le, RngCore, SeedableRng};
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A PCG random number generator (XSL RR 128/64 (LCG) variant).
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize};
 /// Note that two generators with different stream parameters may be closely
 /// correlated.
 #[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Lcg128Xsl64 {
     state: u128,
     increment: u128,
@@ -166,7 +166,7 @@ impl RngCore for Lcg128Xsl64 {
 /// output function), this RNG is faster, also has a long cycle, and still has
 /// good performance on statistical tests.
 #[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Mcg128Xsl64 {
     state: u128,
 }

--- a/rand_pcg/src/pcg128cm.rs
+++ b/rand_pcg/src/pcg128cm.rs
@@ -15,7 +15,7 @@ const MULTIPLIER: u64 = 15750249268501108917;
 
 use core::fmt;
 use rand_core::{impls, le, RngCore, SeedableRng};
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A PCG random number generator (CM DXSM 128/64 (LCG) variant).
@@ -37,7 +37,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [upgrading-pcg64]: https://numpy.org/doc/stable/reference/random/upgrading-pcg64.html
 #[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Lcg128CmDxsm64 {
     state: u128,
     increment: u128,

--- a/rand_pcg/src/pcg64.rs
+++ b/rand_pcg/src/pcg64.rs
@@ -12,7 +12,7 @@
 
 use core::fmt;
 use rand_core::{impls, le, RngCore, SeedableRng};
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 // This is the default multiplier used by PCG for 64-bit state.
@@ -34,7 +34,7 @@ const MULTIPLIER: u64 = 6364136223846793005;
 /// Note that two generators with different stream parameter may be closely
 /// correlated.
 #[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Lcg64Xsh32 {
     state: u64,
     increment: u64,

--- a/rand_pcg/tests/lcg128cmdxsm64.rs
+++ b/rand_pcg/tests/lcg128cmdxsm64.rs
@@ -54,7 +54,7 @@ fn test_lcg128cmdxsm64_reference() {
     assert_eq!(results, expected);
 }
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 #[test]
 fn test_lcg128cmdxsm64_serde() {
     use bincode;

--- a/rand_pcg/tests/lcg128xsl64.rs
+++ b/rand_pcg/tests/lcg128xsl64.rs
@@ -54,7 +54,7 @@ fn test_lcg128xsl64_reference() {
     assert_eq!(results, expected);
 }
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 #[test]
 fn test_lcg128xsl64_serde() {
     use bincode;

--- a/rand_pcg/tests/lcg64xsh32.rs
+++ b/rand_pcg/tests/lcg64xsh32.rs
@@ -47,7 +47,7 @@ fn test_lcg64xsh32_reference() {
     assert_eq!(results, expected);
 }
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 #[test]
 fn test_lcg64xsh32_serde() {
     use bincode;

--- a/rand_pcg/tests/mcg128xsl64.rs
+++ b/rand_pcg/tests/mcg128xsl64.rs
@@ -52,7 +52,7 @@ fn test_mcg128xsl64_reference() {
     assert_eq!(results, expected);
 }
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 #[test]
 fn test_mcg128xsl64_serde() {
     use bincode;

--- a/src/distr/bernoulli.rs
+++ b/src/distr/bernoulli.rs
@@ -12,7 +12,7 @@ use crate::distr::Distribution;
 use crate::Rng;
 use core::fmt;
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// The [Bernoulli distribution](https://en.wikipedia.org/wiki/Bernoulli_distribution) `Bernoulli(p)`.
@@ -44,7 +44,7 @@ use serde::{Deserialize, Serialize};
 /// so only probabilities that are multiples of 2<sup>-64</sup> can be
 /// represented.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Bernoulli {
     /// Probability of success, relative to the maximal integer.
     p_int: u64,
@@ -157,7 +157,7 @@ mod test {
     use crate::Rng;
 
     #[test]
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     fn test_serializing_deserializing_bernoulli() {
         let coin_flip = Bernoulli::new(0.5).unwrap();
         let de_coin_flip: Bernoulli =

--- a/src/distr/float.rs
+++ b/src/distr/float.rs
@@ -15,7 +15,7 @@ use core::mem;
 #[cfg(feature = "simd_support")]
 use core::simd::prelude::*;
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A distribution to sample floating point numbers uniformly in the half-open
@@ -43,7 +43,7 @@ use serde::{Deserialize, Serialize};
 /// [`Open01`]: crate::distr::Open01
 /// [`Uniform`]: crate::distr::uniform::Uniform
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct OpenClosed01;
 
 /// A distribution to sample floating point numbers uniformly in the open
@@ -70,7 +70,7 @@ pub struct OpenClosed01;
 /// [`OpenClosed01`]: crate::distr::OpenClosed01
 /// [`Uniform`]: crate::distr::uniform::Uniform
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Open01;
 
 // This trait is needed by both this lib and rand_distr hence is a hidden export

--- a/src/distr/mod.rs
+++ b/src/distr/mod.rs
@@ -218,5 +218,5 @@ use crate::Rng;
 /// [`mask32x4`]: std::simd::mask32x4
 /// [`simd_support`]: https://github.com/rust-random/rand#crate-features
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Standard;

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -23,7 +23,7 @@ use core::mem::{self, MaybeUninit};
 use core::simd::prelude::*;
 #[cfg(feature = "simd_support")]
 use core::simd::{LaneCount, MaskElement, SupportedLaneCount};
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 // ----- Sampling distributions -----
@@ -67,7 +67,7 @@ use serde::{Deserialize, Serialize};
 /// - [Wikipedia article on Password Strength](https://en.wikipedia.org/wiki/Password_strength)
 /// - [Diceware for generating memorable passwords](https://en.wikipedia.org/wiki/Diceware)
 #[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Alphanumeric;
 
 // ----- Implementations of distributions -----

--- a/src/distr/uniform.rs
+++ b/src/distr/uniform.rs
@@ -146,7 +146,7 @@ impl fmt::Display for Error {
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Sample values uniformly between two bounds.
@@ -199,10 +199,10 @@ use serde::{Deserialize, Serialize};
 /// [`new_inclusive`]: Uniform::new_inclusive
 /// [`Rng::gen_range`]: Rng::gen_range
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde1", serde(bound(serialize = "X::Sampler: Serialize")))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(serialize = "X::Sampler: Serialize")))]
 #[cfg_attr(
-    feature = "serde1",
+    feature = "serde",
     serde(bound(deserialize = "X::Sampler: Deserialize<'de>"))
 )]
 pub struct Uniform<X: SampleUniform>(X::Sampler);
@@ -445,7 +445,7 @@ mod tests {
     use core::time::Duration;
 
     #[test]
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     fn test_uniform_serialization() {
         let unit_box: Uniform<i32> = Uniform::new(-1, 1).unwrap();
         let de_unit_box: Uniform<i32> =

--- a/src/distr/uniform_float.rs
+++ b/src/distr/uniform_float.rs
@@ -19,7 +19,7 @@ use core::simd::prelude::*;
 // #[cfg(feature = "simd_support")]
 // use core::simd::{LaneCount, SupportedLaneCount};
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// The back-end implementing [`UniformSampler`] for floating-point types.
@@ -43,7 +43,7 @@ use serde::{Deserialize, Serialize};
 /// [`Standard`]: crate::distr::Standard
 /// [`Uniform`]: super::Uniform
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UniformFloat<X> {
     low: X,
     scale: X,

--- a/src/distr/uniform_int.rs
+++ b/src/distr/uniform_int.rs
@@ -20,7 +20,7 @@ use core::simd::prelude::*;
 #[cfg(feature = "simd_support")]
 use core::simd::{LaneCount, SupportedLaneCount};
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// The back-end implementing [`UniformSampler`] for integer types.
@@ -60,7 +60,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Uniform`]: super::Uniform
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UniformInt<X> {
     pub(super) low: X,
     pub(super) range: X,

--- a/src/distr/uniform_other.rs
+++ b/src/distr/uniform_other.rs
@@ -14,7 +14,7 @@ use crate::distr::Distribution;
 use crate::Rng;
 use core::time::Duration;
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 impl SampleUniform for char {
@@ -31,7 +31,7 @@ impl SampleUniform for char {
 /// valid Unicode code points. We must therefore avoid sampling values in this
 /// range.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UniformChar {
     sampler: UniformInt<u32>,
 }
@@ -118,14 +118,14 @@ impl crate::distr::DistString for Uniform<char> {
 /// Unless you are implementing [`UniformSampler`] for your own types, this type
 /// should not be used directly, use [`Uniform`] instead.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UniformDuration {
     mode: UniformDurationMode,
     offset: u32,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 enum UniformDurationMode {
     Small {
         secs: u64,
@@ -251,7 +251,7 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     fn test_serialization_uniform_duration() {
         let distr = UniformDuration::new(Duration::from_secs(10), Duration::from_secs(60)).unwrap();
         let de_distr: UniformDuration =

--- a/src/distr/weighted_index.rs
+++ b/src/distr/weighted_index.rs
@@ -17,7 +17,7 @@ use core::fmt;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A distribution using weighted sampling of discrete items.
@@ -83,7 +83,7 @@ use serde::{Deserialize, Serialize};
 /// [`rand_distr::weighted_alias`]: https://docs.rs/rand_distr/*/rand_distr/weighted_alias/index.html
 /// [`rand_distr::weighted_tree`]: https://docs.rs/rand_distr/*/rand_distr/weighted_tree/index.html
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct WeightedIndex<X: SampleUniform + PartialOrd> {
     cumulative_weights: Vec<X>,
     total_weight: X,
@@ -437,9 +437,9 @@ impl_weight_float!(f64);
 mod test {
     use super::*;
 
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     #[test]
-    fn test_weightedindex_serde1() {
+    fn test_weightedindex_serde() {
         let weighted_index = WeightedIndex::new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).unwrap();
 
         let ser_weighted_index = bincode::serialize(&weighted_index).unwrap();

--- a/src/rngs/mock.rs
+++ b/src/rngs/mock.rs
@@ -10,7 +10,7 @@
 
 use rand_core::{impls, RngCore};
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A mock generator yielding very predictable output
@@ -39,7 +39,7 @@ use serde::{Deserialize, Serialize};
 /// assert_eq!(sample, [2, 3, 4]);
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct StepRng {
     v: u64,
     a: u64,
@@ -79,11 +79,11 @@ rand_core::impl_try_rng_from_rng_core!(StepRng);
 
 #[cfg(test)]
 mod tests {
-    #[cfg(any(feature = "alloc", feature = "serde1"))]
+    #[cfg(any(feature = "alloc", feature = "serde"))]
     use super::StepRng;
 
     #[test]
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     fn test_serialization_step_rng() {
         let some_rng = StepRng::new(42, 7);
         let de_some_rng: StepRng =

--- a/src/rngs/xoshiro128plusplus.rs
+++ b/src/rngs/xoshiro128plusplus.rs
@@ -9,7 +9,7 @@
 use rand_core::impls::{fill_bytes_via_next, next_u64_via_u32};
 use rand_core::le::read_u32_into;
 use rand_core::{RngCore, SeedableRng};
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A xoshiro128++ random number generator.
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 /// reference source code](http://xoshiro.di.unimi.it/xoshiro128plusplus.c) by
 /// David Blackman and Sebastiano Vigna.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Xoshiro128PlusPlus {
     s: [u32; 4],
 }

--- a/src/rngs/xoshiro256plusplus.rs
+++ b/src/rngs/xoshiro256plusplus.rs
@@ -9,7 +9,7 @@
 use rand_core::impls::fill_bytes_via_next;
 use rand_core::le::read_u64_into;
 use rand_core::{RngCore, SeedableRng};
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A xoshiro256++ random number generator.
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 /// reference source code](http://xoshiro.di.unimi.it/xoshiro256plusplus.c) by
 /// David Blackman and Sebastiano Vigna.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Xoshiro256PlusPlus {
     s: [u64; 4],
 }

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -18,7 +18,7 @@ use crate::distr::{Distribution, Uniform};
 use crate::Rng;
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeSet;
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "std")]
 use std::collections::HashSet;
@@ -27,7 +27,7 @@ use std::collections::HashSet;
 ///
 /// Multiple internal representations are possible.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum IndexVec {
     #[doc(hidden)]
     U32(Vec<u32>),
@@ -519,7 +519,7 @@ mod test {
     use alloc::vec;
 
     #[test]
-    #[cfg(feature = "serde1")]
+    #[cfg(feature = "serde")]
     fn test_serialization_index_vec() {
         let some_index_vec = IndexVec::from(vec![254_usize, 234, 2, 1]);
         let de_some_index_vec: IndexVec =


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary
Rename `serde1` feature to `serde`

# Motivation
As stated in #1473, most of the ecosystem has used the name `serde` for the feature to enable `serde` (once `dep:` syntax was added in Rust 1.60).

# Details
N/A
