### PR TITLE
Update: getrandom v0.3.0 rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ This is a pre-release. To depend on this version, use `rand = "=0.9.0-beta.0"` t
 - Distribution `Uniform` implements `TryFrom` instead of `From` for ranges (#1229)
 - Optimize distribution `Uniform`: use Canon's method (single sampling) / Lemire's method (distribution sampling) for faster sampling (breaks value stability; #1287)
 - Add `UniformUsize` and use to make `Uniform` for `usize` portable (#1487)
+- Remove support for generating `isize` and `usize` values with `Standard`, `Uniform` (except via `UniformUsize`) and `Fill` and usage as a `WeightedAliasIndex` weight (#1487)
 - Optimize fn `sample_single_inclusive` for floats (+~20% perf) (#1289)
 - Allow `UniformFloat::new` samples and `UniformFloat::sample_single` to yield `high` (#1462)
 - Add impl `DistString` for distributions `Slice<char>` and `Uniform<char>` (#1315)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [0.9.0-beta.1] - 2024-11-30
+- Bump `rand_core` version
+
 ## [0.9.0-beta.0] - 2024-11-25
 This is a pre-release. To depend on this version, use `rand = "=0.9.0-beta.0"` to prevent automatic updates (which can be expected to include breaking changes).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.9.0-beta.0"
+version = "0.9.0-beta.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -69,14 +69,14 @@ members = [
 exclude = ["benches", "distr_test"]
 
 [dependencies]
-rand_core = { path = "rand_core", version = "=0.9.0-beta.0", default-features = false }
+rand_core = { path = "rand_core", version = "=0.9.0-beta.1", default-features = false }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
-rand_chacha = { path = "rand_chacha", version = "=0.9.0-beta.0", default-features = false, optional = true }
+rand_chacha = { path = "rand_chacha", version = "=0.9.0-beta.1", default-features = false, optional = true }
 zerocopy = { version = "0.8.0", default-features = false, features = ["simd"] }
 
 [dev-dependencies]
-rand_pcg = { path = "rand_pcg", version = "=0.9.0-beta.0" }
+rand_pcg = { path = "rand_pcg", version = "=0.9.0-beta.1" }
 # Only to test serde
 bincode = "1.2.1"
 rayon = "1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde = ["dep:serde", "rand_core/serde"]
 std = ["rand_core/std", "rand_chacha?/std", "alloc"]
 
 # Option: "alloc" enables support for Vec and Box when not using "std"
-alloc = ["rand_core/alloc"]
+alloc = []
 
 # Option: enable OsRng
 os_rng = ["rand_core/os_rng"]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ rand = "0.8.5"
 Or, to try the 0.9.0 beta release:
 ```toml
 [dependencies]
-rand = "=0.9.0-beta.0"
+rand = "=0.9.0-beta.1"
 ```
 
 To get started using Rand, see [The Book](https://rust-random.github.io/book).

--- a/distr_test/Cargo.toml
+++ b/distr_test/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dev-dependencies]
 rand_distr = { path = "../rand_distr", version = "=0.5.0-beta.1", default-features = false, features = ["alloc"] }
-rand = { path = "..", version = "=0.9.0-beta.0", features = ["small_rng"] }
+rand = { path = "..", version = "=0.9.0-beta.1", features = ["small_rng"] }
 num-traits = "0.2.19"
 # Special functions for testing distributions
 special = "0.11.0"

--- a/rand_chacha/CHANGELOG.md
+++ b/rand_chacha/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0-beta.1] - 2024-11-30
+- Bump `rand_core` version
+
 ## [0.9.0-beta.0] - 2024-11-25
 This is a pre-release. To depend on this version, use `rand_chacha = "=0.9.0-beta.0"` to prevent automatic updates (which can be expected to include breaking changes).
 

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_chacha"
-version = "0.9.0-beta.0"
+version = "0.9.0-beta.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers", "The CryptoCorrosion Contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -20,14 +20,14 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition"]
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "=0.9.0-beta.0" }
+rand_core = { path = "../rand_core", version = "=0.9.0-beta.1" }
 ppv-lite86 = { version = "0.2.14", default-features = false, features = ["simd"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 # Only to test serde
 serde_json = "1.0"
-rand_core = { path = "../rand_core", version = "=0.9.0-beta.0", features = ["os_rng"] }
+rand_core = { path = "../rand_core", version = "=0.9.0-beta.1", features = ["os_rng"] }
 
 [features]
 default = ["std"]

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0-beta.1] - 2024-11-30
+- Update to `getrandom` v0.3.0-rc.0
+
 ## [0.9.0-beta.0] - 2024-11-25
 This is a pre-release. To depend on this version, use `rand_core = "=0.9.0-beta.0"` to prevent automatic updates (which can be expected to include breaking changes).
 

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -32,5 +32,5 @@ serde = ["dep:serde"] # enables serde for BlockRng wrapper
 
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }
-getrandom = { version = "0.2", optional = true }
+getrandom = { version = "0.3.0-rc.0", optional = true }
 zerocopy = { version = "0.8.0", default-features = false }

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -25,8 +25,7 @@ rustdoc-args = ["--generate-link-to-definition"]
 all-features = true
 
 [features]
-std = ["alloc", "getrandom?/std"]
-alloc = []  # enables Vec and Box support without std
+std = ["getrandom?/std"]
 os_rng = ["dep:getrandom"]
 serde = ["dep:serde"] # enables serde for BlockRng wrapper
 

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.9.0-beta.0"
+version = "0.9.0-beta.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_core/README.md
+++ b/rand_core/README.md
@@ -42,33 +42,8 @@ The traits and error types are also available via `rand`.
 
 The current version is:
 ```
-rand_core = "0.6.4"
+rand_core = "=0.9.0-beta.1"
 ```
-
-Rand libs have inter-dependencies and make use of the
-[semver trick](https://github.com/dtolnay/semver-trick/) in order to make traits
-compatible across crate versions. (This is especially important for `RngCore`
-and `SeedableRng`.) A few crate releases are thus compatibility shims,
-depending on the *next* lib version (e.g. `rand_core` versions `0.2.2` and
-`0.3.1`). This means, for example, that `rand_core_0_4_0::SeedableRng` and
-`rand_core_0_3_0::SeedableRng` are distinct, incompatible traits, which can
-cause build errors. Usually, running `cargo update` is enough to fix any issues.
-
-## Crate Features
-
-`rand_core` supports `no_std` and `alloc`-only configurations, as well as full
-`std` functionality. The differences between `no_std` and full `std` are small,
-comprising `RngCore` support for `Box<R>` types where `R: RngCore`,
-`std::io::Read` support for types supporting `RngCore`, and
-extensions to the `Error` type's functionality.
-
-The `std` feature is *not enabled by default*. This is primarily to avoid build
-problems where one crate implicitly requires `rand_core` with `std` support and
-another crate requires `rand` *without* `std` support. However, the `rand` crate
-continues to enable `std` support by default, both for itself and `rand_core`.
-
-The `serde` feature can be used to derive `Serialize` and `Deserialize` for RNG
-implementations that use the `BlockRng` or `BlockRng64` wrappers.
 
 
 # License

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -512,7 +512,7 @@ pub trait SeedableRng: Sized {
     #[cfg(feature = "os_rng")]
     fn try_from_os_rng() -> Result<Self, getrandom::Error> {
         let mut seed = Self::Seed::default();
-        getrandom::getrandom(seed.as_mut())?;
+        getrandom::fill(seed.as_mut())?;
         let res = Self::from_seed(seed);
         Ok(res)
     }

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -35,8 +35,6 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]
 
-#[cfg(feature = "alloc")]
-extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/rand_core/src/os.rs
+++ b/rand_core/src/os.rs
@@ -79,15 +79,6 @@ impl OsError {
     pub fn raw_os_error(self) -> Option<i32> {
         self.0.raw_os_error()
     }
-
-    /// Extract the bare error code.
-    ///
-    /// This code can either come from the underlying OS, or be a custom error.
-    /// Use [`OsError::raw_os_error()`] to disambiguate.
-    #[inline]
-    pub const fn code(self) -> core::num::NonZeroU32 {
-        self.0.code()
-    }
 }
 
 impl TryRngCore for OsRng {

--- a/rand_core/src/os.rs
+++ b/rand_core/src/os.rs
@@ -9,7 +9,6 @@
 //! Interface to the random number generator of the operating system.
 
 use crate::{TryCryptoRng, TryRngCore};
-use getrandom::getrandom;
 
 /// An interface over the operating-system's random data source
 ///
@@ -87,20 +86,20 @@ impl TryRngCore for OsRng {
     #[inline]
     fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
         let mut buf = [0u8; 4];
-        getrandom(&mut buf).map_err(OsError)?;
+        getrandom::fill(&mut buf).map_err(OsError)?;
         Ok(u32::from_ne_bytes(buf))
     }
 
     #[inline]
     fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
         let mut buf = [0u8; 8];
-        getrandom(&mut buf).map_err(OsError)?;
+        getrandom::fill(&mut buf).map_err(OsError)?;
         Ok(u64::from_ne_bytes(buf))
     }
 
     #[inline]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
-        getrandom(dest).map_err(OsError)?;
+        getrandom::fill(dest).map_err(OsError)?;
         Ok(())
     }
 }

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0-beta.2] - 2024-11-30
+- Bump `rand` version
+
 ## [0.5.0-beta.1] - 2024-11-27
 - Fix docs.rs build (#1539)
 

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_distr"
-version = "0.5.0-beta.1"
+version = "0.5.0-beta.2"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -33,15 +33,15 @@ std_math = ["num-traits/std"]
 serde = ["dep:serde", "dep:serde_with", "rand/serde"]
 
 [dependencies]
-rand = { path = "..", version = "=0.9.0-beta.0", default-features = false }
+rand = { path = "..", version = "=0.9.0-beta.1", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 serde_with = { version = ">= 3.0, <= 3.11", optional = true }
 
 [dev-dependencies]
-rand_pcg = { version = "=0.9.0-beta.0", path = "../rand_pcg" }
+rand_pcg = { version = "=0.9.0-beta.1", path = "../rand_pcg" }
 # For inline examples
-rand = { path = "..", version = "=0.9.0-beta.0", features = ["small_rng"] }
+rand = { path = "..", version = "=0.9.0-beta.1", features = ["small_rng"] }
 # Histogram implementation for testing uniformity
 average = { version = "0.15", features = [ "std" ] }
 # Special functions for testing distributions

--- a/rand_pcg/CHANGELOG.md
+++ b/rand_pcg/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0-beta.1] - 2024-11-30
+- Bump `rand_core` version
+
 ## [0.9.0-beta.0] - 2024-11-25
 This is a pre-release. To depend on this version, use `rand_chacha = "=0.9.0-beta.0"` to prevent automatic updates (which can be expected to include breaking changes).
 

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_pcg"
-version = "0.9.0-beta.0"
+version = "0.9.0-beta.1"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -24,7 +24,7 @@ serde = ["dep:serde"]
 os_rng = ["rand_core/os_rng"]
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "=0.9.0-beta.0" }
+rand_core = { path = "../rand_core", version = "=0.9.0-beta.1" }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
@@ -32,4 +32,4 @@ serde = { version = "1", features = ["derive"], optional = true }
 # deps yet, see: https://github.com/rust-lang/cargo/issues/1596
 # Versions prior to 1.1.4 had incorrect minimal dependencies.
 bincode = { version = "1.1.4" }
-rand_core = { path = "../rand_core", version = "=0.9.0-beta.0", features = ["os_rng"] }
+rand_core = { path = "../rand_core", version = "=0.9.0-beta.1", features = ["os_rng"] }


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Update to `getrandom` v0.3.0-rc.0

Since our [`OsRng` docs](https://docs.rs/rand_core/0.9.0-beta.0/rand_core/struct.OsRng.html) simply say "refert to getrandom documentation for details" I don't think we need any doc changes.

Also removed the `alloc` feature from `rand_core` which no longer has any purpose.