### PR TITLE
Thread rng

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [0.9.0-beta.3] - 2025-01-03
+- Add feature `thread_rng` (#1547)
+
 ## [0.9.0-beta.1] - 2024-11-30
 - Bump `rand_core` version
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ features = ["small_rng", "serde"]
 
 [features]
 # Meta-features:
-default = ["std", "std_rng", "os_rng", "small_rng"]
+default = ["std", "std_rng", "os_rng", "small_rng", "thread_rng"]
 nightly = [] # some additions requiring nightly Rust
 serde = ["dep:serde", "rand_core/serde"]
 
@@ -50,6 +50,9 @@ std_rng = ["dep:rand_chacha"]
 
 # Option: enable SmallRng
 small_rng = []
+
+# Option: enable ThreadRng and rng()
+thread_rng = ["std", "std_rng", "os_rng"]
 
 # Option: use unbiased sampling for algorithms supporting this option: Uniform distribution.
 # By default, bias affecting no more than one in  2^48 samples is accepted.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.9.0-beta.1"
+version = "0.9.0-beta.3"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ rand = "0.8.5"
 Or, to try the 0.9.0 beta release:
 ```toml
 [dependencies]
-rand = "=0.9.0-beta.1"
+rand = "=0.9.0-beta.3"
 ```
 
 To get started using Rand, see [The Book](https://rust-random.github.io/book).

--- a/distr_test/Cargo.toml
+++ b/distr_test/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dev-dependencies]
-rand_distr = { path = "../rand_distr", version = "=0.5.0-beta.2", default-features = false, features = ["alloc"] }
-rand = { path = "..", version = "=0.9.0-beta.1", features = ["small_rng"] }
+rand_distr = { path = "../rand_distr", version = "=0.5.0-beta.3", default-features = false, features = ["alloc"] }
+rand = { path = "..", version = "=0.9.0-beta.3", features = ["small_rng"] }
 num-traits = "0.2.19"
 # Special functions for testing distributions
 special = "0.11.0"

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0-beta.3] - 2025-01-03
+- Bump `rand` version (#1547)
+
 ## [0.5.0-beta.2] - 2024-11-30
 - Bump `rand` version
 

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_distr"
-version = "0.5.0-beta.2"
+version = "0.5.0-beta.3"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -33,7 +33,7 @@ std_math = ["num-traits/std"]
 serde = ["dep:serde", "dep:serde_with", "rand/serde"]
 
 [dependencies]
-rand = { path = "..", version = "=0.9.0-beta.1", default-features = false }
+rand = { path = "..", version = "=0.9.0-beta.3", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 serde_with = { version = ">= 3.0, <= 3.11", optional = true }
@@ -41,7 +41,7 @@ serde_with = { version = ">= 3.0, <= 3.11", optional = true }
 [dev-dependencies]
 rand_pcg = { version = "=0.9.0-beta.1", path = "../rand_pcg" }
 # For inline examples
-rand = { path = "..", version = "=0.9.0-beta.1", features = ["small_rng"] }
+rand = { path = "..", version = "=0.9.0-beta.3", features = ["small_rng"] }
 # Histogram implementation for testing uniformity
 average = { version = "0.15", features = [ "std" ] }
 # Special functions for testing distributions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,13 +103,13 @@ pub mod rngs;
 pub mod seq;
 
 // Public exports
-#[cfg(all(feature = "std", feature = "std_rng", feature = "os_rng"))]
+#[cfg(feature = "thread_rng")]
 pub use crate::rngs::thread::rng;
 
 /// Access the thread-local generator
 ///
 /// Use [`rand::rng()`](rng()) instead.
-#[cfg(all(feature = "std", feature = "std_rng", feature = "os_rng"))]
+#[cfg(feature = "thread_rng")]
 #[deprecated(since = "0.9.0", note = "renamed to `rng`")]
 #[inline]
 pub fn thread_rng() -> crate::rngs::ThreadRng {
@@ -118,7 +118,7 @@ pub fn thread_rng() -> crate::rngs::ThreadRng {
 
 pub use rng::{Fill, Rng};
 
-#[cfg(all(feature = "std", feature = "std_rng", feature = "os_rng"))]
+#[cfg(feature = "thread_rng")]
 use crate::distr::{Distribution, StandardUniform};
 
 /// Generate a random value using the thread-local random number generator.
@@ -159,7 +159,7 @@ use crate::distr::{Distribution, StandardUniform};
 ///
 /// [`StandardUniform`]: distr::StandardUniform
 /// [`ThreadRng`]: rngs::ThreadRng
-#[cfg(all(feature = "std", feature = "std_rng", feature = "os_rng"))]
+#[cfg(feature = "thread_rng")]
 #[inline]
 pub fn random<T>() -> T
 where
@@ -179,7 +179,7 @@ where
 /// let v: Vec<i32> = rand::random_iter().take(5).collect();
 /// println!("{v:?}");
 /// ```
-#[cfg(all(feature = "std", feature = "std_rng", feature = "os_rng"))]
+#[cfg(feature = "thread_rng")]
 #[inline]
 pub fn random_iter<T>() -> distr::DistIter<StandardUniform, rngs::ThreadRng, T>
 where
@@ -204,7 +204,7 @@ where
 /// ```
 /// Note that the first example can also be achieved (without `collect`'ing
 /// to a `Vec`) using [`seq::IteratorRandom::choose`].
-#[cfg(all(feature = "std", feature = "std_rng", feature = "os_rng"))]
+#[cfg(feature = "thread_rng")]
 #[inline]
 pub fn random_range<T, R>(range: R) -> T
 where
@@ -228,7 +228,7 @@ where
 /// # Panics
 ///
 /// If `p < 0` or `p > 1`.
-#[cfg(all(feature = "std", feature = "std_rng", feature = "os_rng"))]
+#[cfg(feature = "thread_rng")]
 #[inline]
 #[track_caller]
 pub fn random_bool(p: f64) -> bool {
@@ -260,7 +260,7 @@ pub fn random_bool(p: f64) -> bool {
 /// ```
 ///
 /// [`Bernoulli`]: distr::Bernoulli
-#[cfg(all(feature = "std", feature = "std_rng", feature = "os_rng"))]
+#[cfg(feature = "thread_rng")]
 #[inline]
 #[track_caller]
 pub fn random_ratio(numerator: u32, denominator: u32) -> bool {
@@ -282,7 +282,7 @@ pub fn random_ratio(numerator: u32, denominator: u32) -> bool {
 /// Note that you can instead use [`random()`] to generate an array of random
 /// data, though this is slower for small elements (smaller than the RNG word
 /// size).
-#[cfg(all(feature = "std", feature = "std_rng", feature = "os_rng"))]
+#[cfg(feature = "thread_rng")]
 #[inline]
 #[track_caller]
 pub fn fill<T: Fill + ?Sized>(dest: &mut T) {
@@ -302,7 +302,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(all(feature = "std", feature = "std_rng", feature = "os_rng"))]
+    #[cfg(feature = "thread_rng")]
     fn test_random() {
         let _n: u64 = random();
         let _f: f32 = random();
@@ -316,7 +316,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(all(feature = "std", feature = "std_rng", feature = "os_rng"))]
+    #[cfg(feature = "thread_rng")]
     fn test_range() {
         let _n: usize = random_range(42..=43);
         let _f: f32 = random_range(42.0..43.0);

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -27,7 +27,7 @@ pub use crate::rngs::SmallRng;
 #[doc(no_inline)]
 pub use crate::rngs::StdRng;
 #[doc(no_inline)]
-#[cfg(all(feature = "std", feature = "std_rng", feature = "os_rng"))]
+#[cfg(feature = "thread_rng")]
 pub use crate::rngs::ThreadRng;
 #[doc(no_inline)]
 pub use crate::seq::{IndexedMutRandom, IndexedRandom, IteratorRandom, SliceRandom};

--- a/src/rngs/mod.rs
+++ b/src/rngs/mod.rs
@@ -95,14 +95,14 @@ mod xoshiro256plusplus;
 
 #[cfg(feature = "std_rng")]
 mod std;
-#[cfg(all(feature = "std", feature = "std_rng", feature = "os_rng"))]
+#[cfg(feature = "thread_rng")]
 pub(crate) mod thread;
 
 #[cfg(feature = "small_rng")]
 pub use self::small::SmallRng;
 #[cfg(feature = "std_rng")]
 pub use self::std::StdRng;
-#[cfg(all(feature = "std", feature = "std_rng", feature = "os_rng"))]
+#[cfg(feature = "thread_rng")]
 pub use self::thread::ThreadRng;
 
 #[cfg(feature = "os_rng")]


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Add the `thread_rng` feature flag

# Motivation

- Symmetry with `small_rng`, `std_rng`, `os_rng` feature flags
- Cleaner feature tags in docs (having `std and std_rng and os_rng` on `rng()` etc. is not pretty)
- The possibility of #1545 as a non-breaking change (though it likely won't happen)
