### PR TITLE
Enable `stdarch_x86_avx512` for cpu has `avx512bw`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 #![no_std]
 #![cfg_attr(feature = "simd_support", feature(portable_simd))]
+#![cfg_attr(all(feature = "simd_support", target_feature = "avx512bw"), feature(stdarch_x86_avx512))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(
     clippy::float_cmp,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,10 @@
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 #![no_std]
 #![cfg_attr(feature = "simd_support", feature(portable_simd))]
-#![cfg_attr(all(feature = "simd_support", target_feature = "avx512bw"), feature(stdarch_x86_avx512))]
+#![cfg_attr(
+    all(feature = "simd_support", target_feature = "avx512bw"),
+    feature(stdarch_x86_avx512)
+)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(
     clippy::float_cmp,


### PR DESCRIPTION
# Motivation
Enable feature `stdarch_x86_avx512` for cpu has `avx512bw` when `simd_support` is enabled.

# Details
The trait `WideningMultiply` for `u16x32` need `avx512`, which needs unstable library feature `stdarch_x86_avx512`. This modification enable it when cpu has target_feature `avx512bw`.