### PR TITLE
Binv remodel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Fix portability of `rand::distributions::Slice` (#1469)
 - Rename `rand::distributions` to `rand::distr` (#1470)
 - The `serde1` feature has been renamed `serde` (#1477)
+- Refactor inverse `Binomial` algorithm to permit for n > i32::MAX values.
 
 ## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)

--- a/rand_distr/src/binomial.rs
+++ b/rand_distr/src/binomial.rs
@@ -125,7 +125,6 @@ impl Distribution<u64> for Binomial {
         let q = 1. - p;
         let np = (self.n as f64) * p;
 
-
         // For small n * min(p, 1 - p), the BINV algorithm based on the inverse
         // transformation of the binomial distribution is efficient. Otherwise,
         // the BTPE algorithm is used.
@@ -148,12 +147,12 @@ impl Distribution<u64> for Binomial {
         // It is possible for BINV to get stuck, so we break if x > BINV_MAX_X and try again.
         // It would be safer to set BINV_MAX_X to self.n, but it is extremely unlikely to be relevant.
         // When n*p < 10, so is n*p*q which is the variance, so a result > 110 would be 100 / sqrt(10) = 31 standard deviations away.
-        const BINV_MAX_X: u64 = 110;        
-        
+        const BINV_MAX_X: u64 = 110;
+
         let mut r: f64;
         if self.n == 1 {
             // Use the BINV algorithm for special case n = 1 (simplify r calculations).
-            let s: f64 = p/q;
+            let s: f64 = p / q;
 
             result = 'outer: loop {
                 r = q;
@@ -170,11 +169,10 @@ impl Distribution<u64> for Binomial {
                 }
                 break x;
             }
-        }
-        else if np < SMALL_NP_THRESHOLD && self.n <= (i32::MAX as u64) {
+        } else if np < SMALL_NP_THRESHOLD && self.n <= (i32::MAX as u64) {
             // For very small n*p the powi is superior.
             // Use the BINV algorithm.
-            let s: f64 = p/q;
+            let s: f64 = p / q;
 
             result = 'outer: loop {
                 r = q.powi(self.n as i32);
@@ -191,11 +189,10 @@ impl Distribution<u64> for Binomial {
                 }
                 break x;
             }
-        }
-        else if np < BINV_THRESHOLD {
+        } else if np < BINV_THRESHOLD {
             // For everything else r = (q.ln() * (self.n as f64)).exp() is superior.
             // Use the BINV algorithm.
-            let s: f64 = p/q;
+            let s: f64 = p / q;
 
             result = 'outer: loop {
                 r = (q.ln() * (self.n as f64)).exp();

--- a/rand_distr/src/binomial.rs
+++ b/rand_distr/src/binomial.rs
@@ -16,8 +16,6 @@ use core::fmt;
 use num_traits::Float;
 use rand::Rng;
 
-use std::println;
-
 /// The [binomial distribution](https://en.wikipedia.org/wiki/Binomial_distribution) `Binomial(n, p)`.
 ///
 /// The binomial distribution is a discrete probability distribution
@@ -92,8 +90,7 @@ impl Binomial {
 /// Convert a `f64` to an `i64`, panicking on overflow.
 fn f64_to_i64(x: f64) -> i64 {
     assert!(x < (i64::MAX as f64));
-    x.floor() as i64
-    //x as i64
+    x as i64
 }
 
 impl Distribution<u64> for Binomial {


### PR DESCRIPTION
- [] Added a `CHANGELOG.md` entry

# Summary

Slightly refactor algorithm to match the Binary Inverse algorithm used by numpy in order to remove the n <= i32::MAX issues.

# Motivation

In my use case (large N, small p, seen frequently in computational biology with large N populations of cells with some small mutation rate p, I encountered frequent crashes. 

# Details

I found the numpy C-implementation of the BINV algorithm and noted they had no i32::MAX constraint to enter. The issue with the current implementation comes as a result of powi() taking i32. I modified the current algorithm to fit the implementation that numpy uses which relaxes this constraint. I tested the new algorithm against a handful of (n,p) values for large n,p and it seems to match what I get in python. I don't think this introduces any new panic/crash conditions, but I may have missed something.
