### PR TITLE
Prepare 0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [0.8.6] - 2024-11-18
+- Doc rebuild without `simd_support` (#1529)
+
 ## [0.8.5] - 2021-08-20
 ### Fixes
 - Fix build on non-32/64-bit architectures (#1144)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -19,7 +19,7 @@ include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 [package.metadata.docs.rs]
 # To build locally:
 # RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --all-features --no-deps --open
-all-features = true
+features = ["serde1", "getrandom", "small_rng", "min_const_gen", "log"]
 rustdoc-args = ["--cfg", "doc_cfg"]
 
 [package.metadata.playground]


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Rebuild docs.rs docs to fix #1528 

# Details

There are a bunch of warnings, but I don't feel the need to fix these for an old release. (Most were solved by #1450.)