### PR TITLE
Reduce MSRV to 1.60

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,10 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             variant: MSRV
+            toolchain: 1.60.0 # build-test only
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            variant: MSRV
             toolchain: 1.61.0
           - os: ubuntu-latest
             deps: sudo apt-get update ; sudo apt install gcc-multilib
@@ -87,14 +91,20 @@ jobs:
           cargo test --target ${{ matrix.target }} --all-features
           cargo test --target ${{ matrix.target }} --manifest-path benches/Cargo.toml --benches
           cargo test --target ${{ matrix.target }} --lib --tests --no-default-features
+      - name: Build-test (1.60.0)
+        if: ${{ matrix.toolchain == '1.60.0' }}
+        run: |
+          cargo build --target ${{ matrix.target }} --no-default-features
+          cargo build --target ${{ matrix.target }} --no-default-features --features alloc,getrandom,small_rng,unbiased
+          cargo build --target ${{ matrix.target }} --features serde
+          cargo build --target ${{ matrix.target }} --manifest-path rand_distr/Cargo.toml --features=serde
       - name: Test rand
+        if: ${{ matrix.toolchain != '1.60.0' }}
         run: |
           cargo test --target ${{ matrix.target }} --lib --tests --no-default-features
           cargo build --target ${{ matrix.target }} --no-default-features --features alloc,getrandom,small_rng,unbiased
           cargo test --target ${{ matrix.target }} --lib --tests --no-default-features --features=alloc,getrandom,small_rng
           cargo test --target ${{ matrix.target }} --examples
-      - name: Test rand (all stable features)
-        run: |
           cargo test --target ${{ matrix.target }} --features=serde,log,small_rng
       - name: Test rand_core
         run: |
@@ -102,6 +112,7 @@ jobs:
           cargo test --target ${{ matrix.target }} --manifest-path rand_core/Cargo.toml --no-default-features
           cargo test --target ${{ matrix.target }} --manifest-path rand_core/Cargo.toml --no-default-features --features=alloc,getrandom
       - name: Test rand_distr
+        if: ${{ matrix.toolchain != '1.60.0' }}
         run: |
           cargo test --target ${{ matrix.target }} --manifest-path rand_distr/Cargo.toml --features=serde
           cargo test --target ${{ matrix.target }} --manifest-path rand_distr/Cargo.toml --no-default-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 ## [Unreleased]
 - Add `rand::distributions::WeightedIndex::{weight, weights, total_weight}` (#1420)
 - Add `IndexedRandom::choose_multiple_array`, `index::sample_array` (#1453, #1469)
-- Bump the MSRV to 1.61.0
+- Bump the MSRV to ~~1.61.0~~ 1.60.0 (#1416, #1513)
 - Rename `Rng::gen` to `Rng::random` to avoid conflict with the new `gen` keyword in Rust 2024 (#1435)
 - Move all benchmarks to new `benches` crate (#1439) and migrate to Criterion (#1490)
 - Annotate panicking methods with `#[track_caller]` (#1442, #1447)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["random", "rng"]
 categories = ["algorithms", "no-std"]
 autobenches = true
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.60"
 include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["random", "rng"]
 categories = ["algorithms", "no-std"]
 autobenches = true
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.60" # Tests require 1.61
 include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [package.metadata.docs.rs]

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -13,7 +13,7 @@ ChaCha random number generator
 keywords = ["random", "rng", "chacha"]
 categories = ["algorithms", "no-std"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -13,7 +13,7 @@ Core random number generator traits and tools for implementation.
 keywords = ["random", "rng"]
 categories = ["algorithms", "no-std"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -13,7 +13,7 @@ Sampling from random number distributions
 keywords = ["random", "rng", "distribution", "probability"]
 categories = ["algorithms", "no-std"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.60"
 include = ["/src", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [package.metadata.docs.rs]

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -13,7 +13,7 @@ Sampling from random number distributions
 keywords = ["random", "rng", "distribution", "probability"]
 categories = ["algorithms", "no-std"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.60" # Tests require 1.61
 include = ["/src", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [package.metadata.docs.rs]

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -13,7 +13,7 @@ Selected PCG random number generators
 keywords = ["random", "rng", "pcg"]
 categories = ["algorithms", "no-std"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

MSRV = 1.60 for build, 1.61 for tests

# Motivation

This was [requested](https://www.reddit.com/r/rust/comments/1egixd9/rand_v09_alpha_usizeisize_support/lfsgtha/).

# Details

The lack of full tests on 1.60 isn't documented anywhere. Should it be?