### PR TITLE
Poisson u64 sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Add `UniformUsize` and use to make `Uniform` for `usize` portable (#1487)
 - Remove support for generating `isize` and `usize` values with `Standard`, `Uniform` and `Fill` and usage as a `WeightedAliasIndex` weight (#1487)
 - Require `Clone` and `AsRef` bound for `SeedableRng::Seed`. (#1491)
+- Implement `Distribution<u64>` for `Poisson<f64>` (#1498)
+- Limit the maximal acceptable lambda for `Poisson` to solve (#1312) (#1498)
 
 ## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)

--- a/rand_distr/src/poisson.rs
+++ b/rand_distr/src/poisson.rs
@@ -60,7 +60,7 @@ pub enum Error {
     /// `lambda = ∞` or `lambda = nan`
     NonFinite,
     /// `lambda` is too large, we disallo
-    ShapeTooLarge
+    ShapeTooLarge,
 }
 
 impl fmt::Display for Error {
@@ -68,7 +68,9 @@ impl fmt::Display for Error {
         f.write_str(match self {
             Error::ShapeTooSmall => "lambda is not positive in Poisson distribution",
             Error::NonFinite => "lambda is infinite or nan in Poisson distribution",
-            Error::ShapeTooLarge => "lambda is too large in Poisson distribution, see Poisson::MAX_LAMBDA_POISSON",
+            Error::ShapeTooLarge => {
+                "lambda is too large in Poisson distribution, see Poisson::MAX_LAMBDA_POISSON"
+            }
         })
     }
 }
@@ -127,7 +129,7 @@ where
 {
     /// Construct a new `Poisson` with the given shape parameter
     /// `lambda`.
-    /// 
+    ///
     /// The maximum allowed lambda is [MAX_LAMBDA_POISSON](Self::MAX_LAMBDA_POISSON).
     pub fn new(lambda: F) -> Result<Poisson<F>, Error> {
         if !lambda.is_finite() {
@@ -149,14 +151,13 @@ where
 
         Ok(Poisson(method))
     }
-    
+
     /// Maximum value for `lambda` in the Poisson distribution.
     /// This will make sure the samples will fit in a `u64`.
     /// It also makes sure we do not run into numerical problems with very large `lambda`.
     /// `1.844e19 + 1_000_000 * sqrt(1.844e19) < 2^64 - 1`,
     /// so the probability of getting a value larger than `u64::MAX` is << 1e-1000.
     pub const MAX_LAMBDA_POISSON: f64 = 1.844e19;
-
 }
 
 impl<F> Distribution<F> for KnuthMethod<F>
@@ -239,11 +240,10 @@ where
     }
 }
 
-impl Distribution<u64> for Poisson<f64>
-{
+impl Distribution<u64> for Poisson<f64> {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u64 {
-        <Poisson<f64> as Distribution<f64>>::sample(self,rng) as u64
+        <Poisson<f64> as Distribution<f64>>::sample(self, rng) as u64
     }
 }
 

--- a/rand_distr/src/poisson.rs
+++ b/rand_distr/src/poisson.rs
@@ -23,10 +23,6 @@ use rand::Rng;
 /// This distribution has density function:
 /// `f(k) = λ^k * exp(-λ) / k!` for `k >= 0`.
 ///
-/// # Known issues
-///
-/// See documentation of [`Poisson::new`].
-///
 /// # Plot
 ///
 /// The following plot shows the Poisson distribution with various values of `λ`.


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

This addresses https://github.com/rust-random/rand/issues/1497 by adding `Distribution<u64>`
It also solves https://github.com/rust-random/rand/issues/1312 by not allowing `lambda` bigger than `1.844e19` (this also makes them always fit into `u64`)

# Details

The `Distribution<u64>` is a breaking change and will have a bit of negative impact on the call side, because it requires sometimes type annotations.
Alternatively we keep the maximum lambda and document that it is always safe to just `as u64` on the samples if required.
