### PR TITLE
Weibull doc numerics warning

### DIFF
--- a/rand_distr/src/weibull.rs
+++ b/rand_distr/src/weibull.rs
@@ -20,9 +20,9 @@ use rand::Rng;
 /// to model reliability data, life data, and accelerated life testing data.
 ///
 /// # Density function
-/// 
+///
 /// `f(x; λ, k) = (k / λ) * (x / λ)^(k - 1) * exp(-(x / λ)^k)` for `x >= 0`.
-/// 
+///
 /// # Plot
 ///
 /// The following plot shows the Weibull distribution with various values of `λ` and `k`.
@@ -37,9 +37,9 @@ use rand::Rng;
 /// let val: f64 = rand::rng().sample(Weibull::new(1., 10.).unwrap());
 /// println!("{}", val);
 /// ```
-/// 
+///
 /// # Numerics
-/// 
+///
 /// For small `k` like `< 0.005`, even with `f64` a significant number of samples will be so small that they underflow to `0.0`
 /// or so big they overflow to `inf`. This is a limitation of the floating point representation and not specific to this implementation.
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/rand_distr/src/weibull.rs
+++ b/rand_distr/src/weibull.rs
@@ -19,6 +19,10 @@ use rand::Rng;
 /// scale parameter `λ` (`lambda`) and shape parameter `k`. It is used
 /// to model reliability data, life data, and accelerated life testing data.
 ///
+/// # Density function
+/// 
+/// `f(x; λ, k) = (k / λ) * (x / λ)^(k - 1) * exp(-(x / λ)^k)` for `x >= 0`.
+/// 
 /// # Plot
 ///
 /// The following plot shows the Weibull distribution with various values of `λ` and `k`.
@@ -33,6 +37,11 @@ use rand::Rng;
 /// let val: f64 = rand::rng().sample(Weibull::new(1., 10.).unwrap());
 /// println!("{}", val);
 /// ```
+/// 
+/// # Numerics
+/// 
+/// For small `k` like `< 0.005`, even with `f64` a significant number of samples will be so small that they underflow to `0.0`
+/// or so big they overflow to `inf`. This is a limitation of the floating point representation and not specific to this implementation.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Weibull<F>


### PR DESCRIPTION
This is a concrete proposal for https://github.com/rust-random/rand/issues/1507

I am also fine with not adding it, as the limitations are not specific to our implementation and people can figure this out on their own. I think a short reminder that Weibull does exhaust the floating point limits very quickly is worthwhile.

It also adds the pdf to the documentation, I find this always very helpful to make sure me and the library author using the same parameterization of the distribution.