### PR TITLE
Rename SmallRng::from_thread_rng to from_rand_rng

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Rename `Rng::gen_range` to `random_range`, `gen_bool` to `random_bool`, `gen_ratio` to `random_ratio` (#1505)
 - Rename `Standard` to `StandardUniform` (#1526)
 - Remove impl of `Distribution<Option<T>>` for `Standard` (#1526)
+- Rename `SmallRng::from_thread_rng` to `from_rand_rng` (#1531)
 
 ## [0.9.0-alpha.1] - 2024-03-18
 - Add the `Slice::num_choices` method to the Slice distribution (#1402)

--- a/benches/benches/generators.rs
+++ b/benches/benches/generators.rs
@@ -48,7 +48,7 @@ pub fn random_bytes(c: &mut Criterion) {
     bench(&mut g, "chacha12", ChaCha12Rng::from_os_rng());
     bench(&mut g, "chacha20", ChaCha20Rng::from_os_rng());
     bench(&mut g, "std", StdRng::from_os_rng());
-    bench(&mut g, "small", SmallRng::from_thread_rng());
+    bench(&mut g, "small", SmallRng::from_rand_rng());
     bench(&mut g, "os", UnwrapErr(OsRng));
     bench(&mut g, "thread", rand::rng());
 
@@ -77,7 +77,7 @@ pub fn random_u32(c: &mut Criterion) {
     bench(&mut g, "chacha12", ChaCha12Rng::from_os_rng());
     bench(&mut g, "chacha20", ChaCha20Rng::from_os_rng());
     bench(&mut g, "std", StdRng::from_os_rng());
-    bench(&mut g, "small", SmallRng::from_thread_rng());
+    bench(&mut g, "small", SmallRng::from_rand_rng());
     bench(&mut g, "os", UnwrapErr(OsRng));
     bench(&mut g, "thread", rand::rng());
 
@@ -106,7 +106,7 @@ pub fn random_u64(c: &mut Criterion) {
     bench(&mut g, "chacha12", ChaCha12Rng::from_os_rng());
     bench(&mut g, "chacha20", ChaCha20Rng::from_os_rng());
     bench(&mut g, "std", StdRng::from_os_rng());
-    bench(&mut g, "small", SmallRng::from_thread_rng());
+    bench(&mut g, "small", SmallRng::from_rand_rng());
     bench(&mut g, "os", UnwrapErr(OsRng));
     bench(&mut g, "thread", rand::rng());
 

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -53,10 +53,10 @@ type Rng = super::xoshiro256plusplus::Xoshiro256PlusPlus;
 ///     let rng = SmallRng::from_os_rng();
 ///     # let _: SmallRng = rng;
 ///     ```
-/// 3.  Via [`SmallRng::from_thread_rng`]:
+/// 3.  Via [`SmallRng::from_rand_rng`]:
 ///     ```
 ///     # use rand::rngs::SmallRng;
-///     let rng = SmallRng::from_thread_rng();
+///     let rng = SmallRng::from_rand_rng();
 ///     ```
 ///
 /// See also [Seeding RNGs] in the book.
@@ -123,7 +123,7 @@ impl SmallRng {
     /// [`rand::rng`]: crate::rng()
     #[cfg(all(feature = "std", feature = "std_rng", feature = "getrandom"))]
     #[inline(always)]
-    pub fn from_thread_rng() -> Self {
+    pub fn from_rand_rng() -> Self {
         let mut seed = <Rng as SeedableRng>::Seed::default();
         crate::rng().fill_bytes(seed.as_mut());
         SmallRng(Rng::from_seed(seed))

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -114,12 +114,13 @@ impl RngCore for SmallRng {
 }
 
 impl SmallRng {
-    /// Construct an instance seeded from `rand::rng`
+    /// Construct an instance seeded from [`rand::rng`]
     ///
     /// # Panics
     ///
-    /// This method panics only if [`crate::rng()`] fails to
-    /// initialize.
+    /// This method panics only if [`rand::rng`] fails to initialize.
+    ///
+    /// [`rand::rng`]: crate::rng()
     #[cfg(all(feature = "std", feature = "std_rng", feature = "getrandom"))]
     #[inline(always)]
     pub fn from_thread_rng() -> Self {

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -40,24 +40,20 @@ type Rng = super::xoshiro256plusplus::Xoshiro256PlusPlus;
 /// suitable for seeding, but note that, even with a fixed seed, output is not
 /// [portable]. Some suggestions:
 ///
-/// 1.  Seed **from an integer** via `seed_from_u64`. This uses a hash function
-///     internally to yield a (typically) good seed from any input.
+/// 1.  To automatically seed with a unique seed, use [`SmallRng::from_rand_rng`]:
+///     ```
+///     # use rand::rngs::SmallRng;
+///     let rng = SmallRng::from_rand_rng();
+///     ```
+/// 2.  To use a deterministic integral seed, use `seed_from_u64`. This uses a
+///     hash function internally to yield a (typically) good seed from any
+///     input.
 ///     ```
 ///     # use rand::{SeedableRng, rngs::SmallRng};
 ///     let rng = SmallRng::seed_from_u64(1);
 ///     # let _: SmallRng = rng;
 ///     ```
-/// 2.  With a fresh seed, **direct from the OS** (implies a syscall):
-///     ```
-///     # use rand::{SeedableRng, rngs::SmallRng};
-///     let rng = SmallRng::from_os_rng();
-///     # let _: SmallRng = rng;
-///     ```
-/// 3.  Via [`SmallRng::from_rand_rng`]:
-///     ```
-///     # use rand::rngs::SmallRng;
-///     let rng = SmallRng::from_rand_rng();
-///     ```
+/// 3.  To seed deterministically from text or other input, use [`rand_seeder`].
 ///
 /// See also [Seeding RNGs] in the book.
 ///
@@ -74,6 +70,7 @@ type Rng = super::xoshiro256plusplus::Xoshiro256PlusPlus;
 /// [rand_pcg]: https://crates.io/crates/rand_pcg
 /// [rand_xoshiro]: https://crates.io/crates/rand_xoshiro
 /// [`rand_chacha::ChaCha8Rng`]: https://docs.rs/rand_chacha/latest/rand_chacha/struct.ChaCha8Rng.html
+/// [`rand_seeder`]: https://docs.rs/rand_seeder/latest/rand_seeder/
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SmallRng(Rng);
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Title

# Motivation

Function `thread_rng` was renamed to just `rng`. We can't call this method `from_rng` since that clashes with the `SeedableRng` method, so this seems like the next best choice (also aligning somewhat with the terminology we use in docs).