### PR TITLE
Cdf testing with Kolmogorov Smirnov

### DIFF
--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - The `serde1` feature has been renamed `serde` (#1477)
+- Add Kolmogorov Smirnov test for sampling of `Normal` and `Binomial` (#1494)
 
 ### Added
 - Add plots for `rand_distr` distributions to documentation (#1434)

--- a/rand_distr/tests/cdf.rs
+++ b/rand_distr/tests/cdf.rs
@@ -107,7 +107,7 @@ where
 }
 
 /// Tests a distribution against an analytical CDF.
-/// The cdf has to be continuous.
+/// The CDF has to be continuous.
 pub fn test_continuous(seed: u64, dist: impl Distribution<f64>, cdf: impl Fn(f64) -> f64) {
     let ecdf = sample_ecdf(seed, dist);
     let ks_statistic = kolmogorov_smirnov_statistic_continuous(ecdf, cdf);

--- a/rand_distr/tests/cdf.rs
+++ b/rand_distr/tests/cdf.rs
@@ -138,7 +138,7 @@ pub fn test_discrete<I: AsPrimitive<f64>>(
 }
 
 fn normal_cdf(x: f64, mean: f64, std_dev: f64) -> f64 {
-    0.5 * (1.0 + ((x - mean) / (std_dev * f64::consts::SQRT_2)).erf())
+    0.5 * ((mean - x) / (std_dev * f64::consts::SQRT_2)).erfc()
 }
 
 #[test]
@@ -163,11 +163,12 @@ fn binomial_cdf(k: i64, p: f64, n: u64) -> f64 {
     if k < 0 {
         return 0.0;
     }
-    if k >= n as i64 {
+    let k = k as u64;
+    if k >= n {
         return 1.0;
     }
 
-    let a = n as f64 - k as f64;
+    let a = (n - k) as f64;
     let b = k as f64 + 1.0;
 
     let q = 1.0 - p;

--- a/rand_distr/tests/cdf.rs
+++ b/rand_distr/tests/cdf.rs
@@ -68,7 +68,7 @@ fn kolmogorov_smirnov_statistic_continuous(ecdf: Ecdf, cdf: impl Fn(f64) -> f64)
 
 fn kolmogorov_smirnov_statistic_discrete(ecdf: Ecdf, cdf: impl Fn(i64) -> f64) -> f64 {
     // We implement equation (4) from [1]
-    
+
     let mut max_diff: f64 = 0.;
 
     let step_points = ecdf.step_points(); // x_i in the paper
@@ -136,9 +136,13 @@ fn normal() {
 fn binomial() {
     for seed in 1..20 {
         test_discrete(seed, rand_distr::Binomial::new(10, 0.5).unwrap(), |x| {
-            statrs::distribution::Binomial::new(0.5, 10)
-                .unwrap()
-                .cdf(x as u64)
+            if x < 0 {
+                0.0
+            } else {
+                statrs::distribution::Binomial::new(0.5, 10)
+                    .unwrap()
+                    .cdf(x as u64)
+            }
         });
     }
 }

--- a/rand_distr/tests/cdf.rs
+++ b/rand_distr/tests/cdf.rs
@@ -168,11 +168,9 @@ fn binomial_cdf(k: i64, p: f64, n: u64) -> f64 {
     let q = 1.0 - p;
 
     let ln_beta_ab = a.ln_beta(b);
-    
-    let reg_incomplete_beta = q.inc_beta(a, b, ln_beta_ab);
 
-    return reg_incomplete_beta;
-}    
+    q.inc_beta(a, b, ln_beta_ab)
+}
 
 #[test]
 fn binomial() {

--- a/rand_distr/tests/cdf.rs
+++ b/rand_distr/tests/cdf.rs
@@ -1,0 +1,132 @@
+// Copyright 2021 Developers of the Rand project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use rand::SeedableRng;
+use rand_distr::{Distribution, Normal};
+use statrs::distribution::ContinuousCDF;
+use statrs::distribution::DiscreteCDF;
+
+/// Empirical Cumulative Distribution Function (ECDF)
+struct ECDF {
+    sorted_samples: Vec<f64>,
+}
+
+impl ECDF {
+    fn new(mut samples: Vec<f64>) -> Self {
+        samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        Self {
+            sorted_samples: samples,
+        }
+    }
+
+    /// Returns the step points of the ECDF
+    /// The ECDF is a step function that increases by 1/n at each sample point
+    /// The function is continoius from the right, so we give the bigger value at the step points
+    /// First point is (-inf, 0.0), last point is (max(samples), 1.0)
+    fn step_points(&self) -> Vec<(f64, f64)> {
+        let mut points = Vec::with_capacity(self.sorted_samples.len() + 1);
+        let mut last = f64::NEG_INFINITY;
+        let mut count = 0;
+        let n = self.sorted_samples.len() as f64;
+        for &x in &self.sorted_samples {
+            if x != last {
+                points.push((last, count as f64 / n));
+                last = x;
+            }
+            count += 1;
+        }
+        points.push((last, count as f64 / n));
+        points
+    }
+}
+
+fn kolmo_smirnov_statistic_continuous(ecdf: ECDF, cdf: impl Fn(f64) -> f64) -> f64 {
+    let mut max_diff = 0.;
+    // The maximum will always be at a step point, because the cdf is continious monotonic increasing
+    let step_points = ecdf.step_points();
+    for i in 0..step_points.len() - 1 {
+        // This shift is because we want the value of the ecdf at (x_{i + 1} - epsilon) = ecdf(x_i) and comare it to cdf(x_{i + 1})
+        // cdf(x_{i + 1} - epsilon) = cdf(x_{i+1}) because cdf is continious
+        let x = step_points[i + 1].0;
+        let diff = (step_points[i].1 - cdf(x)).abs();
+
+        if diff > max_diff {
+            max_diff = diff;
+        }
+    }
+    max_diff
+}
+
+fn kolmo_smirnov_statistic_discrete(ecdf: ECDF, cdf: impl Fn(i64) -> f64) -> f64 {
+    let mut max_diff = 0.;
+
+    // The maximum will always be at a step point, but we have to be careful because the cdf is not continious
+    // It is actually easier because both are right continious step functions
+    let step_points = ecdf.step_points();
+    for i in 1..step_points.len() {
+        let x = step_points[i].0;
+        let diff = (step_points[i].1 - cdf(x as i64)).abs();
+        if diff > max_diff {
+            max_diff = diff;
+        }
+    }
+    max_diff
+}
+#[test]
+fn normal() {
+    const N_SAMPLES: u64 = 1_000_000;
+    const MEAN: f64 = 2.;
+    const STD_DEV: f64 = 50.0;
+
+    let dist = Normal::new(MEAN, STD_DEV).unwrap();
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(1);
+    let samples = (0..N_SAMPLES).map(|_| dist.sample(&mut rng)).collect();
+    let ecdf = ECDF::new(samples);
+
+    let cdf = |x| {
+        statrs::distribution::Normal::new(MEAN, STD_DEV)
+            .unwrap()
+            .cdf(x)
+    };
+
+    let ks_statistic = kolmo_smirnov_statistic_continuous(ecdf, cdf);
+
+    let critical_value = 1.36 / (N_SAMPLES as f64).sqrt();
+
+    println!("KS statistic: {}", ks_statistic);
+    println!("Critical value: {}", critical_value);
+    assert!(ks_statistic < critical_value);
+}
+
+#[test]
+fn binomial() {
+    const N_SAMPLES: u64 = 10_000_000;
+    const N: u64 = 10000000;
+    const P: f64 = 0.001;
+
+    let dist = rand_distr::Binomial::new(N, P).unwrap();
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(1);
+    let samples = (0..N_SAMPLES)
+        .map(|_| dist.sample(&mut rng) as f64)
+        .collect();
+    let ecdf = ECDF::new(samples);
+
+    let cdf = |x| {
+        statrs::distribution::Binomial::new(P, N)
+            .unwrap()
+            .cdf(x as u64)
+    };
+
+    let ks_statistic = kolmo_smirnov_statistic_discrete(ecdf, cdf);
+
+    let critical_value = 1.36 / (N_SAMPLES as f64).sqrt();
+
+    println!("KS statistic: {}", ks_statistic);
+    println!("Critical value: {}", critical_value);
+    assert!(ks_statistic < critical_value);
+}

--- a/rand_distr/tests/cdf.rs
+++ b/rand_distr/tests/cdf.rs
@@ -80,14 +80,14 @@ fn kolmo_smirnov_statistic_discrete(ecdf: Ecdf, cdf: impl Fn(i64) -> f64) -> f64
 #[cfg(test)]
 fn test_continious(dist: impl Distribution<f64>, cdf: impl Fn(f64) -> f64) {
     const N_SAMPLES: u64 = 1_000_000;
-    let mut rng = rand::rngs::SmallRng::seed_from_u64(1);
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(6);
     let samples = (0..N_SAMPLES).map(|_| dist.sample(&mut rng)).collect();
     let ecdf = Ecdf::new(samples);
 
     let ks_statistic = kolmo_smirnov_statistic_continuous(ecdf, cdf);
 
-    // It is a heuristic value, we want to prove that the distributions match, so p values don't help us
-    let critical_value = 1.36 / (N_SAMPLES as f64).sqrt();
+    // If the sampler is correct, we expect less than 0.001 false positives (alpha = 0.001). Passing this does not prove that the sampler is correct but is a good indication.
+    let critical_value = 1.95 / (N_SAMPLES as f64).sqrt();
 
     println!("KS statistic: {}", ks_statistic);
     println!("Critical value: {}", critical_value);
@@ -100,7 +100,7 @@ where
     <I as TryInto<i64>>::Error: std::fmt::Debug,
 {
     const N_SAMPLES: u64 = 1_000_000;
-    let mut rng = rand::rngs::SmallRng::seed_from_u64(1);
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(2);
     let samples = (0..N_SAMPLES)
         .map(|_| dist.sample(&mut rng).try_into().unwrap() as f64)
         .collect();
@@ -108,7 +108,8 @@ where
 
     let ks_statistic = kolmo_smirnov_statistic_discrete(ecdf, cdf);
 
-    let critical_value = 1.36 / (N_SAMPLES as f64).sqrt();
+    // If the sampler is correct, we expect less than 0.001 false positives (alpha = 0.001). Passing this does not prove that the sampler is correct but is a good indication.
+    let critical_value = 1.95 / (N_SAMPLES as f64).sqrt();
 
     println!("KS statistic: {}", ks_statistic);
     println!("Critical value: {}", critical_value);

--- a/rand_distr/tests/cdf.rs
+++ b/rand_distr/tests/cdf.rs
@@ -61,8 +61,9 @@ fn kolmogorov_smirnov_statistic_continuous(ecdf: Ecdf, cdf: impl Fn(f64) -> f64)
     for i in 1..step_points.len() {
         let (x_i, f_i) = step_points[i];
         let (_, f_i_1) = step_points[i - 1];
-        let max_1 = (cdf(x_i) - f_i).abs();
-        let max_2 = (cdf(x_i) - f_i_1).abs();
+        let cdf_i = cdf(x_i);
+        let max_1 = (cdf_i - f_i).abs();
+        let max_2 = (cdf_i - f_i_1).abs();
 
         max_diff = max_diff.max(max_1).max(max_2);
     }
@@ -105,7 +106,9 @@ where
     Ecdf::new(samples)
 }
 
-fn test_continuous(seed: u64, dist: impl Distribution<f64>, cdf: impl Fn(f64) -> f64) {
+/// Tests a distribution against an analytical CDF.
+/// The cdf has to be continuous.
+pub fn test_continuous(seed: u64, dist: impl Distribution<f64>, cdf: impl Fn(f64) -> f64) {
     let ecdf = sample_ecdf(seed, dist);
     let ks_statistic = kolmogorov_smirnov_statistic_continuous(ecdf, cdf);
 
@@ -116,7 +119,9 @@ fn test_continuous(seed: u64, dist: impl Distribution<f64>, cdf: impl Fn(f64) ->
     assert!(ks_statistic < critical_value);
 }
 
-fn test_discrete<I: AsPrimitive<f64>>(
+/// Tests a distribution over integers against an analytical CDF.
+/// The analytical CDF must not have jump points which are not integers.
+pub fn test_discrete<I: AsPrimitive<f64>>(
     seed: u64,
     dist: impl Distribution<I>,
     cdf: impl Fn(i64) -> f64,


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

As addition and alternative to pdf testing, I implemented distribution testing based on cdf

# Motivation

The cdf tests should be more robust and avoid having the bin-width choice problem

# Details

I have two simple example tests for normal and binomial. If we like these tests we should also add some way to test on different parameter sets and the other distributions.

This can't be easily generalized to multivariate ones.
