### PR TITLE
Poisson: split Knuth/Rejection methods

### DIFF
--- a/benches/benches/distr.rs
+++ b/benches/benches/distr.rs
@@ -211,7 +211,9 @@ fn bench(c: &mut Criterion<CyclesPerByte>) {
 
 criterion_group!(
     name = benches;
-    config = Criterion::default().with_measurement(CyclesPerByte);
+    config = Criterion::default().with_measurement(CyclesPerByte)
+        .warm_up_time(core::time::Duration::from_secs(1))
+        .measurement_time(core::time::Duration::from_secs(2));
     targets = bench
 );
 criterion_main!(benches);

--- a/benches/benches/distr.rs
+++ b/benches/benches/distr.rs
@@ -111,14 +111,12 @@ macro_rules! sample_binomial {
 }
 
 fn bench(c: &mut Criterion<CyclesPerByte>) {
-    {
     let mut g = c.benchmark_group("exp");
     distr_float!(g, "exp", f64, Exp::new(1.23 * 4.56).unwrap());
     distr_float!(g, "exp1_specialized", f64, Exp1);
     distr_float!(g, "exp1_general", f64, Exp::new(1.).unwrap());
-    }
+    g.finish();
 
-    {
     let mut g = c.benchmark_group("normal");
     distr_float!(g, "normal", f64, Normal::new(-1.23, 4.56).unwrap());
     distr_float!(g, "standardnormal_specialized", f64, StandardNormal);
@@ -139,16 +137,14 @@ fn bench(c: &mut Criterion<CyclesPerByte>) {
             accum
         });
     });
-    }
+    g.finish();
 
-    {
     let mut g = c.benchmark_group("skew_normal");
     distr_float!(g, "shape_zero", f64, SkewNormal::new(0.0, 1.0, 0.0).unwrap());
     distr_float!(g, "shape_positive", f64, SkewNormal::new(0.0, 1.0, 100.0).unwrap());
     distr_float!(g, "shape_negative", f64, SkewNormal::new(0.0, 1.0, -100.0).unwrap());
-    }
+    g.finish();
 
-    {
     let mut g = c.benchmark_group("gamma");
     distr_float!(g, "gamma_large_shape", f64, Gamma::new(10., 1.0).unwrap());
     distr_float!(g, "gamma_small_shape", f64, Gamma::new(0.1, 1.0).unwrap());
@@ -156,25 +152,21 @@ fn bench(c: &mut Criterion<CyclesPerByte>) {
     distr_float!(g, "beta_large_param_similar", f64, Beta::new(101., 95.).unwrap());
     distr_float!(g, "beta_large_param_different", f64, Beta::new(10., 1000.).unwrap());
     distr_float!(g, "beta_mixed_param", f64, Beta::new(0.5, 100.).unwrap());
-    }
+    g.finish();
 
-    {
     let mut g = c.benchmark_group("cauchy");
     distr_float!(g, "cauchy", f64, Cauchy::new(4.2, 6.9).unwrap());
-    }
+    g.finish();
 
-    {
     let mut g = c.benchmark_group("triangular");
     distr_float!(g, "triangular", f64, Triangular::new(0., 1., 0.9).unwrap());
-    }
+    g.finish();
 
-    {
     let mut g = c.benchmark_group("geometric");
     distr_int!(g, "geometric", u64, Geometric::new(0.5).unwrap());
     distr_int!(g, "standard_geometric", u64, StandardGeometric);
-    }
+    g.finish();
 
-    {
     let mut g = c.benchmark_group("weighted");
     distr_int!(g, "weighted_i8", usize, WeightedIndex::new([1i8, 2, 3, 4, 12, 0, 2, 1]).unwrap());
     distr_int!(g, "weighted_u32", usize, WeightedIndex::new([1u32, 2, 3, 4, 12, 0, 2, 1]).unwrap());
@@ -184,9 +176,8 @@ fn bench(c: &mut Criterion<CyclesPerByte>) {
     distr_int!(g, "weighted_alias_method_u32", usize, WeightedAliasIndex::new(vec![1u32, 2, 3, 4, 12, 0, 2, 1]).unwrap());
     distr_int!(g, "weighted_alias_method_f64", usize, WeightedAliasIndex::new(vec![1.0f64, 0.001, 1.0/3.0, 4.01, 0.0, 3.3, 22.0, 0.001]).unwrap());
     distr_int!(g, "weighted_alias_method_large_set", usize, WeightedAliasIndex::new((0..10000).rev().chain(1..10001).collect()).unwrap());
-    }
+    g.finish();
 
-    {
     let mut g = c.benchmark_group("binomial");
     sample_binomial!(g, "binomial", 20, 0.7);
     sample_binomial!(g, "binomial_small", 1_000_000, 1e-30);
@@ -195,33 +186,28 @@ fn bench(c: &mut Criterion<CyclesPerByte>) {
     sample_binomial!(g, "binomial_100", 100, 0.99);
     sample_binomial!(g, "binomial_1000", 1000, 0.01);
     sample_binomial!(g, "binomial_1e12", 1_000_000_000_000, 0.2);
-    }
+    g.finish();
 
-    {
     let mut g = c.benchmark_group("poisson");
     distr_float!(g, "poisson", f64, Poisson::new(4.0).unwrap());
-    }
+    g.finish();
 
-    {
     let mut g = c.benchmark_group("zipf");
     distr_float!(g, "zipf", f64, Zipf::new(10, 1.5).unwrap());
     distr_float!(g, "zeta", f64, Zeta::new(1.5).unwrap());
-    }
+    g.finish();
 
-    {
     let mut g = c.benchmark_group("bernoulli");
     distr!(g, "bernoulli", bool, Bernoulli::new(0.18).unwrap());
-    }
+    g.finish();
 
-    {
     let mut g = c.benchmark_group("circle");
     distr_arr!(g, "circle", [f64; 2], UnitCircle);
-    }
+    g.finish();
 
-    {
     let mut g = c.benchmark_group("sphere");
     distr_arr!(g, "sphere", [f64; 3], UnitSphere);
-    }
+    g.finish();
 }
 
 criterion_group!(

--- a/benches/benches/distr.rs
+++ b/benches/benches/distr.rs
@@ -44,17 +44,6 @@ macro_rules! distr_float {
     };
 }
 
-macro_rules! distr {
-    ($group:ident, $fnn:expr, $ty:ty, $distr:expr) => {
-        $group.bench_function($fnn, |c| {
-            let mut rng = Pcg64Mcg::from_os_rng();
-            let distr = $distr;
-
-            c.iter(|| distr.sample(&mut rng));
-        });
-    };
-}
-
 macro_rules! distr_arr {
     ($group:ident, $fnn:expr, $ty:ty, $distr:expr) => {
         $group.bench_function($fnn, |c| {
@@ -159,7 +148,11 @@ fn bench(c: &mut Criterion<CyclesPerByte>) {
     g.finish();
 
     let mut g = c.benchmark_group("bernoulli");
-    distr!(g, "bernoulli", bool, Bernoulli::new(0.18).unwrap());
+    g.bench_function("bernoulli", |c| {
+        let mut rng = Pcg64Mcg::from_os_rng();
+        let distr = Bernoulli::new(0.18).unwrap();
+        c.iter(|| distr.sample(&mut rng))
+    });
     g.finish();
 
     let mut g = c.benchmark_group("unit");

--- a/benches/benches/distr.rs
+++ b/benches/benches/distr.rs
@@ -146,12 +146,15 @@ fn bench(c: &mut Criterion<CyclesPerByte>) {
     g.finish();
 
     let mut g = c.benchmark_group("gamma");
-    distr_float!(g, "gamma_large_shape", f64, Gamma::new(10., 1.0).unwrap());
-    distr_float!(g, "gamma_small_shape", f64, Gamma::new(0.1, 1.0).unwrap());
-    distr_float!(g, "beta_small_param", f64, Beta::new(0.1, 0.1).unwrap());
-    distr_float!(g, "beta_large_param_similar", f64, Beta::new(101., 95.).unwrap());
-    distr_float!(g, "beta_large_param_different", f64, Beta::new(10., 1000.).unwrap());
-    distr_float!(g, "beta_mixed_param", f64, Beta::new(0.5, 100.).unwrap());
+    distr_float!(g, "large_shape", f64, Gamma::new(10., 1.0).unwrap());
+    distr_float!(g, "small_shape", f64, Gamma::new(0.1, 1.0).unwrap());
+    g.finish();
+
+    let mut g = c.benchmark_group("beta");
+    distr_float!(g, "small_param", f64, Beta::new(0.1, 0.1).unwrap());
+    distr_float!(g, "large_param_similar", f64, Beta::new(101., 95.).unwrap());
+    distr_float!(g, "large_param_different", f64, Beta::new(10., 1000.).unwrap());
+    distr_float!(g, "mixed_param", f64, Beta::new(0.5, 100.).unwrap());
     g.finish();
 
     let mut g = c.benchmark_group("cauchy");
@@ -168,24 +171,23 @@ fn bench(c: &mut Criterion<CyclesPerByte>) {
     g.finish();
 
     let mut g = c.benchmark_group("weighted");
-    distr_int!(g, "weighted_i8", usize, WeightedIndex::new([1i8, 2, 3, 4, 12, 0, 2, 1]).unwrap());
-    distr_int!(g, "weighted_u32", usize, WeightedIndex::new([1u32, 2, 3, 4, 12, 0, 2, 1]).unwrap());
-    distr_int!(g, "weighted_f64", usize, WeightedIndex::new([1.0f64, 0.001, 1.0/3.0, 4.01, 0.0, 3.3, 22.0, 0.001]).unwrap());
-    distr_int!(g, "weighted_large_set", usize, WeightedIndex::new((0..10000).rev().chain(1..10001)).unwrap());
-    distr_int!(g, "weighted_alias_method_i8", usize, WeightedAliasIndex::new(vec![1i8, 2, 3, 4, 12, 0, 2, 1]).unwrap());
-    distr_int!(g, "weighted_alias_method_u32", usize, WeightedAliasIndex::new(vec![1u32, 2, 3, 4, 12, 0, 2, 1]).unwrap());
-    distr_int!(g, "weighted_alias_method_f64", usize, WeightedAliasIndex::new(vec![1.0f64, 0.001, 1.0/3.0, 4.01, 0.0, 3.3, 22.0, 0.001]).unwrap());
-    distr_int!(g, "weighted_alias_method_large_set", usize, WeightedAliasIndex::new((0..10000).rev().chain(1..10001).collect()).unwrap());
+    distr_int!(g, "i8", usize, WeightedIndex::new([1i8, 2, 3, 4, 12, 0, 2, 1]).unwrap());
+    distr_int!(g, "u32", usize, WeightedIndex::new([1u32, 2, 3, 4, 12, 0, 2, 1]).unwrap());
+    distr_int!(g, "f64", usize, WeightedIndex::new([1.0f64, 0.001, 1.0/3.0, 4.01, 0.0, 3.3, 22.0, 0.001]).unwrap());
+    distr_int!(g, "large_set", usize, WeightedIndex::new((0..10000).rev().chain(1..10001)).unwrap());
+    distr_int!(g, "alias_method_i8", usize, WeightedAliasIndex::new(vec![1i8, 2, 3, 4, 12, 0, 2, 1]).unwrap());
+    distr_int!(g, "alias_method_u32", usize, WeightedAliasIndex::new(vec![1u32, 2, 3, 4, 12, 0, 2, 1]).unwrap());
+    distr_int!(g, "alias_method_f64", usize, WeightedAliasIndex::new(vec![1.0f64, 0.001, 1.0/3.0, 4.01, 0.0, 3.3, 22.0, 0.001]).unwrap());
+    distr_int!(g, "alias_method_large_set", usize, WeightedAliasIndex::new((0..10000).rev().chain(1..10001).collect()).unwrap());
     g.finish();
 
     let mut g = c.benchmark_group("binomial");
-    sample_binomial!(g, "binomial", 20, 0.7);
-    sample_binomial!(g, "binomial_small", 1_000_000, 1e-30);
-    sample_binomial!(g, "binomial_1", 1, 0.9);
-    sample_binomial!(g, "binomial_10", 10, 0.9);
-    sample_binomial!(g, "binomial_100", 100, 0.99);
-    sample_binomial!(g, "binomial_1000", 1000, 0.01);
-    sample_binomial!(g, "binomial_1e12", 1_000_000_000_000, 0.2);
+    sample_binomial!(g, "small", 1_000_000, 1e-30);
+    sample_binomial!(g, "1", 1, 0.9);
+    sample_binomial!(g, "10", 10, 0.9);
+    sample_binomial!(g, "100", 100, 0.99);
+    sample_binomial!(g, "1000", 1000, 0.01);
+    sample_binomial!(g, "1e12", 1_000_000_000_000, 0.2);
     g.finish();
 
     let mut g = c.benchmark_group("poisson");
@@ -201,11 +203,8 @@ fn bench(c: &mut Criterion<CyclesPerByte>) {
     distr!(g, "bernoulli", bool, Bernoulli::new(0.18).unwrap());
     g.finish();
 
-    let mut g = c.benchmark_group("circle");
+    let mut g = c.benchmark_group("unit");
     distr_arr!(g, "circle", [f64; 2], UnitCircle);
-    g.finish();
-
-    let mut g = c.benchmark_group("sphere");
     distr_arr!(g, "sphere", [f64; 3], UnitSphere);
     g.finish();
 }

--- a/rand_distr/src/lib.rs
+++ b/rand_distr/src/lib.rs
@@ -211,7 +211,7 @@ mod normal;
 mod normal_inverse_gaussian;
 mod pareto;
 mod pert;
-mod poisson;
+pub(crate) mod poisson;
 mod skew_normal;
 mod student_t;
 mod triangular;

--- a/rand_distr/src/poisson.rs
+++ b/rand_distr/src/poisson.rs
@@ -78,6 +78,7 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct KnuthMethod<F> {
     exp_lambda: F,
 }
@@ -90,12 +91,14 @@ impl<F: Float> KnuthMethod<F> {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct RejectionMethod<F> {
     log_lambda: F,
     sqrt_2lambda: F,
     magic_val: F,
 }
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 enum Method<F> {
     Knuth(KnuthMethod<F>),
     Rejection(RejectionMethod<F>),

--- a/rand_distr/src/poisson.rs
+++ b/rand_distr/src/poisson.rs
@@ -78,9 +78,17 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-struct KnuthMethod<F> {
+pub(crate) struct KnuthMethod<F> {
     exp_lambda: F,
 }
+impl<F: Float> KnuthMethod<F> {
+    pub(crate) fn new(lambda: F) -> Self {
+        KnuthMethod {
+            exp_lambda: (-lambda).exp(),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct RejectionMethod<F> {
     log_lambda: F,
@@ -119,9 +127,7 @@ where
 
         // Use the Knuth method only for low expected values
         let method = if lambda < F::from(12.0).unwrap() {
-            Method::Knuth(KnuthMethod {
-                exp_lambda: (-lambda).exp(),
-            })
+            Method::Knuth(KnuthMethod::new(lambda))
         } else {
             let log_lambda = lambda.ln();
             let sqrt_2lambda = (F::from(2.0).unwrap() * lambda).sqrt();


### PR DESCRIPTION
# Summary

Use an enum over Poisson implementations

# Motivation

#1484 uses the `Poisson` method internally, but only for small expected values.
@benjamin-lieser please merge this PR into yours and use `poisson::KnuthMethod` instead of `Poisson`.