### PR TITLE
remove conditional compilation around using core

### DIFF
--- a/rand_chacha/src/chacha.rs
+++ b/rand_chacha/src/chacha.rs
@@ -8,13 +8,8 @@
 
 //! The ChaCha random number generator.
 
-#[cfg(not(feature = "std"))]
-use core;
-#[cfg(feature = "std")]
-use std as core;
-
-use self::core::fmt;
 use crate::guts::ChaCha;
+use core::fmt;
 use rand_core::block::{BlockRng, BlockRngCore, CryptoBlockRng};
 use rand_core::{CryptoRng, RngCore, SeedableRng};
 


### PR DESCRIPTION
# Summary

Minor simplification

# Motivation

Makes things cleaner; probably makes code completion in editors know what's actually in code

# Details

I tested this with 1.61 locally and it seems to work fine. I wasn't able to quickly figure out which rust version stabilized using core from anywhere though. Probably sometime around 2018 edition, I'd guess