### PR TITLE
Inherent rng methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Implement `Distribution<u64>` for `Poisson<f64>` (#1498)
 - Limit the maximal acceptable lambda for `Poisson` to solve (#1312) (#1498)
 - Rename `Rng::gen_iter` to `random_iter` (#1500)
+- Implement `Rng` methods as inherent methods on `StepRng`, `SmallRng`, `StdRng`, `ThreadRng` (#1492)
 
 ## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)

--- a/rand_distr/src/triangular.rs
+++ b/rand_distr/src/triangular.rs
@@ -113,7 +113,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use rand::{rngs::mock, Rng};
+    use rand::rngs::mock;
 
     #[test]
     fn test_triangular() {

--- a/rand_distr/tests/pdf.rs
+++ b/rand_distr/tests/pdf.rs
@@ -9,7 +9,7 @@
 #![allow(clippy::float_cmp)]
 
 use average::Histogram;
-use rand::{Rng, SeedableRng};
+use rand::SeedableRng;
 use rand_distr::{Normal, SkewNormal};
 
 const HIST_LEN: usize = 100;

--- a/src/distr/float.rs
+++ b/src/distr/float.rs
@@ -32,10 +32,9 @@ use serde::{Deserialize, Serialize};
 ///
 /// # Example
 /// ```
-/// use rand::{thread_rng, Rng};
 /// use rand::distr::OpenClosed01;
 ///
-/// let val: f32 = thread_rng().sample(OpenClosed01);
+/// let val: f32 = rand::thread_rng().sample(OpenClosed01);
 /// println!("f32 from (0, 1): {}", val);
 /// ```
 ///
@@ -59,10 +58,9 @@ pub struct OpenClosed01;
 ///
 /// # Example
 /// ```
-/// use rand::{thread_rng, Rng};
 /// use rand::distr::Open01;
 ///
-/// let val: f32 = thread_rng().sample(Open01);
+/// let val: f32 = rand::thread_rng().sample(Open01);
 /// println!("f32 from (0, 1): {}", val);
 /// ```
 ///

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -34,10 +34,9 @@ use serde::{Deserialize, Serialize};
 /// # Example
 ///
 /// ```
-/// use rand::{Rng, thread_rng};
 /// use rand::distr::Alphanumeric;
 ///
-/// let mut rng = thread_rng();
+/// let mut rng = rand::thread_rng();
 /// let chars: String = (0..7).map(|_| rng.sample(Alphanumeric) as char).collect();
 /// println!("Random chars: {}", chars);
 /// ```

--- a/src/distr/slice.rs
+++ b/src/distr/slice.rs
@@ -33,7 +33,6 @@ use alloc::string::String;
 /// # Example
 ///
 /// ```
-/// use rand::Rng;
 /// use rand::distr::Slice;
 ///
 /// let vowels = ['a', 'e', 'i', 'o', 'u'];

--- a/src/distr/uniform.rs
+++ b/src/distr/uniform.rs
@@ -26,10 +26,9 @@
 //! # Example usage
 //!
 //! ```
-//! use rand::{Rng, thread_rng};
 //! use rand::distr::Uniform;
 //!
-//! let mut rng = thread_rng();
+//! let mut rng = rand::thread_rng();
 //! let side = Uniform::new(-10.0, 10.0).unwrap();
 //!
 //! // sample between 1 and 10 points
@@ -189,8 +188,6 @@ use serde::{Deserialize, Serialize};
 /// For a single sample, [`Rng::gen_range`] may be preferred:
 ///
 /// ```
-/// use rand::Rng;
-///
 /// let mut rng = rand::thread_rng();
 /// println!("{}", rng.gen_range(0..10));
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,6 @@
 //! # Quick Start
 //!
 //! ```
-//! // The prelude import enables methods we use below, specifically
-//! // Rng::random, Rng::sample, SliceRandom::shuffle and IndexedRandom::choose.
-//! use rand::prelude::*;
-//!
 //! // Get an RNG:
 //! let mut rng = rand::thread_rng();
 //!
@@ -26,6 +22,9 @@
 //! println!("char: '{}'", rng.random::<char>());
 //! // Try printing a random alphanumeric value instead!
 //! println!("alpha: '{}'", rng.sample(rand::distr::Alphanumeric) as char);
+//!
+//! // The prelude makes choose and shuffle available on sequences:
+//! use rand::prelude::*;
 //!
 //! // Generate and shuffle a sequence:
 //! let mut nums: Vec<i32> = (1..100).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ pub use rand_core::{CryptoRng, RngCore, SeedableRng, TryCryptoRng, TryRngCore};
 // Public modules
 pub mod distr;
 pub mod prelude;
+#[macro_use]
 mod rng;
 pub mod rngs;
 pub mod seq;
@@ -135,8 +136,6 @@ use crate::distr::{Distribution, Standard};
 /// following example can increase performance.
 ///
 /// ```
-/// use rand::Rng;
-///
 /// let mut v = vec![1, 2, 3];
 ///
 /// for x in v.iter_mut() {

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -22,7 +22,11 @@ use rand_core::RngCore;
 /// RNGs. It is implemented automatically for any `R: RngCore`.
 ///
 /// This trait must usually be brought into scope via `use rand::Rng;` or
-/// `use rand::prelude::*;`.
+/// `use rand::prelude::*;`. This is not necessary for
+/// [`ThreadRng`](crate::rngs::ThreadRng), [`StdRng`](crate::rngs::StdRng),
+/// [`SmallRng`](crate::rngs::SmallRng) and
+/// [`StepRng`](crate::rngs::mock::StepRng)
+/// which implement `Rng` methods as inherent methods.
 ///
 /// # Generic usage
 ///

--- a/src/rngs/mock.rs
+++ b/src/rngs/mock.rs
@@ -31,10 +31,7 @@ use serde::{Deserialize, Serialize};
 /// # Example
 ///
 /// ```
-/// use rand::Rng;
-/// use rand::rngs::mock::StepRng;
-///
-/// let mut my_rng = StepRng::new(2, 1);
+/// let mut my_rng = rand::rngs::mock::StepRng::new(2, 1);
 /// let sample: [u64; 3] = my_rng.random();
 /// assert_eq!(sample, [2, 3, 4]);
 /// ```
@@ -77,6 +74,8 @@ impl RngCore for StepRng {
 
 rand_core::impl_try_rng_from_rng_core!(StepRng);
 
+impl_rng_methods_as_inherent!(StepRng, crate, rand::rngs::mock::StepRng::new(1, 1));
+
 #[cfg(test)]
 mod tests {
     #[cfg(any(feature = "alloc", feature = "serde"))]
@@ -95,7 +94,7 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn test_bool() {
-        use crate::{distr::Standard, Rng};
+        use crate::distr::Standard;
 
         // If this result ever changes, update doc on StepRng!
         let rng = StepRng::new(0, 1 << 31);

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -129,3 +129,5 @@ impl SmallRng {
         SmallRng(Rng::from_seed(seed))
     }
 }
+
+impl_rng_methods_as_inherent!(SmallRng, crate, rand::rngs::SmallRng::from_thread_rng());

--- a/src/rngs/std.rs
+++ b/src/rngs/std.rs
@@ -93,6 +93,12 @@ impl CryptoRng for StdRng {}
 
 rand_core::impl_try_crypto_rng_from_crypto_rng!(StdRng);
 
+impl_rng_methods_as_inherent!(
+    StdRng,
+    crate,
+    <rand::rngs::StdRng as rand::SeedableRng>::from_os_rng()
+);
+
 #[cfg(test)]
 mod test {
     use crate::rngs::StdRng;

--- a/src/rngs/thread.rs
+++ b/src/rngs/thread.rs
@@ -121,8 +121,6 @@ thread_local!(
 ///
 /// Example usage:
 /// ```
-/// use rand::Rng;
-///
 /// # fn main() {
 /// // rand::random() may be used instead of rand::thread_rng().gen():
 /// println!("A random boolean: {}", rand::random::<bool>());
@@ -172,11 +170,12 @@ impl CryptoRng for ThreadRng {}
 
 rand_core::impl_try_crypto_rng_from_crypto_rng!(ThreadRng);
 
+impl_rng_methods_as_inherent!(ThreadRng, crate, rand::thread_rng());
+
 #[cfg(test)]
 mod test {
     #[test]
     fn test_thread_rng() {
-        use crate::Rng;
         let mut r = crate::thread_rng();
         r.random::<i32>();
         assert_eq!(r.gen_range(0..1), 0);


### PR DESCRIPTION
- [ ] Added a `CHANGELOG.md` entry

# Summary

Make `Rng` methods inherent methods on RNGs, and more usability tweaks.

# Motivation and details

This follows arguments made in #989 and #1488. Specifically,

- We rename `Rng::gen_iter` to `random_iter` since it is the iterable version of `Rng::random`
- We implement all (non-deprecated) `Rng` methods on `StdRng`, `SmallRng`, `ThreadRng` and `StepRng`
- ~~We remove `rand::random`, favouring usage of `rand::thread_rng().random` instead. This is not *necessary* but is more in-line with other `Rng` methods.~~ Change removed from this PR.

I *did* consider publicly exporting `impl_rng_methods_as_inherent`, but realised a problem: `rand_chacha` cannot use this since `rand` depends on `rand_chacha` (and the macro cannot be moved to `rand_core`); some other RNG crates *could* use this but *should not* depend on `rand`.

# Incomplete / questions

Do we want to rename `gen_range` to just `range`? What about `gen_bool`, `gen_ratio`?

*Do* we want to remove `rand::random`? If not, do we want to add `random_iter`, `gen_range` etc. as free functions? (`rand::random` is hardly used inside `rand` itself. [This GitHub search](https://github.com/search?q=rand%3A%3Arandom+path%3A*.rs&type=code&ref=advsearch) has 33k code hits but it's hard to tell how many are genuine matches.)

[@oconnor663 gave motivation](https://github.com/rust-random/rand/issues/989#issuecomment-2303902351) to rename `thread_rng` to just `rng`:

> you [the user] have to understand what `thread_rng` means and that it's the right thing to use

We *could* do this. If this were a clean design then probably we should: it's an implementation detail that we use a thread-local generator and not, say, a mutex over a single (static) generator. But it's also rather widely used: approx 150 mentions in this repo and 176k code hits via GitHub search.