### PR TITLE
No usize except uniform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Rename `rand::distributions` to `rand::distr` (#1470)
 - The `serde1` feature has been renamed `serde` (#1477)
 - Mark `WeightError`, `PoissonError`, `BinomialError` as `#[non_exhaustive]` (#1480).
+- Add `UniformUsize` and use to make `Uniform` for `usize` portable (#1487)
+- Remove support for generating `isize` and `usize` values with `Standard`, `Uniform` and `Fill` and usage as a `WeightedAliasIndex` weight (#1487)
 
 ## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)

--- a/benches/benches/standard.rs
+++ b/benches/benches/standard.rs
@@ -49,7 +49,7 @@ pub fn bench(c: &mut Criterion) {
         };
     }
 
-    do_ty!(i8, i16, i32, i64, i128, isize);
+    do_ty!(i8, i16, i32, i64, i128);
     do_ty!(f32, f64);
     do_ty!(char);
 

--- a/rand_distr/src/weighted_alias.rs
+++ b/rand_distr/src/weighted_alias.rs
@@ -365,7 +365,6 @@ impl_weight_for_int!(u64);
 impl_weight_for_int!(u32);
 impl_weight_for_int!(u16);
 impl_weight_for_int!(u8);
-impl_weight_for_int!(isize);
 impl_weight_for_int!(i128);
 impl_weight_for_int!(i64);
 impl_weight_for_int!(i32);

--- a/src/distr/integer.rs
+++ b/src/distr/integer.rs
@@ -19,8 +19,8 @@ use core::arch::x86_64::__m512i;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::{__m128i, __m256i};
 use core::num::{
-    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
-    NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
+    NonZeroU32, NonZeroU64, NonZeroU8,
 };
 #[cfg(feature = "simd_support")]
 use core::simd::*;
@@ -63,20 +63,6 @@ impl Distribution<u128> for Standard {
     }
 }
 
-impl Distribution<usize> for Standard {
-    #[inline]
-    #[cfg(any(target_pointer_width = "32", target_pointer_width = "16"))]
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
-        rng.next_u32() as usize
-    }
-
-    #[inline]
-    #[cfg(target_pointer_width = "64")]
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
-        rng.next_u64() as usize
-    }
-}
-
 macro_rules! impl_int_from_uint {
     ($ty:ty, $uty:ty) => {
         impl Distribution<$ty> for Standard {
@@ -93,7 +79,6 @@ impl_int_from_uint! { i16, u16 }
 impl_int_from_uint! { i32, u32 }
 impl_int_from_uint! { i64, u64 }
 impl_int_from_uint! { i128, u128 }
-impl_int_from_uint! { isize, usize }
 
 macro_rules! impl_nzint {
     ($ty:ty, $new:path) => {
@@ -114,14 +99,12 @@ impl_nzint!(NonZeroU16, NonZeroU16::new);
 impl_nzint!(NonZeroU32, NonZeroU32::new);
 impl_nzint!(NonZeroU64, NonZeroU64::new);
 impl_nzint!(NonZeroU128, NonZeroU128::new);
-impl_nzint!(NonZeroUsize, NonZeroUsize::new);
 
 impl_nzint!(NonZeroI8, NonZeroI8::new);
 impl_nzint!(NonZeroI16, NonZeroI16::new);
 impl_nzint!(NonZeroI32, NonZeroI32::new);
 impl_nzint!(NonZeroI64, NonZeroI64::new);
 impl_nzint!(NonZeroI128, NonZeroI128::new);
-impl_nzint!(NonZeroIsize, NonZeroIsize::new);
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 macro_rules! x86_intrinsic_impl {
@@ -163,7 +146,7 @@ macro_rules! simd_impl {
 }
 
 #[cfg(feature = "simd_support")]
-simd_impl!(u8, i8, u16, i16, u32, i32, u64, i64, usize, isize);
+simd_impl!(u8, i8, u16, i16, u32, i32, u64, i64);
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 x86_intrinsic_impl!(
@@ -191,14 +174,12 @@ mod tests {
     fn test_integers() {
         let mut rng = crate::test::rng(806);
 
-        rng.sample::<isize, _>(Standard);
         rng.sample::<i8, _>(Standard);
         rng.sample::<i16, _>(Standard);
         rng.sample::<i32, _>(Standard);
         rng.sample::<i64, _>(Standard);
         rng.sample::<i128, _>(Standard);
 
-        rng.sample::<usize, _>(Standard);
         rng.sample::<u8, _>(Standard);
         rng.sample::<u16, _>(Standard);
         rng.sample::<u32, _>(Standard);
@@ -237,17 +218,6 @@ mod tests {
                 296930161868957086625409848350820761097,
                 145644820879247630242265036535529306392,
                 111087889832015897993126088499035356354,
-            ],
-        );
-        #[cfg(any(target_pointer_width = "32", target_pointer_width = "16"))]
-        test_samples(0usize, &[2220326409, 2575017975, 2018088303]);
-        #[cfg(target_pointer_width = "64")]
-        test_samples(
-            0usize,
-            &[
-                11059617991457472009,
-                16096616328739788143,
-                1487364411147516184,
             ],
         );
 

--- a/src/distr/slice.rs
+++ b/src/distr/slice.rs
@@ -8,39 +8,10 @@
 
 use core::num::NonZeroUsize;
 
-use crate::distr::{Distribution, Uniform};
-use crate::Rng;
+use crate::distr::uniform::{UniformSampler, UniformUsize};
+use crate::distr::Distribution;
 #[cfg(feature = "alloc")]
 use alloc::string::String;
-
-#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
-compile_error!("unsupported pointer width");
-
-#[derive(Debug, Clone, Copy)]
-enum UniformUsize {
-    U32(Uniform<u32>),
-    #[cfg(target_pointer_width = "64")]
-    U64(Uniform<u64>),
-}
-
-impl UniformUsize {
-    pub fn new(ubound: usize) -> Result<Self, super::uniform::Error> {
-        #[cfg(target_pointer_width = "64")]
-        if ubound > (u32::MAX as usize) {
-            return Uniform::new(0, ubound as u64).map(UniformUsize::U64);
-        }
-
-        Uniform::new(0, ubound as u32).map(UniformUsize::U32)
-    }
-
-    pub fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
-        match self {
-            UniformUsize::U32(uu) => uu.sample(rng) as usize,
-            #[cfg(target_pointer_width = "64")]
-            UniformUsize::U64(uu) => uu.sample(rng) as usize,
-        }
-    }
-}
 
 /// A distribution to sample items uniformly from a slice.
 ///
@@ -110,7 +81,7 @@ impl<'a, T> Slice<'a, T> {
 
         Ok(Self {
             slice,
-            range: UniformUsize::new(num_choices.get()).unwrap(),
+            range: UniformUsize::new(0, num_choices.get()).unwrap(),
             num_choices,
         })
     }

--- a/src/distr/uniform.rs
+++ b/src/distr/uniform.rs
@@ -112,7 +112,7 @@ pub use float::UniformFloat;
 #[path = "uniform_int.rs"]
 mod int;
 #[doc(inline)]
-pub use int::UniformInt;
+pub use int::{UniformInt, UniformUsize};
 
 #[path = "uniform_other.rs"]
 mod other;

--- a/src/distr/uniform.rs
+++ b/src/distr/uniform.rs
@@ -120,7 +120,7 @@ mod other;
 pub use other::{UniformChar, UniformDuration};
 
 use core::fmt;
-use core::ops::{Range, RangeInclusive};
+use core::ops::{Range, RangeInclusive, RangeTo, RangeToInclusive};
 
 use crate::distr::Distribution;
 use crate::{Rng, RngCore};
@@ -438,6 +438,41 @@ impl<T: SampleUniform + PartialOrd> SampleRange<T> for RangeInclusive<T> {
         !(self.start() <= self.end())
     }
 }
+
+macro_rules! impl_sample_range_u {
+    ($t:ty) => {
+        impl SampleRange<$t> for RangeTo<$t> {
+            #[inline]
+            fn sample_single<R: RngCore + ?Sized>(self, rng: &mut R) -> Result<$t, Error> {
+                <$t as SampleUniform>::Sampler::sample_single(0, self.end, rng)
+            }
+
+            #[inline]
+            fn is_empty(&self) -> bool {
+                0 == self.end
+            }
+        }
+
+        impl SampleRange<$t> for RangeToInclusive<$t> {
+            #[inline]
+            fn sample_single<R: RngCore + ?Sized>(self, rng: &mut R) -> Result<$t, Error> {
+                <$t as SampleUniform>::Sampler::sample_single_inclusive(0, self.end, rng)
+            }
+
+            #[inline]
+            fn is_empty(&self) -> bool {
+                false
+            }
+        }
+    };
+}
+
+impl_sample_range_u!(u8);
+impl_sample_range_u!(u16);
+impl_sample_range_u!(u32);
+impl_sample_range_u!(u64);
+impl_sample_range_u!(u128);
+impl_sample_range_u!(usize);
 
 #[cfg(test)]
 mod tests {

--- a/src/distr/uniform.rs
+++ b/src/distr/uniform.rs
@@ -530,12 +530,6 @@ mod tests {
             assert_eq!(&buf, expected_multiple);
         }
 
-        // We test on a sub-set of types; possibly we should do more.
-        // TODO: SIMD types
-
-        test_samples(11u8, 219, &[17, 66, 214], &[181, 93, 165]);
-        test_samples(11u32, 219, &[17, 66, 214], &[181, 93, 165]);
-
         test_samples(
             0f32,
             1e-2f32,

--- a/src/distr/uniform_int.rs
+++ b/src/distr/uniform_int.rs
@@ -258,7 +258,6 @@ uniform_int_impl! { i16, u16, u32 }
 uniform_int_impl! { i32, u32, u32 }
 uniform_int_impl! { i64, u64, u64 }
 uniform_int_impl! { i128, u128, u128 }
-uniform_int_impl! { isize, usize, usize }
 uniform_int_impl! { u8, u8, u32 }
 uniform_int_impl! { u16, u16, u32 }
 uniform_int_impl! { u32, u32, u32 }
@@ -611,7 +610,7 @@ mod tests {
                 );)*
             }};
         }
-        t!(i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, i128, u128);
+        t!(i8, i16, i32, i64, i128, u8, u16, u32, u64, usize, u128);
 
         #[cfg(feature = "simd_support")]
         {

--- a/src/distr/uniform_int.rs
+++ b/src/distr/uniform_int.rs
@@ -263,7 +263,6 @@ uniform_int_impl! { u8, u8, u32 }
 uniform_int_impl! { u16, u16, u32 }
 uniform_int_impl! { u32, u32, u32 }
 uniform_int_impl! { u64, u64, u64 }
-uniform_int_impl! { usize, usize, usize }
 uniform_int_impl! { u128, u128, u128 }
 
 #[cfg(feature = "simd_support")]
@@ -384,6 +383,142 @@ macro_rules! uniform_simd_int_impl {
 
 #[cfg(feature = "simd_support")]
 uniform_simd_int_impl! { (u8, i8), (u16, i16), (u32, i32), (u64, i64) }
+
+/// The back-end implementing [`UniformSampler`] for `usize`.
+///
+/// # Implementation notes
+///
+/// Sampling a `usize` value is usually used in relation to the length of an
+/// array or other memory structure, thus it is reasonable to assume that the
+/// vast majority of use-cases will have a maximum size under [`u32::MAX`].
+/// In part to optimise for this use-case, but mostly to ensure that results
+/// are portable across 32-bit and 64-bit architectures (as far as is possible),
+/// this implementation will use 32-bit sampling when possible.
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UniformUsize(UniformUsizeImpl);
+
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+impl SampleUniform for usize {
+    type Sampler = UniformUsize;
+}
+
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UniformUsizeImpl {
+    U32(UniformInt<u32>),
+    #[cfg(target_pointer_width = "64")]
+    U64(UniformInt<u64>),
+}
+
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+impl UniformSampler for UniformUsize {
+    type X = usize;
+
+    #[inline] // if the range is constant, this helps LLVM to do the
+              // calculations at compile-time.
+    fn new<B1, B2>(low_b: B1, high_b: B2) -> Result<Self, Error>
+    where
+        B1: SampleBorrow<Self::X> + Sized,
+        B2: SampleBorrow<Self::X> + Sized,
+    {
+        let low = *low_b.borrow();
+        let high = *high_b.borrow();
+        if !(low < high) {
+            return Err(Error::EmptyRange);
+        }
+
+        #[cfg(target_pointer_width = "64")]
+        if high > (u32::MAX as usize) {
+            return UniformInt::new(low as u64, high as u64)
+                .map(|ui| UniformUsize(UniformUsizeImpl::U64(ui)));
+        }
+
+        UniformInt::new(low as u32, high as u32).map(|ui| UniformUsize(UniformUsizeImpl::U32(ui)))
+    }
+
+    #[inline] // if the range is constant, this helps LLVM to do the
+              // calculations at compile-time.
+    fn new_inclusive<B1, B2>(low_b: B1, high_b: B2) -> Result<Self, Error>
+    where
+        B1: SampleBorrow<Self::X> + Sized,
+        B2: SampleBorrow<Self::X> + Sized,
+    {
+        let low = *low_b.borrow();
+        let high = *high_b.borrow();
+        if !(low <= high) {
+            return Err(Error::EmptyRange);
+        }
+
+        #[cfg(target_pointer_width = "64")]
+        if high > (u32::MAX as usize) {
+            return UniformInt::new_inclusive(low as u64, high as u64)
+                .map(|ui| UniformUsize(UniformUsizeImpl::U64(ui)));
+        }
+
+        UniformInt::new_inclusive(low as u32, high as u32)
+            .map(|ui| UniformUsize(UniformUsizeImpl::U32(ui)))
+    }
+
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
+        match self.0 {
+            UniformUsizeImpl::U32(uu) => uu.sample(rng) as usize,
+            #[cfg(target_pointer_width = "64")]
+            UniformUsizeImpl::U64(uu) => uu.sample(rng) as usize,
+        }
+    }
+
+    #[inline]
+    fn sample_single<R: Rng + ?Sized, B1, B2>(
+        low_b: B1,
+        high_b: B2,
+        rng: &mut R,
+    ) -> Result<Self::X, Error>
+    where
+        B1: SampleBorrow<Self::X> + Sized,
+        B2: SampleBorrow<Self::X> + Sized,
+    {
+        let low = *low_b.borrow();
+        let high = *high_b.borrow();
+        if !(low < high) {
+            return Err(Error::EmptyRange);
+        }
+
+        #[cfg(target_pointer_width = "64")]
+        if high > (u32::MAX as usize) {
+            return UniformInt::<u64>::sample_single(low as u64, high as u64, rng)
+                .map(|x| x as usize);
+        }
+
+        UniformInt::<u32>::sample_single(low as u32, high as u32, rng).map(|x| x as usize)
+    }
+
+    #[inline]
+    fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(
+        low_b: B1,
+        high_b: B2,
+        rng: &mut R,
+    ) -> Result<Self::X, Error>
+    where
+        B1: SampleBorrow<Self::X> + Sized,
+        B2: SampleBorrow<Self::X> + Sized,
+    {
+        let low = *low_b.borrow();
+        let high = *high_b.borrow();
+        if !(low <= high) {
+            return Err(Error::EmptyRange);
+        }
+
+        #[cfg(target_pointer_width = "64")]
+        if high > (u32::MAX as usize) {
+            return UniformInt::<u64>::sample_single_inclusive(low as u64, high as u64, rng)
+                .map(|x| x as usize);
+        }
+
+        UniformInt::<u32>::sample_single_inclusive(low as u32, high as u32, rng).map(|x| x as usize)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,13 +179,13 @@ mod test {
     #[test]
     #[cfg(all(feature = "std", feature = "std_rng", feature = "getrandom"))]
     fn test_random() {
-        let _n: usize = random();
+        let _n: u64 = random();
         let _f: f32 = random();
         let _o: Option<Option<i8>> = random();
         #[allow(clippy::type_complexity)]
         let _many: (
             (),
-            (usize, isize, Option<(u32, (bool,))>),
+            Option<(u32, (bool,))>,
             (u8, i8, u16, i16, u32, i32, u64, i64),
             (f32, (f64, (f64,))),
         ) = random();

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -407,8 +407,8 @@ macro_rules! impl_fill {
     }
 }
 
-impl_fill!(u16, u32, u64, usize, u128,);
-impl_fill!(i8, i16, i32, i64, isize, i128,);
+impl_fill!(u16, u32, u64, u128,);
+impl_fill!(i8, i16, i32, i64, i128,);
 
 impl<T, const N: usize> Fill for [T; N]
 where

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -102,7 +102,8 @@ pub trait Rng: RngCore {
     /// made from the given range. See also the [`Uniform`] distribution
     /// type which may be faster if sampling from the same range repeatedly.
     ///
-    /// Only `gen_range(low..high)` and `gen_range(low..=high)` are supported.
+    /// All types support `low..high_exclusive` and `low..=high` range syntax.
+    /// Unsigned integer types also support `..high_exclusive` and `..=high` syntax.
     ///
     /// # Panics
     ///
@@ -116,13 +117,13 @@ pub trait Rng: RngCore {
     /// let mut rng = thread_rng();
     ///
     /// // Exclusive range
-    /// let n: u32 = rng.gen_range(0..10);
+    /// let n: u32 = rng.gen_range(..10);
     /// println!("{}", n);
     /// let m: f64 = rng.gen_range(-40.0..1.3e5);
     /// println!("{}", m);
     ///
     /// // Inclusive range
-    /// let n: u32 = rng.gen_range(0..=10);
+    /// let n: u32 = rng.gen_range(..=10);
     /// println!("{}", n);
     /// ```
     ///
@@ -500,7 +501,7 @@ mod test {
             let a: u32 = r.gen_range(12..=24);
             assert!((12..=24).contains(&a));
 
-            assert_eq!(r.gen_range(0u32..1), 0u32);
+            assert_eq!(r.gen_range(..1u32), 0u32);
             assert_eq!(r.gen_range(-12i64..-11), -12i64);
             assert_eq!(r.gen_range(3_000_000..3_000_001), 3_000_000);
         }

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -434,7 +434,7 @@ where
     debug_assert!(amount <= length);
     let mut indices = Vec::with_capacity(amount as usize);
     for j in length - amount..length {
-        let t = rng.gen_range(0..=j);
+        let t = rng.gen_range(..=j);
         if let Some(pos) = indices.iter().position(|&x| x == t) {
             indices[pos] = j;
         }

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -43,20 +43,20 @@ impl IndexVec {
     /// Returns the number of indices
     #[inline]
     pub fn len(&self) -> usize {
-        match *self {
-            IndexVec::U32(ref v) => v.len(),
+        match self {
+            IndexVec::U32(v) => v.len(),
             #[cfg(target_pointer_width = "64")]
-            IndexVec::U64(ref v) => v.len(),
+            IndexVec::U64(v) => v.len(),
         }
     }
 
     /// Returns `true` if the length is 0.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        match *self {
-            IndexVec::U32(ref v) => v.is_empty(),
+        match self {
+            IndexVec::U32(v) => v.is_empty(),
             #[cfg(target_pointer_width = "64")]
-            IndexVec::U64(ref v) => v.is_empty(),
+            IndexVec::U64(v) => v.is_empty(),
         }
     }
 
@@ -66,10 +66,10 @@ impl IndexVec {
     /// restrictions.)
     #[inline]
     pub fn index(&self, index: usize) -> usize {
-        match *self {
-            IndexVec::U32(ref v) => v[index] as usize,
+        match self {
+            IndexVec::U32(v) => v[index] as usize,
             #[cfg(target_pointer_width = "64")]
-            IndexVec::U64(ref v) => v[index] as usize,
+            IndexVec::U64(v) => v[index] as usize,
         }
     }
 
@@ -86,10 +86,10 @@ impl IndexVec {
     /// Iterate over the indices as a sequence of `usize` values
     #[inline]
     pub fn iter(&self) -> IndexVecIter<'_> {
-        match *self {
-            IndexVec::U32(ref v) => IndexVecIter::U32(v.iter()),
+        match self {
+            IndexVec::U32(v) => IndexVecIter::U32(v.iter()),
             #[cfg(target_pointer_width = "64")]
-            IndexVec::U64(ref v) => IndexVecIter::U64(v.iter()),
+            IndexVec::U64(v) => IndexVecIter::U64(v.iter()),
         }
     }
 }
@@ -158,17 +158,17 @@ impl<'a> Iterator for IndexVecIter<'a> {
     #[inline]
     fn next(&mut self) -> Option<usize> {
         use self::IndexVecIter::*;
-        match *self {
-            U32(ref mut iter) => iter.next().map(|i| *i as usize),
-            U64(ref mut iter) => iter.next().map(|i| *i as usize),
+        match self {
+            U32(iter) => iter.next().map(|i| *i as usize),
+            U64(iter) => iter.next().map(|i| *i as usize),
         }
     }
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        match *self {
-            IndexVecIter::U32(ref v) => v.size_hint(),
-            IndexVecIter::U64(ref v) => v.size_hint(),
+        match self {
+            IndexVecIter::U32(v) => v.size_hint(),
+            IndexVecIter::U64(v) => v.size_hint(),
         }
     }
 }
@@ -190,18 +190,18 @@ impl Iterator for IndexVecIntoIter {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         use self::IndexVecIntoIter::*;
-        match *self {
-            U32(ref mut v) => v.next().map(|i| i as usize),
-            U64(ref mut v) => v.next().map(|i| i as usize),
+        match self {
+            U32(v) => v.next().map(|i| i as usize),
+            U64(v) => v.next().map(|i| i as usize),
         }
     }
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         use self::IndexVecIntoIter::*;
-        match *self {
-            U32(ref v) => v.size_hint(),
-            U64(ref v) => v.size_hint(),
+        match self {
+            U32(v) => v.size_hint(),
+            U64(v) => v.size_hint(),
         }
     }
 }
@@ -627,6 +627,7 @@ mod test {
                         assert!((i as usize) < len);
                     }
                 }
+                #[cfg(target_pointer_width = "64")]
                 _ => panic!("expected `IndexVec::U32`"),
             }
         }

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -36,7 +36,7 @@ pub enum IndexVec {
     U32(Vec<u32>),
     #[cfg(target_pointer_width = "64")]
     #[doc(hidden)]
-    USize(Vec<usize>),
+    U64(Vec<u64>),
 }
 
 impl IndexVec {
@@ -46,7 +46,7 @@ impl IndexVec {
         match *self {
             IndexVec::U32(ref v) => v.len(),
             #[cfg(target_pointer_width = "64")]
-            IndexVec::USize(ref v) => v.len(),
+            IndexVec::U64(ref v) => v.len(),
         }
     }
 
@@ -56,7 +56,7 @@ impl IndexVec {
         match *self {
             IndexVec::U32(ref v) => v.is_empty(),
             #[cfg(target_pointer_width = "64")]
-            IndexVec::USize(ref v) => v.is_empty(),
+            IndexVec::U64(ref v) => v.is_empty(),
         }
     }
 
@@ -69,7 +69,7 @@ impl IndexVec {
         match *self {
             IndexVec::U32(ref v) => v[index] as usize,
             #[cfg(target_pointer_width = "64")]
-            IndexVec::USize(ref v) => v[index],
+            IndexVec::U64(ref v) => v[index] as usize,
         }
     }
 
@@ -79,7 +79,7 @@ impl IndexVec {
         match self {
             IndexVec::U32(v) => v.into_iter().map(|i| i as usize).collect(),
             #[cfg(target_pointer_width = "64")]
-            IndexVec::USize(v) => v,
+            IndexVec::U64(v) => v.into_iter().map(|i| i as usize).collect(),
         }
     }
 
@@ -89,7 +89,7 @@ impl IndexVec {
         match *self {
             IndexVec::U32(ref v) => IndexVecIter::U32(v.iter()),
             #[cfg(target_pointer_width = "64")]
-            IndexVec::USize(ref v) => IndexVecIter::USize(v.iter()),
+            IndexVec::U64(ref v) => IndexVecIter::U64(v.iter()),
         }
     }
 }
@@ -104,7 +104,7 @@ impl IntoIterator for IndexVec {
         match self {
             IndexVec::U32(v) => IndexVecIntoIter::U32(v.into_iter()),
             #[cfg(target_pointer_width = "64")]
-            IndexVec::USize(v) => IndexVecIntoIter::USize(v.into_iter()),
+            IndexVec::U64(v) => IndexVecIntoIter::U64(v.into_iter()),
         }
     }
 }
@@ -115,14 +115,14 @@ impl PartialEq for IndexVec {
         match (self, other) {
             (U32(v1), U32(v2)) => v1 == v2,
             #[cfg(target_pointer_width = "64")]
-            (USize(v1), USize(v2)) => v1 == v2,
+            (U64(v1), U64(v2)) => v1 == v2,
             #[cfg(target_pointer_width = "64")]
-            (U32(v1), USize(v2)) => {
-                (v1.len() == v2.len()) && (v1.iter().zip(v2.iter()).all(|(x, y)| *x as usize == *y))
+            (U32(v1), U64(v2)) => {
+                (v1.len() == v2.len()) && (v1.iter().zip(v2.iter()).all(|(x, y)| *x as u64 == *y))
             }
             #[cfg(target_pointer_width = "64")]
-            (USize(v1), U32(v2)) => {
-                (v1.len() == v2.len()) && (v1.iter().zip(v2.iter()).all(|(x, y)| *x == *y as usize))
+            (U64(v1), U32(v2)) => {
+                (v1.len() == v2.len()) && (v1.iter().zip(v2.iter()).all(|(x, y)| *x == *y as u64))
             }
         }
     }
@@ -136,10 +136,10 @@ impl From<Vec<u32>> for IndexVec {
 }
 
 #[cfg(target_pointer_width = "64")]
-impl From<Vec<usize>> for IndexVec {
+impl From<Vec<u64>> for IndexVec {
     #[inline]
-    fn from(v: Vec<usize>) -> Self {
-        IndexVec::USize(v)
+    fn from(v: Vec<u64>) -> Self {
+        IndexVec::U64(v)
     }
 }
 
@@ -149,7 +149,7 @@ pub enum IndexVecIter<'a> {
     #[doc(hidden)]
     U32(slice::Iter<'a, u32>),
     #[doc(hidden)]
-    USize(slice::Iter<'a, usize>),
+    U64(slice::Iter<'a, u64>),
 }
 
 impl<'a> Iterator for IndexVecIter<'a> {
@@ -160,7 +160,7 @@ impl<'a> Iterator for IndexVecIter<'a> {
         use self::IndexVecIter::*;
         match *self {
             U32(ref mut iter) => iter.next().map(|i| *i as usize),
-            USize(ref mut iter) => iter.next().cloned(),
+            U64(ref mut iter) => iter.next().map(|i| *i as usize),
         }
     }
 
@@ -168,7 +168,7 @@ impl<'a> Iterator for IndexVecIter<'a> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         match *self {
             IndexVecIter::U32(ref v) => v.size_hint(),
-            IndexVecIter::USize(ref v) => v.size_hint(),
+            IndexVecIter::U64(ref v) => v.size_hint(),
         }
     }
 }
@@ -181,7 +181,7 @@ pub enum IndexVecIntoIter {
     #[doc(hidden)]
     U32(vec::IntoIter<u32>),
     #[doc(hidden)]
-    USize(vec::IntoIter<usize>),
+    U64(vec::IntoIter<u64>),
 }
 
 impl Iterator for IndexVecIntoIter {
@@ -192,7 +192,7 @@ impl Iterator for IndexVecIntoIter {
         use self::IndexVecIntoIter::*;
         match *self {
             U32(ref mut v) => v.next().map(|i| i as usize),
-            USize(ref mut v) => v.next(),
+            U64(ref mut v) => v.next().map(|i| i as usize),
         }
     }
 
@@ -201,7 +201,7 @@ impl Iterator for IndexVecIntoIter {
         use self::IndexVecIntoIter::*;
         match *self {
             U32(ref v) => v.size_hint(),
-            USize(ref v) => v.size_hint(),
+            U64(ref v) => v.size_hint(),
         }
     }
 }
@@ -245,7 +245,7 @@ where
         // We never want to use inplace here, but could use floyd's alg
         // Lazy version: always use the cache alg.
         #[cfg(target_pointer_width = "64")]
-        return sample_rejection(rng, length, amount);
+        return sample_rejection(rng, length as u64, amount as u64);
     }
     let amount = amount as u32;
     let length = length as u32;
@@ -307,7 +307,11 @@ where
         unreachable!();
 
         #[cfg(target_pointer_width = "64")]
-        sample_efraimidis_spirakis(rng, length, weight, amount)
+        {
+            let amount = amount as u64;
+            let length = length as u64;
+            sample_efraimidis_spirakis(rng, length, weight, amount)
+        }
     } else {
         assert!(amount <= u32::MAX as usize);
         let amount = amount as u32;
@@ -486,7 +490,7 @@ impl UInt for u32 {
 }
 
 #[cfg(target_pointer_width = "64")]
-impl UInt for usize {
+impl UInt for u64 {
     #[inline]
     fn zero() -> Self {
         0
@@ -499,7 +503,7 @@ impl UInt for usize {
 
     #[inline]
     fn as_usize(self) -> usize {
-        self
+        self as usize
     }
 }
 

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -148,6 +148,7 @@ impl From<Vec<u64>> for IndexVec {
 pub enum IndexVecIter<'a> {
     #[doc(hidden)]
     U32(slice::Iter<'a, u32>),
+    #[cfg(target_pointer_width = "64")]
     #[doc(hidden)]
     U64(slice::Iter<'a, u64>),
 }
@@ -160,6 +161,7 @@ impl<'a> Iterator for IndexVecIter<'a> {
         use self::IndexVecIter::*;
         match self {
             U32(iter) => iter.next().map(|i| *i as usize),
+            #[cfg(target_pointer_width = "64")]
             U64(iter) => iter.next().map(|i| *i as usize),
         }
     }
@@ -168,6 +170,7 @@ impl<'a> Iterator for IndexVecIter<'a> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self {
             IndexVecIter::U32(v) => v.size_hint(),
+            #[cfg(target_pointer_width = "64")]
             IndexVecIter::U64(v) => v.size_hint(),
         }
     }
@@ -180,6 +183,7 @@ impl<'a> ExactSizeIterator for IndexVecIter<'a> {}
 pub enum IndexVecIntoIter {
     #[doc(hidden)]
     U32(vec::IntoIter<u32>),
+    #[cfg(target_pointer_width = "64")]
     #[doc(hidden)]
     U64(vec::IntoIter<u64>),
 }
@@ -192,6 +196,7 @@ impl Iterator for IndexVecIntoIter {
         use self::IndexVecIntoIter::*;
         match self {
             U32(v) => v.next().map(|i| i as usize),
+            #[cfg(target_pointer_width = "64")]
             U64(v) => v.next().map(|i| i as usize),
         }
     }
@@ -201,6 +206,7 @@ impl Iterator for IndexVecIntoIter {
         use self::IndexVecIntoIter::*;
         match self {
             U32(v) => v.size_hint(),
+            #[cfg(target_pointer_width = "64")]
             U64(v) => v.size_hint(),
         }
     }

--- a/src/seq/iterator.rs
+++ b/src/seq/iterator.rs
@@ -70,7 +70,7 @@ pub trait IteratorRandom: Iterator + Sized {
             return match lower {
                 0 => None,
                 1 => self.next(),
-                _ => self.nth(rng.gen_range(0..lower)),
+                _ => self.nth(rng.gen_range(..lower)),
             };
         }
 
@@ -80,7 +80,7 @@ pub trait IteratorRandom: Iterator + Sized {
         // Continue until the iterator is exhausted
         loop {
             if lower > 1 {
-                let ix = coin_flipper.rng.gen_range(0..lower + consumed);
+                let ix = coin_flipper.rng.gen_range(..lower + consumed);
                 let skip = if ix < lower {
                     result = self.nth(ix);
                     lower - (ix + 1)
@@ -203,7 +203,7 @@ pub trait IteratorRandom: Iterator + Sized {
 
         // Continue, since the iterator was not exhausted
         for (i, elem) in self.enumerate() {
-            let k = rng.gen_range(0..i + 1 + amount);
+            let k = rng.gen_range(..i + 1 + amount);
             if let Some(slot) = buf.get_mut(k) {
                 *slot = elem;
             }
@@ -239,7 +239,7 @@ pub trait IteratorRandom: Iterator + Sized {
         // If the iterator stops once, then so do we.
         if reservoir.len() == amount {
             for (i, elem) in self.enumerate() {
-                let k = rng.gen_range(0..i + 1 + amount);
+                let k = rng.gen_range(..i + 1 + amount);
                 if let Some(slot) = reservoir.get_mut(k) {
                     *slot = elem;
                 }

--- a/src/seq/iterator.rs
+++ b/src/seq/iterator.rs
@@ -9,7 +9,6 @@
 //! `IteratorRandom`
 
 use super::coin_flipper::CoinFlipper;
-use super::gen_index;
 #[allow(unused)]
 use super::IndexedRandom;
 use crate::Rng;
@@ -71,7 +70,7 @@ pub trait IteratorRandom: Iterator + Sized {
             return match lower {
                 0 => None,
                 1 => self.next(),
-                _ => self.nth(gen_index(rng, lower)),
+                _ => self.nth(rng.gen_range(0..lower)),
             };
         }
 
@@ -81,7 +80,7 @@ pub trait IteratorRandom: Iterator + Sized {
         // Continue until the iterator is exhausted
         loop {
             if lower > 1 {
-                let ix = gen_index(coin_flipper.rng, lower + consumed);
+                let ix = coin_flipper.rng.gen_range(0..lower + consumed);
                 let skip = if ix < lower {
                     result = self.nth(ix);
                     lower - (ix + 1)
@@ -204,7 +203,7 @@ pub trait IteratorRandom: Iterator + Sized {
 
         // Continue, since the iterator was not exhausted
         for (i, elem) in self.enumerate() {
-            let k = gen_index(rng, i + 1 + amount);
+            let k = rng.gen_range(0..i + 1 + amount);
             if let Some(slot) = buf.get_mut(k) {
                 *slot = elem;
             }
@@ -240,7 +239,7 @@ pub trait IteratorRandom: Iterator + Sized {
         // If the iterator stops once, then so do we.
         if reservoir.len() == amount {
             for (i, elem) in self.enumerate() {
-                let k = gen_index(rng, i + 1 + amount);
+                let k = rng.gen_range(0..i + 1 + amount);
                 if let Some(slot) = reservoir.get_mut(k) {
                     *slot = elem;
                 }

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -53,7 +53,11 @@ fn gen_index<R: Rng + ?Sized>(rng: &mut R, ubound: usize) -> usize {
     if ubound <= (u32::MAX as usize) {
         rng.gen_range(0..ubound as u32) as usize
     } else {
-        rng.gen_range(0..ubound)
+        #[cfg(target_pointer_width = "32")]
+        unreachable!();
+
+        #[cfg(target_pointer_width = "64")]
+        return rng.gen_range(0..ubound as u64) as usize;
     }
 }
 

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -43,27 +43,8 @@ pub use iterator::IteratorRandom;
 pub use slice::SliceChooseIter;
 pub use slice::{IndexedMutRandom, IndexedRandom, SliceRandom};
 
-use crate::Rng;
-
-// Sample a number uniformly between 0 and `ubound`. Uses 32-bit sampling where
-// possible, primarily in order to produce the same output on 32-bit and 64-bit
-// platforms.
-#[inline]
-fn gen_index<R: Rng + ?Sized>(rng: &mut R, ubound: usize) -> usize {
-    if ubound <= (u32::MAX as usize) {
-        rng.gen_range(0..ubound as u32) as usize
-    } else {
-        #[cfg(target_pointer_width = "32")]
-        unreachable!();
-
-        #[cfg(target_pointer_width = "64")]
-        return rng.gen_range(0..ubound as u64) as usize;
-    }
-}
-
 /// Low-level API for sampling indices
 pub mod index {
-    use super::gen_index;
     use crate::Rng;
 
     #[cfg(feature = "alloc")]
@@ -88,7 +69,7 @@ pub mod index {
         // Floyd's algorithm
         let mut indices = [0; N];
         for (i, j) in (len - N..len).enumerate() {
-            let t = gen_index(rng, j + 1);
+            let t = rng.gen_range(0..j + 1);
             if let Some(pos) = indices[0..i].iter().position(|&x| x == t) {
                 indices[pos] = j;
             }

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -69,7 +69,7 @@ pub mod index {
         // Floyd's algorithm
         let mut indices = [0; N];
         for (i, j) in (len - N..len).enumerate() {
-            let t = rng.gen_range(0..j + 1);
+            let t = rng.gen_range(..j + 1);
             if let Some(pos) = indices[0..i].iter().position(|&x| x == t) {
                 indices[pos] = j;
             }

--- a/src/seq/slice.rs
+++ b/src/seq/slice.rs
@@ -57,7 +57,7 @@ pub trait IndexedRandom: Index<usize> {
         if self.is_empty() {
             None
         } else {
-            Some(&self[rng.gen_range(0..self.len())])
+            Some(&self[rng.gen_range(..self.len())])
         }
     }
 
@@ -259,7 +259,7 @@ pub trait IndexedMutRandom: IndexedRandom + IndexMut<usize> {
             None
         } else {
             let len = self.len();
-            Some(&mut self[rng.gen_range(0..len)])
+            Some(&mut self[rng.gen_range(..len)])
         }
     }
 
@@ -410,7 +410,7 @@ impl<T> SliceRandom for [T] {
             }
         } else {
             for i in m..self.len() {
-                let index = rng.gen_range(0..i + 1);
+                let index = rng.gen_range(..i + 1);
                 self.swap(i, index);
             }
         }

--- a/src/seq/slice.rs
+++ b/src/seq/slice.rs
@@ -9,7 +9,7 @@
 //! `IndexedRandom`, `IndexedMutRandom`, `SliceRandom`
 
 use super::increasing_uniform::IncreasingUniform;
-use super::{gen_index, index};
+use super::index;
 #[cfg(feature = "alloc")]
 use crate::distr::uniform::{SampleBorrow, SampleUniform};
 #[cfg(feature = "alloc")]
@@ -57,7 +57,7 @@ pub trait IndexedRandom: Index<usize> {
         if self.is_empty() {
             None
         } else {
-            Some(&self[gen_index(rng, self.len())])
+            Some(&self[rng.gen_range(0..self.len())])
         }
     }
 
@@ -259,7 +259,7 @@ pub trait IndexedMutRandom: IndexedRandom + IndexMut<usize> {
             None
         } else {
             let len = self.len();
-            Some(&mut self[gen_index(rng, len)])
+            Some(&mut self[rng.gen_range(0..len)])
         }
     }
 
@@ -399,7 +399,7 @@ impl<T> SliceRandom for [T] {
         // It ensures that the last `amount` elements of the slice
         // are randomly selected from the whole slice.
 
-        // `IncreasingUniform::next_index()` is faster than `gen_index`
+        // `IncreasingUniform::next_index()` is faster than `Rng::gen_range`
         // but only works for 32 bit integers
         // So we must use the slow method if the slice is longer than that.
         if self.len() < (u32::MAX as usize) {
@@ -410,7 +410,7 @@ impl<T> SliceRandom for [T] {
             }
         } else {
             for i in m..self.len() {
-                let index = gen_index(rng, i + 1);
+                let index = rng.gen_range(0..i + 1);
                 self.swap(i, index);
             }
         }


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

This is #1471 without `Rng::gen_index`. Since we can't have `UniformUsize` without directly supporting `usize` in `Rng::gen_range` this is probably the best way to go.