### PR TITLE
Use `f32` arithmetic for `f32` normal distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Fix portability of `rand::distributions::Slice` (#1469)
 - Rename `rand::distributions` to `rand::distr` (#1470)
 - The `serde1` feature has been renamed `serde` (#1477)
+- Add `rand_distr::Normal` proper `f32` implementation (#1485).
 
 ## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)

--- a/rand_distr/src/normal.rs
+++ b/rand_distr/src/normal.rs
@@ -481,11 +481,11 @@ mod tests {
 
         let e = core::f32::consts::E;
         let lnorm = LogNormal::from_mean_cv(e.sqrt(), (e - 1.0).sqrt()).unwrap();
-        assert_almost_eq!(lnorm.norm.mean, 0.0, 2e-16);
-        assert_almost_eq!(lnorm.norm.std_dev, 1.0, 2e-16);
+        assert_almost_eq!(lnorm.norm.mean, 0.0, 2e-7);
+        assert_almost_eq!(lnorm.norm.std_dev, 1.0, 2e-7);
 
         let lnorm = LogNormal::from_mean_cv(e.powf(1.5), (e - 1.0).sqrt()).unwrap();
-        assert_almost_eq!(lnorm.norm.mean, 1.0, 1e-15);
+        assert_almost_eq!(lnorm.norm.mean, 1.0, 1e-6);
         assert_eq!(lnorm.norm.std_dev, 1.0);
     }
 

--- a/rand_distr/src/normal.rs
+++ b/rand_distr/src/normal.rs
@@ -486,7 +486,7 @@ mod tests {
 
         let lnorm = LogNormal::from_mean_cv(e.powf(1.5), (e - 1.0).sqrt()).unwrap();
         assert_almost_eq!(lnorm.norm.mean, 1.0, 1e-6);
-        assert_eq!(lnorm.norm.std_dev, 1.0);
+        assert_almost_eq!(lnorm.norm.std_dev, 1.0, 1e-6);
     }
 
     #[test]

--- a/rand_distr/src/skew_normal.rs
+++ b/rand_distr/src/skew_normal.rs
@@ -220,7 +220,7 @@ mod tests {
         test_samples(
             SkewNormal::new(0.0, 1.0, 0.0).unwrap(),
             0f32,
-            &[-0.11844189, 0.781378, 0.06563994, -1.1932899],
+            &[1.8696455, -0.1461722, -1.1125228, 0.20563208],
         );
         test_samples(
             SkewNormal::new(0.0, 1.0, 0.0).unwrap(),

--- a/rand_distr/tests/value_stability.rs
+++ b/rand_distr/tests/value_stability.rs
@@ -231,7 +231,7 @@ fn normal_inverse_gaussian_stability() {
     test_samples(
         213,
         NormalInverseGaussian::new(2.0, 1.0).unwrap(),
-        &[0.6568966f32, 1.3744819, 2.216063, 0.11488572],
+        &[-0.28254104f32, 0.7503831, 0.6274264, 0.38120824],
     );
     test_samples(
         213,
@@ -266,7 +266,7 @@ fn inverse_gaussian_stability() {
     test_samples(
         213,
         InverseGaussian::new(1.0, 3.0).unwrap(),
-        &[0.9339157f32, 1.108113, 0.50864697, 0.39849377],
+        &[0.35597056f32, 1.8809121, 1.1565078, 0.63038194],
     );
     test_samples(
         213,
@@ -291,7 +291,7 @@ fn gamma_stability() {
     test_samples(
         223,
         Gamma::new(0.8, 5.0).unwrap(),
-        &[0.5051203f32, 0.9048302, 3.095812, 1.8566116],
+        &[0.46801063f32, 3.9947987, 4.116252, 8.795569],
     );
     test_samples(
         223,
@@ -328,19 +328,19 @@ fn gamma_stability() {
     test_samples(
         223,
         ChiSquared::new(10.0).unwrap(),
-        &[12.693656f32, 6.812016, 11.082001, 12.436167],
+        &[4.94985f32, 14.257126, 7.4251842, 9.095535],
     );
 
     // FisherF has same special cases as ChiSquared on each param
     test_samples(
         223,
         FisherF::new(1.0, 13.5).unwrap(),
-        &[0.32283646f32, 0.048049655, 0.0788893, 1.817178],
+        &[1.1028901f32, 0.8565854, 0.002667761, 0.5884251],
     );
     test_samples(
         223,
         FisherF::new(1.0, 1.0).unwrap(),
-        &[0.29925257f32, 3.4392934, 9.567652, 0.020074],
+        &[1.4913899f32, 1.4406309, 0.050560303, 0.011843223],
     );
     test_samples(
         223,
@@ -357,7 +357,7 @@ fn gamma_stability() {
     test_samples(
         223,
         StudentT::new(1.0).unwrap(),
-        &[0.54703987f32, -1.8545331, 3.093162, -0.14168274],
+        &[-1.2212248f32, 1.2002629, -0.22485618, -0.10882657],
     );
     test_samples(
         223,
@@ -432,7 +432,7 @@ fn normal_stability() {
     test_samples(
         213,
         StandardNormal,
-        &[-0.11844189f32, 0.781378, 0.06563994, -1.1932899],
+        &[1.8696455f32, -0.1461722, -1.1125228, 0.20563208],
     );
     test_samples(
         213,
@@ -448,7 +448,7 @@ fn normal_stability() {
     test_samples(
         213,
         Normal::new(0.0, 1.0).unwrap(),
-        &[-0.11844189f32, 0.781378, 0.06563994, -1.1932899],
+        &[1.8696455f32, -0.1461722, -1.1125228, 0.20563208],
     );
     test_samples(
         213,
@@ -464,7 +464,7 @@ fn normal_stability() {
     test_samples(
         213,
         LogNormal::new(0.0, 1.0).unwrap(),
-        &[0.88830346f32, 2.1844804, 1.0678421, 0.30322206],
+        &[6.4859967f32, 0.8640089, 0.3287286, 1.2283012],
     );
     test_samples(
         213,


### PR DESCRIPTION
# Summary

The current normal distribution `f32` implementation just computes the `f64` version and converts the result to `f32`.

- [x] Added a `CHANGELOG.md` entry

# Motivation

The TODO suggested this, and I agreed. This should be significantly faster on platforms where single-precision floats are faster.

# Details

I converted the code to use `f32` arithmetic and adjusted the number of bits used for the calculation of `u`, the base number.

In addition to the tests, I also generated some normal numbers with the current f64 and the new f32 paths and ensured that they both look "normal".

Tests that depended on the specific `f32` values generated by the old normal distribution code had to be updated, since we now use `u32`-sized random numbers as the source, which will be different from the `u64`s used previously.

I also fixed some comments that were confusing and possibly incorrect in the ziggurat code.

I was originally tempted to convert the ziggurat tables to `f32` for all versions, but this appears to affect the precision of the `f64` generated numbers too much.