### PR TITLE
Require SeedableRng::Seed to impl Clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Rename `rand::distributions` to `rand::distr` (#1470)
 - The `serde1` feature has been renamed `serde` (#1477)
 - Mark `WeightError`, `PoissonError`, `BinomialError` as `#[non_exhaustive]` (#1480).
-- Require `Clone` bound for `SeedableRng::Seed`. (#1491)
+- Require `Clone` and `AsRef` bound for `SeedableRng::Seed`. (#1491)
 
 ## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Rename `rand::distributions` to `rand::distr` (#1470)
 - The `serde1` feature has been renamed `serde` (#1477)
 - Mark `WeightError`, `PoissonError`, `BinomialError` as `#[non_exhaustive]` (#1480).
+- Require `Clone` bound for `SeedableRng::Seed`. (#1491)
 
 ## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -289,6 +289,7 @@ pub trait SeedableRng: Sized {
     /// use rand_core::SeedableRng;
     ///
     /// const N: usize = 64;
+    /// #[derive(Clone)]
     /// pub struct MyRngSeed(pub [u8; N]);
     /// # #[allow(dead_code)]
     /// pub struct MyRng(MyRngSeed);
@@ -313,7 +314,7 @@ pub trait SeedableRng: Sized {
     ///     }
     /// }
     /// ```
-    type Seed: Sized + Default + AsMut<[u8]>;
+    type Seed: Clone + Default + AsMut<[u8]>;
 
     /// Create a new PRNG using the given seed.
     ///

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -279,11 +279,9 @@ pub trait SeedableRng: Sized {
     ///
     /// # Implementing `SeedableRng` for RNGs with large seeds
     ///
-    /// Note that the required traits `core::default::Default` and
-    /// `core::convert::AsMut<u8>` are not implemented for large arrays
-    /// `[u8; N]` with `N` > 32. To be able to implement the traits required by
-    /// `SeedableRng` for RNGs with such large seeds, the newtype pattern can be
-    /// used:
+    /// Note that [`Default`] is not implemented for large arrays `[u8; N]` with
+    /// `N` > 32. To be able to implement the traits required by `SeedableRng`
+    /// for RNGs with such large seeds, the newtype pattern can be used:
     ///
     /// ```
     /// use rand_core::SeedableRng;
@@ -297,6 +295,12 @@ pub trait SeedableRng: Sized {
     /// impl Default for MyRngSeed {
     ///     fn default() -> MyRngSeed {
     ///         MyRngSeed([0; N])
+    ///     }
+    /// }
+    ///
+    /// impl AsRef<[u8]> for MyRngSeed {
+    ///     fn as_ref(&self) -> &[u8] {
+    ///         &self.0
     ///     }
     /// }
     ///
@@ -314,7 +318,7 @@ pub trait SeedableRng: Sized {
     ///     }
     /// }
     /// ```
-    type Seed: Clone + Default + AsMut<[u8]>;
+    type Seed: Clone + Default + AsRef<[u8]> + AsMut<[u8]>;
 
     /// Create a new PRNG using the given seed.
     ///


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Adds a `Clone` bound to `SeedableRng::Seed`.

# Motivation

Simply put: it's already possible to clone these seeds based upon the bounds already provided, but it's *really annoying* without a proper `Clone` bound. You can just as easily create a new one with `Default` and write all of the data from the old seed into the new one with `AsMut`, but this now requires me to do this explicitly instead of just being able to `derive(Clone)` on a struct that contains a seed.

# Details

This is also a breaking change, but I don't think people will have a problem including it in the next breaking release.