### PR TITLE
Zipf: let n have type F

### DIFF
--- a/benches/benches/distr.rs
+++ b/benches/benches/distr.rs
@@ -159,7 +159,7 @@ fn bench(c: &mut Criterion<CyclesPerByte>) {
     g.finish();
 
     let mut g = c.benchmark_group("zipf");
-    distr_float!(g, "zipf", f64, Zipf::new(10, 1.5).unwrap());
+    distr_float!(g, "zipf", f64, Zipf::new(10.0, 1.5).unwrap());
     distr_float!(g, "zeta", f64, Zeta::new(1.5).unwrap());
     g.finish();
 

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move some of the computations in Binomial from `sample` to `new` (#1484)
 - Add Kolmogorov Smirnov test for sampling of `Normal` and `Binomial` (#1494)
 - Add Kolmogorov Smirnov test for more distributions (#1504)
+- Change parameter type of `Zipf::new`: `n` is now floating-point (#1518)
 
 ### Added
 - Add plots for `rand_distr` distributions to documentation (#1434)

--- a/rand_distr/src/zipf.rs
+++ b/rand_distr/src/zipf.rs
@@ -35,7 +35,7 @@ use rand::Rng;
 /// use rand::prelude::*;
 /// use rand_distr::Zipf;
 ///
-/// let val: f64 = rand::rng().sample(Zipf::new(10, 1.5).unwrap());
+/// let val: f64 = rand::rng().sample(Zipf::new(10.0, 1.5).unwrap());
 /// println!("{}", val);
 /// ```
 ///

--- a/rand_distr/src/zipf.rs
+++ b/rand_distr/src/zipf.rs
@@ -85,16 +85,17 @@ where
     /// Construct a new `Zipf` distribution for a set with `n` elements and a
     /// frequency rank exponent `s`.
     ///
-    /// For large `n`, rounding may occur to fit the number into the float type.
+    /// The parameter `n` is typically integral, however we use type
+    /// <pre><code>F: [Float]</code></pre> in order to permit very large values
+    /// and since our implementation requires a floating-point type.
     #[inline]
-    pub fn new(n: u64, s: F) -> Result<Zipf<F>, Error> {
+    pub fn new(n: F, s: F) -> Result<Zipf<F>, Error> {
         if !(s >= F::zero()) {
             return Err(Error::STooSmall);
         }
-        if n < 1 {
+        if n < F::one() {
             return Err(Error::NTooSmall);
         }
-        let n = F::from(n).unwrap(); // This does not fail.
         let q = if s != F::one() {
             // Make sure to calculate the division only once.
             F::one() / (F::one() - s)
@@ -166,24 +167,24 @@ mod tests {
     #[test]
     #[should_panic]
     fn zipf_s_too_small() {
-        Zipf::new(10, -1.).unwrap();
+        Zipf::new(10., -1.).unwrap();
     }
 
     #[test]
     #[should_panic]
     fn zipf_n_too_small() {
-        Zipf::new(0, 1.).unwrap();
+        Zipf::new(0., 1.).unwrap();
     }
 
     #[test]
     #[should_panic]
     fn zipf_nan() {
-        Zipf::new(10, f64::NAN).unwrap();
+        Zipf::new(10., f64::NAN).unwrap();
     }
 
     #[test]
     fn zipf_sample() {
-        let d = Zipf::new(10, 0.5).unwrap();
+        let d = Zipf::new(10., 0.5).unwrap();
         let mut rng = crate::test::rng(2);
         for _ in 0..1000 {
             let r = d.sample(&mut rng);
@@ -193,7 +194,7 @@ mod tests {
 
     #[test]
     fn zipf_sample_s_1() {
-        let d = Zipf::new(10, 1.).unwrap();
+        let d = Zipf::new(10., 1.).unwrap();
         let mut rng = crate::test::rng(2);
         for _ in 0..1000 {
             let r = d.sample(&mut rng);
@@ -203,7 +204,7 @@ mod tests {
 
     #[test]
     fn zipf_sample_s_0() {
-        let d = Zipf::new(10, 0.).unwrap();
+        let d = Zipf::new(10., 0.).unwrap();
         let mut rng = crate::test::rng(2);
         for _ in 0..1000 {
             let r = d.sample(&mut rng);
@@ -214,7 +215,7 @@ mod tests {
 
     #[test]
     fn zipf_sample_large_n() {
-        let d = Zipf::new(u64::MAX, 1.5).unwrap();
+        let d = Zipf::new(f64::MAX, 1.5).unwrap();
         let mut rng = crate::test::rng(2);
         for _ in 0..1000 {
             let r = d.sample(&mut rng);
@@ -225,12 +226,12 @@ mod tests {
 
     #[test]
     fn zipf_value_stability() {
-        test_samples(Zipf::new(10, 0.5).unwrap(), 0f32, &[10.0, 2.0, 6.0, 7.0]);
-        test_samples(Zipf::new(10, 2.0).unwrap(), 0f64, &[1.0, 2.0, 3.0, 2.0]);
+        test_samples(Zipf::new(10., 0.5).unwrap(), 0f32, &[10.0, 2.0, 6.0, 7.0]);
+        test_samples(Zipf::new(10., 2.0).unwrap(), 0f64, &[1.0, 2.0, 3.0, 2.0]);
     }
 
     #[test]
     fn zipf_distributions_can_be_compared() {
-        assert_eq!(Zipf::new(1, 2.0), Zipf::new(1, 2.0));
+        assert_eq!(Zipf::new(1.0, 2.0), Zipf::new(1.0, 2.0));
     }
 }

--- a/rand_distr/tests/cdf.rs
+++ b/rand_distr/tests/cdf.rs
@@ -372,22 +372,21 @@ fn zeta() {
 
 #[test]
 fn zipf() {
-    fn cdf(k: f64, n: f64, s: f64) -> f64 {
-        debug_assert!(k.fract() == 0.0 && k < u64::MAX as f64);
-        if k < 1.0 {
+    fn cdf(k: i64, n: u64, s: f64) -> f64 {
+        if k < 1 {
             return 0.0;
         }
-        if k > n {
+        if k > n as i64 {
             return 1.0;
         }
-        gen_harmonic(k as u64, s) / gen_harmonic(n as u64, s)
+        gen_harmonic(k as u64, s) / gen_harmonic(n, s)
     }
 
-    let parameters = [(1000.0, 1.0), (500.0, 2.0), (1000.0, 0.5)];
+    let parameters = [(1000, 1.0), (500, 2.0), (1000, 0.5)];
 
     for (seed, (n, x)) in parameters.into_iter().enumerate() {
-        let dist = rand_distr::Zipf::new(n, x).unwrap();
-        test_continuous(seed as u64, dist, |k| cdf(k, n, x));
+        let dist = rand_distr::Zipf::new(n as f64, x).unwrap();
+        test_discrete(seed as u64, dist, |k| cdf(k, n, x));
     }
 }
 

--- a/rand_distr/tests/cdf.rs
+++ b/rand_distr/tests/cdf.rs
@@ -372,21 +372,22 @@ fn zeta() {
 
 #[test]
 fn zipf() {
-    fn cdf(k: i64, n: u64, s: f64) -> f64 {
-        if k < 1 {
+    fn cdf(k: f64, n: f64, s: f64) -> f64 {
+        debug_assert!(k.fract() == 0.0 && k < u64::MAX as f64);
+        if k < 1.0 {
             return 0.0;
         }
-        if k > n as i64 {
+        if k > n {
             return 1.0;
         }
-        gen_harmonic(k as u64, s) / gen_harmonic(n, s)
+        gen_harmonic(k as u64, s) / gen_harmonic(n as u64, s)
     }
 
-    let parameters = [(1000, 1.0), (500, 2.0), (1000, 0.5)];
+    let parameters = [(1000.0, 1.0), (500.0, 2.0), (1000.0, 0.5)];
 
     for (seed, (n, x)) in parameters.into_iter().enumerate() {
         let dist = rand_distr::Zipf::new(n, x).unwrap();
-        test_discrete(seed as u64, dist, |k| cdf(k, n, x));
+        test_continuous(seed as u64, dist, |k| cdf(k, n, x));
     }
 }
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Change the parameter type of Zipf's `n` to `F`

# Motivation

https://github.com/rust-random/rand/issues/1323#issuecomment-2125324653

# Details

The CDF test fails:
```
---- zipf stdout ----
KS statistic: 0.13359213049244018
Critical value: 0.00195
thread 'zipf' panicked at rand_distr/tests/cdf.rs:119:5:
assertion failed: ks_statistic < critical_value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
The value stability tests (only 4 samples; bottom of `zipf.rs`) did not fail.