### PR TITLE
Improve SmallRng initialization performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Add `UniformUsize` and use to make `Uniform` for `usize` portable (#1487)
 - Remove support for generating `isize` and `usize` values with `Standard`, `Uniform` and `Fill` and usage as a `WeightedAliasIndex` weight (#1487)
 - Require `Clone` and `AsRef` bound for `SeedableRng::Seed`. (#1491)
+- Improve SmallRng initialization performance
 
 ## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -83,7 +83,8 @@ impl SeedableRng for SmallRng {
 
     #[inline(always)]
     fn from_seed(seed: Self::Seed) -> Self {
-        // With MSRV >= 1.77: let seed = *seed.first_chunk().unwrap();
+        // This is for compatibility with 32-bit platforms where Rng::Seed has a different seed size
+        // With MSRV >= 1.77: let seed = *seed.first_chunk().unwrap()
         const LEN: usize = core::mem::size_of::<<Rng as SeedableRng>::Seed>();
         let seed = (&seed[..LEN]).try_into().unwrap();
         SmallRng(Rng::from_seed(seed))

--- a/src/rngs/xoshiro128plusplus.rs
+++ b/src/rngs/xoshiro128plusplus.rs
@@ -120,4 +120,18 @@ mod tests {
             assert_eq!(rng.next_u32(), e);
         }
     }
+
+    #[test]
+    fn stable_seed_from_u64() {
+        // We don't guarantee value-stability for SmallRng but this
+        // could influence keeping stability whenever possible (e.g. after optimizations).
+        let mut rng = Xoshiro128PlusPlus::seed_from_u64(0);
+        let expected = [
+            1179900579, 1938959192, 3089844957, 3657088315, 1015453891, 479942911, 3433842246,
+            669252886, 3985671746, 2737205563,
+        ];
+        for &e in &expected {
+            assert_eq!(rng.next_u32(), e);
+        }
+    }
 }

--- a/src/rngs/xoshiro128plusplus.rs
+++ b/src/rngs/xoshiro128plusplus.rs
@@ -33,29 +33,36 @@ impl SeedableRng for Xoshiro128PlusPlus {
     /// mapped to a different seed.
     #[inline]
     fn from_seed(seed: [u8; 16]) -> Xoshiro128PlusPlus {
-        if seed.iter().all(|&x| x == 0) {
-            return Self::seed_from_u64(0);
-        }
         let mut state = [0; 4];
         read_u32_into(&seed, &mut state);
+        // Check for zero on aligned integers for better code generation.
+        // Furtermore, seed_from_u64(0) will expand to a constant when optimized.
+        if state.iter().all(|&x| x == 0) {
+            return Self::seed_from_u64(0);
+        }
         Xoshiro128PlusPlus { s: state }
     }
 
     /// Create a new `Xoshiro128PlusPlus` from a `u64` seed.
     ///
     /// This uses the SplitMix64 generator internally.
+    #[inline]
     fn seed_from_u64(mut state: u64) -> Self {
         const PHI: u64 = 0x9e3779b97f4a7c15;
-        let mut seed = Self::Seed::default();
-        for chunk in seed.as_mut().chunks_mut(8) {
+        let mut s = [0; 4];
+        for i in s.chunks_exact_mut(2) {
             state = state.wrapping_add(PHI);
             let mut z = state;
             z = (z ^ (z >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
             z = (z ^ (z >> 27)).wrapping_mul(0x94d049bb133111eb);
             z = z ^ (z >> 31);
-            chunk.copy_from_slice(&z.to_le_bytes());
+            i[0] = z.to_le() as u32;
+            i[1] = (z.to_le() >> 32) as u32;
         }
-        Self::from_seed(seed)
+        // By using a non-zero PHI we are guaranteed to generate a non-zero state
+        // Thus preventing a recursion between from_seed and seed_from_u64.
+        debug_assert_ne!(s, [0; 4]);
+        Xoshiro128PlusPlus { s }
     }
 }
 

--- a/src/rngs/xoshiro128plusplus.rs
+++ b/src/rngs/xoshiro128plusplus.rs
@@ -56,8 +56,8 @@ impl SeedableRng for Xoshiro128PlusPlus {
             z = (z ^ (z >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
             z = (z ^ (z >> 27)).wrapping_mul(0x94d049bb133111eb);
             z = z ^ (z >> 31);
-            i[0] = z.to_le() as u32;
-            i[1] = (z.to_le() >> 32) as u32;
+            i[0] = z as u32;
+            i[1] = (z >> 32) as u32;
         }
         // By using a non-zero PHI we are guaranteed to generate a non-zero state
         // Thus preventing a recursion between from_seed and seed_from_u64.

--- a/src/rngs/xoshiro256plusplus.rs
+++ b/src/rngs/xoshiro256plusplus.rs
@@ -56,7 +56,7 @@ impl SeedableRng for Xoshiro256PlusPlus {
             z = (z ^ (z >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
             z = (z ^ (z >> 27)).wrapping_mul(0x94d049bb133111eb);
             z = z ^ (z >> 31);
-            *i = z.to_le();
+            *i = z;
         }
         // By using a non-zero PHI we are guaranteed to generate a non-zero state
         // Thus preventing a recursion between from_seed and seed_from_u64.

--- a/src/rngs/xoshiro256plusplus.rs
+++ b/src/rngs/xoshiro256plusplus.rs
@@ -132,4 +132,26 @@ mod tests {
             assert_eq!(rng.next_u64(), e);
         }
     }
+
+    #[test]
+    fn stable_seed_from_u64() {
+        // We don't guarantee value-stability for SmallRng but this
+        // could influence keeping stability whenever possible (e.g. after optimizations).
+        let mut rng = Xoshiro256PlusPlus::seed_from_u64(0);
+        let expected = [
+            5987356902031041503,
+            7051070477665621255,
+            6633766593972829180,
+            211316841551650330,
+            9136120204379184874,
+            379361710973160858,
+            15813423377499357806,
+            15596884590815070553,
+            5439680534584881407,
+            1369371744833522710,
+        ];
+        for &e in &expected {
+            assert_eq!(rng.next_u64(), e);
+        }
+    }
 }


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Improve initialization speed for SmallRng

# Motivation

`SmallRng` is plenty fast, but the initialization speed was suboptimal.

# Details

An example binary was added to check for code generation with `cargo asm`.

Benchmarks were also added. The results are shown below:

```
before
test init_from_seed_smallrng  ... bench:           0.84 ns/iter (+/- 0.06)
test init_from_u64_smallrng  ... bench:           6.19 ns/iter (+/- 0.58)
test init_smallrng           ... bench:           9.45 ns/iter (+/- 0.18)

after
test init_from_seed_smallrng  ... bench:           0.85 ns/iter (+/- 0.08)
test init_from_u64_smallrng  ... bench:           3.42 ns/iter (+/- 0.09)
test init_smallrng           ... bench:           6.65 ns/iter (+/- 0.15)
```