### PR TITLE
Add rand_distr::TruncatedNormal

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -53,3 +53,7 @@ harness = false
 [[bench]]
 name = "weighted"
 harness = false
+
+[[bench]]
+name = "truncnorm"
+harness = false

--- a/benches/benches/truncnorm.rs
+++ b/benches/benches/truncnorm.rs
@@ -1,0 +1,83 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion_cycles_per_byte::CyclesPerByte;
+
+use rand::prelude::*;
+use rand_distr::*;
+
+// At this time, distributions are optimised for 64-bit platforms.
+use rand_pcg::Pcg64Mcg;
+
+struct TruncatedNormalByRejection {
+    normal: Normal<f64>,
+    a: f64,
+    b: f64,
+}
+
+impl TruncatedNormalByRejection {
+    fn new(mean: f64, std_dev: f64, a: f64, b: f64) -> Self {
+        Self {
+            normal: Normal::new(mean, std_dev).unwrap(),
+            a,
+            b,
+        }
+    }
+}
+
+impl Distribution<f64> for TruncatedNormalByRejection {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> f64 {
+        let mut value;
+        loop {
+            value = rng.sample(self.normal);
+            if value >= self.a && value <= self.b {
+                return value;
+            }
+        }
+    }
+}
+
+fn bench(c: &mut Criterion<CyclesPerByte>) {
+    let distr = TruncatedNormal::new(0., 1., f64::NEG_INFINITY, f64::INFINITY).unwrap();
+
+    let ranges = [
+        (1, f64::NEG_INFINITY, distr.ppf(0.01)),
+        (3, f64::NEG_INFINITY, distr.ppf(0.03)),
+        (5, f64::NEG_INFINITY, distr.ppf(0.05)),
+        (7, f64::NEG_INFINITY, distr.ppf(0.07)),
+        (10, f64::NEG_INFINITY, distr.ppf(0.1)),
+        (30, f64::NEG_INFINITY, distr.ppf(0.3)),
+        (50, f64::NEG_INFINITY, distr.ppf(0.5)),
+        (70, f64::NEG_INFINITY, distr.ppf(0.7)),
+        (100, f64::NEG_INFINITY, f64::INFINITY),
+    ];
+
+    let mut g = c.benchmark_group("truncnorm by rejection");
+    for range in &ranges {
+        let mut rng = Pcg64Mcg::from_os_rng();
+        g.throughput(Throughput::Elements(range.0));
+        g.bench_with_input(BenchmarkId::from_parameter(range.0), range, |b, &range| {
+            let distr = TruncatedNormalByRejection::new(0.0, 1.0, range.1, range.2);
+            b.iter(|| std::hint::black_box(Distribution::<f64>::sample(&distr, &mut rng)));
+        });
+    }
+    g.finish();
+
+    let mut g = c.benchmark_group("truncnorm by ppf");
+    for range in &ranges {
+        let mut rng = Pcg64Mcg::from_os_rng();
+        g.throughput(Throughput::Elements(range.0));
+        g.bench_with_input(BenchmarkId::from_parameter(range.0), range, |b, &range| {
+            let distr = TruncatedNormal::new(0.0, 1.0, range.1, range.2).unwrap();
+            b.iter(|| std::hint::black_box(Distribution::<f64>::sample(&distr, &mut rng)));
+        });
+    }
+    g.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().with_measurement(CyclesPerByte)
+        .warm_up_time(core::time::Duration::from_secs(1))
+        .measurement_time(core::time::Duration::from_secs(2));
+    targets = bench
+);
+criterion_main!(benches);

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add plots for `rand_distr` distributions to documentation (#1434)
 - Add `PertBuilder`, fix case where mode ≅ mean (#1452)
+- Add `rand_distr::TruncatedNormal` (#1523)
 
 ## [0.5.0-alpha.1] - 2024-03-18
 - Target `rand` version `0.9.0-alpha.1`

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -36,6 +36,7 @@ rand = { path = "..", version = "=0.9.0-alpha.1", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 serde_with = { version = ">= 3.0, <= 3.11", optional = true }
+spec_math = "0.1.6"
 
 [dev-dependencies]
 rand_pcg = { version = "=0.9.0-alpha.1", path = "../rand_pcg" }

--- a/rand_distr/src/lib.rs
+++ b/rand_distr/src/lib.rs
@@ -112,7 +112,7 @@ pub use self::geometric::{Error as GeoError, Geometric, StandardGeometric};
 pub use self::gumbel::{Error as GumbelError, Gumbel};
 pub use self::hypergeometric::{Error as HyperGeoError, Hypergeometric};
 pub use self::inverse_gaussian::{Error as InverseGaussianError, InverseGaussian};
-pub use self::normal::{Error as NormalError, LogNormal, Normal, StandardNormal};
+pub use self::normal::{Error as NormalError, LogNormal, Normal, StandardNormal, TruncatedNormal};
 pub use self::normal_inverse_gaussian::{
     Error as NormalInverseGaussianError, NormalInverseGaussian,
 };


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary
Add truncated normal distribution to `rand_distr`, allowing users to specify the mean, standard deviation, left bound, and right bound of the distribution.

# Motivation
As discussion in #1189.
This would be use in numerical simulations, statistics, games, etc.

# Details
This implementation is ported from [`scipy.stats.truncnorm`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.truncnorm.html), which relies on Cephes Mathematical Library.
An extra dependency is added of the Rust implementation of the Cephes library ([`spec_math`](https://crates.io/crates/spec_math)).