### PR TITLE
impl SeedableRng for StepRng

### DIFF
--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Bump the MSRV to 1.61.0
 - The `serde1` feature has been renamed `serde` (#1477)
+- Implement `SeedableRng` for `StepRng`
 
 ## [0.9.0-alpha.1] - 2024-03-18
 

--- a/src/rngs/mock.rs
+++ b/src/rngs/mock.rs
@@ -8,10 +8,11 @@
 
 //! Mock random number generator
 
-use rand_core::{impls, RngCore};
+use rand_core::{impls, RngCore, SeedableRng};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use zerocopy::transmute;
 
 /// A mock generator yielding very predictable output
 ///
@@ -72,6 +73,18 @@ impl RngCore for StepRng {
     #[inline]
     fn fill_bytes(&mut self, dst: &mut [u8]) {
         impls::fill_bytes_via_next(self, dst)
+    }
+}
+
+impl SeedableRng for StepRng {
+    type Seed = [u8; 16];
+
+    fn from_seed(seed: Self::Seed) -> Self {
+        let seed_u64: [u64; 2] = transmute!(seed);
+        StepRng {
+            v: seed_u64[0],
+            a: seed_u64[1],
+        }
     }
 }
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

implement SeedableRng for StepRng

# Motivation

https://github.com/rust-random/rand/issues/1495

# Details

This is not value stable across endianess, not sure if we need/want that here