### PR TITLE
Bump the MSRV to 1.63.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             variant: MSRV
-            toolchain: 1.61.0
+            toolchain: 1.63.0
           - os: ubuntu-latest
             deps: sudo apt-get update ; sudo apt install gcc-multilib
             target: i686-unknown-linux-gnu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 ## [Unreleased]
 - Add `rand::distributions::WeightedIndex::{weight, weights, total_weight}` (#1420)
 - Add `IndexedRandom::choose_multiple_array`, `index::sample_array` (#1453, #1469)
-- Bump the MSRV to 1.61.0
+- Bump the MSRV to 1.63.0
 - Rename `Rng::gen` to `Rng::random` to avoid conflict with the new `gen` keyword in Rust 2024 (#1435)
 - Move all benchmarks to new `benches` crate (#1439) and migrate to Criterion (#1490)
 - Annotate panicking methods with `#[track_caller]` (#1442, #1447)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["random", "rng"]
 categories = ["algorithms", "no-std"]
 autobenches = true
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [package.metadata.docs.rs]

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -13,7 +13,7 @@ ChaCha random number generator
 keywords = ["random", "rng", "chacha"]
 categories = ["algorithms", "no-std"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Bump the MSRV to 1.61.0
+- Bump the MSRV to 1.63.0
 - The `serde1` feature has been renamed `serde` (#1477)
 
 ## [0.9.0-alpha.1] - 2024-03-18

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -13,7 +13,7 @@ Core random number generator traits and tools for implementation.
 keywords = ["random", "rng"]
 categories = ["algorithms", "no-std"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -13,7 +13,7 @@ Sampling from random number distributions
 keywords = ["random", "rng", "distribution", "probability"]
 categories = ["algorithms", "no-std"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 include = ["/src", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [package.metadata.docs.rs]

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -13,7 +13,7 @@ Selected PCG random number generators
 keywords = ["random", "rng", "pcg"]
 categories = ["algorithms", "no-std"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Bump the MSRV to 1.63 due to libc now requiring the same.
