### PR TITLE
Prepare 0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Add `pub` module `rand::distr::weighted`, moving `WeightedIndex` there (#1548)
 - Add trait `weighted::Weight`, allowing `WeightedIndex` to trap overflow (#1353)
 - Add fns `weight, weights, total_weight` to distribution `WeightedIndex` (#1420)
-- Rename enum `WeightedError` to `weighted::WeightError`, revising variants (#1382) and mark as `#[non_exhaustive]` (#1480)
+- Rename enum `WeightedError` to `weighted::Error`, revising variants (#1382) and mark as `#[non_exhaustive]` (#1480)
 
 ### API changes: SIMD
 - Switch to `std::simd`, expand SIMD & docs (#1239)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 
 ### Dependencies
 - Bump the MSRV to 1.63.0 (#1207, #1246, #1269, #1341, #1416, #1536); note that 1.60.0 may work for dependents when using `--ignore-rust-version`
-- Update to `rand_core` v0.9.0 (#1554)
+- Update to `rand_core` v0.9.0 (#1558)
 
 ### Features
 - Support `std` feature without `getrandom` or `rand_chacha` (#1354)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Add fn `RngCore::read_adapter` implementing `std::io::Read` (#1267)
 - Add trait `CryptoBlockRng: BlockRngCore`; make `trait CryptoRng: RngCore` (#1273)
 - Add traits `TryRngCore`, `TryCryptoRng` (#1424, #1499)
+- Rename `fn SeedableRng::from_rng` -> `try_from_rng` and add infallible variant `fn from_rng` (#1424)
+- Rename `fn SeedableRng::from_entropy` -> `from_os_rng` and add fallible variant `fn try_from_os_rng` (#1424)
 - Add bounds `Clone` and `AsRef` to associated type `SeedableRng::Seed` (#1491)
 
 ### API changes: Rng trait and top-level fns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,97 +8,104 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
-## [0.9.0-beta.3] - 2025-01-03
-- Add feature `thread_rng` (#1547)
-- Move `distr::Slice` -> `distr::slice::Choose`, `distr::EmptySlice` -> `distr::slice::Empty` (#1548)
-- Rename trait `distr::DistString` -> `distr::SampleString` (#1548)
-- Rename `distr::DistIter` -> `distr::Iter`, `distr::DistMap` -> `distr::Map` (#1548)
-- Move `distr::{Weight, WeightError, WeightedIndex}` -> `distr::weighted::{Weight, Error, WeightedIndex}` (#1548)
-
-## [0.9.0-beta.1] - 2024-11-30
-- Bump `rand_core` version
-
-## [0.9.0-beta.0] - 2024-11-25
-This is a pre-release. To depend on this version, use `rand = "=0.9.0-beta.0"` to prevent automatic updates (which can be expected to include breaking changes).
-
+## [0.9.0] - 2025-01-27
 ### Security and unsafe
 - Policy: "rand is not a crypto library" (#1514)
 - Remove fork-protection from `ReseedingRng` and `ThreadRng`. Instead, it is recommended to call `ThreadRng::reseed` on fork. (#1379)
 - Use `zerocopy` to replace some `unsafe` code (#1349, #1393, #1446, #1502)
 
-### Compilation options
+### Dependencies
 - Bump the MSRV to 1.63.0 (#1207, #1246, #1269, #1341, #1416, #1536); note that 1.60.0 may work for dependents when using `--ignore-rust-version`
-- Support `std` feature without `getrandom` or `rand_chacha` (#1354)
-- Improve `thread_rng` related docs (#1257)
-- The `serde1` feature has been renamed `serde` (#1477)
-- The implicit feature `rand_chacha` has been removed. This is enabled by `std_rng`. (#1473)
-- Enable feature `small_rng` by default (#1455)
-- Rename feature `getrandom` to `os_rng` (#1537)
+- Update to `rand_core` v0.9.0 (#1554)
 
-### Inherited changes from `rand_core`
+### Features
+- Support `std` feature without `getrandom` or `rand_chacha` (#1354)
+- Enable feature `small_rng` by default (#1455)
+- Remove implicit feature `rand_chacha`; use `std_rng` instead. (#1473)
+- Rename feature `serde1` to `serde` (#1477)
+- Rename feature `getrandom` to `os_rng` (#1537)
+- Add feature `thread_rng` (#1547)
+
+### API changes: rand_core traits
 - Add fn `RngCore::read_adapter` implementing `std::io::Read` (#1267)
 - Add trait `CryptoBlockRng: BlockRngCore`; make `trait CryptoRng: RngCore` (#1273)
 - Add traits `TryRngCore`, `TryCryptoRng` (#1424, #1499)
 - Add bounds `Clone` and `AsRef` to associated type `SeedableRng::Seed` (#1491)
 
-### Rng trait and top-level fns
-- Rename fn `rand::thread_rng()` to `rand::rng()`, and remove from the prelude (#1506)
-- Add top-level fns `random_iter`, `random_range`, `random_bool`, `random_ratio`, `fill` (#1488)
+### API changes: Rng trait and top-level fns
+- Rename fn `rand::thread_rng()` to `rand::rng()` and remove from the prelude (#1506)
 - Remove fn `rand::random()` from the prelude (#1506)
+- Add top-level fns `random_iter`, `random_range`, `random_bool`, `random_ratio`, `fill` (#1488)
 - Re-introduce fn `Rng::gen_iter` as `random_iter` (#1305, #1500)
 - Rename fn `Rng::gen` to `random` to avoid conflict with the new `gen` keyword in Rust 2024 (#1438)
 - Rename fns `Rng::gen_range` to `random_range`, `gen_bool` to `random_bool`, `gen_ratio` to `random_ratio` (#1505)
 - Annotate panicking methods with `#[track_caller]` (#1442, #1447)
 
-### RNGs
-- Make `ReseedingRng::reseed` discard remaining data from the last block generated (#1379)
-- Change fn `SmallRng::seed_from_u64` implementation (#1203)
+### API changes: RNGs
 - Fix `<SmallRng as SeedableRng>::Seed` size to 256 bits (#1455)
 - Remove first parameter (`rng`) of `ReseedingRng::new` (#1533)
-- Improve SmallRng initialization performance (#1482)
 
-### Sequences
-- Optimize fn `sample_floyd`, affecting output of `rand::seq::index::sample` and `rand::seq::SliceRandom::choose_multiple` (#1277)
-- New, faster algorithms for `IteratorRandom::choose` and `choose_stable` (#1268)
-- New, faster algorithms for `SliceRandom::shuffle` and `partial_shuffle` (#1272)
+### API changes: Sequences
 - Split trait `SliceRandom` into `IndexedRandom`, `IndexedMutRandom`, `SliceRandom` (#1382)
 - Add `IndexedRandom::choose_multiple_array`, `index::sample_array` (#1453, #1469)
-- Fix `IndexdRandom::choose_multiple_weighted` for very small seeds and optimize for large input length / low memory (#1530)
 
-### Distributions
+### API changes: Distributions: renames
 - Rename module `rand::distributions` to `rand::distr` (#1470)
-- Relax `Sized` bound on `Distribution<T> for &D` (#1278)
 - Rename distribution `Standard` to `StandardUniform` (#1526)
+- Move `distr::Slice` -> `distr::slice::Choose`, `distr::EmptySlice` -> `distr::slice::Empty` (#1548)
+- Rename trait `distr::DistString` -> `distr::SampleString` (#1548)
+- Rename `distr::DistIter` -> `distr::Iter`, `distr::DistMap` -> `distr::Map` (#1548)
+
+### API changes: Distributions
+- Relax `Sized` bound on `Distribution<T> for &D` (#1278)
 - Remove impl of `Distribution<Option<T>>` for `StandardUniform` (#1526)
 - Let distribution `StandardUniform` support all `NonZero*` types (#1332)
 - Fns `{Uniform, UniformSampler}::{new, new_inclusive}` return a `Result` (instead of potentially panicking) (#1229)
 - Distribution `Uniform` implements `TryFrom` instead of `From` for ranges (#1229)
-- Optimize distribution `Uniform`: use Canon's method (single sampling) / Lemire's method (distribution sampling) for faster sampling (breaks value stability; #1287)
-- Add `UniformUsize` and use to make `Uniform` for `usize` portable (#1487)
-- Remove support for generating `isize` and `usize` values with `Standard`, `Uniform` (except via `UniformUsize`) and `Fill` and usage as a `WeightedAliasIndex` weight (#1487)
-- Optimize fn `sample_single_inclusive` for floats (+~20% perf) (#1289)
-- Allow `UniformFloat::new` samples and `UniformFloat::sample_single` to yield `high` (#1462)
+- Add `UniformUsize` (#1487)
+- Remove support for generating `isize` and `usize` values with `StandardUniform`, `Uniform` (except via `UniformUsize`) and `Fill` and usage as a `WeightedAliasIndex` weight (#1487)
 - Add impl `DistString` for distributions `Slice<char>` and `Uniform<char>` (#1315)
 - Add fn `Slice::num_choices` (#1402)
-- Fix portability of distribution `Slice` (#1469)
-- Add trait `Weight`, allowing `WeightedIndex` to trap overflow (#1353)
-- Add fns `weight, weights, total_weight` to distribution `WeightedIndex` (#1420)
-- Rename enum `WeightedError` to `WeightError`, revising variants (#1382) and mark as `#[non_exhaustive]` (#1480)
 - Add fn `p()` for distribution `Bernoulli` to access probability (#1481)
 
-### SIMD
+### API changes: Weighted distributions
+- Add `pub` module `rand::distr::weighted`, moving `WeightedIndex` there (#1548)
+- Add trait `weighted::Weight`, allowing `WeightedIndex` to trap overflow (#1353)
+- Add fns `weight, weights, total_weight` to distribution `WeightedIndex` (#1420)
+- Rename enum `WeightedError` to `weighted::WeightError`, revising variants (#1382) and mark as `#[non_exhaustive]` (#1480)
+
+### API changes: SIMD
 - Switch to `std::simd`, expand SIMD & docs (#1239)
+
+### Reproducibility-breaking changes
+- Make `ReseedingRng::reseed` discard remaining data from the last block generated (#1379)
+- Change fn `SmallRng::seed_from_u64` implementation (#1203)
+- Allow `UniformFloat::new` samples and `UniformFloat::sample_single` to yield `high` (#1462)
+- Fix portability of distribution `Slice` (#1469)
+- Make `Uniform` for `usize` portable via `UniformUsize` (#1487)
+- Fix `IndexdRandom::choose_multiple_weighted` for very small seeds and optimize for large input length / low memory (#1530)
+
+### Reproducibility-breaking optimisations
+- Optimize fn `sample_floyd`, affecting output of `rand::seq::index::sample` and `rand::seq::SliceRandom::choose_multiple` (#1277)
+- New, faster algorithms for `IteratorRandom::choose` and `choose_stable` (#1268)
+- New, faster algorithms for `SliceRandom::shuffle` and `partial_shuffle` (#1272)
+- Optimize distribution `Uniform`: use Canon's method (single sampling) / Lemire's method (distribution sampling) for faster sampling (breaks value stability; #1287)
+- Optimize fn `sample_single_inclusive` for floats (+~20% perf) (#1289)
+
+### Other optimisations
+- Improve `SmallRng` initialization performance (#1482)
 - Optimise SIMD widening multiply (#1247)
 
-### Documentation
-- Add `Cargo.lock.msrv` file (#1275)
-- Docs: enable experimental `--generate-link-to-definition` feature (#1327)
-- Better doc of crate features, use `doc_auto_cfg` (#1411, #1450)
-
 ### Other
+- Add `Cargo.lock.msrv` file (#1275)
 - Reformat with `rustfmt` and enforce (#1448)
 - Apply Clippy suggestions and enforce (#1448, #1474)
 - Move all benchmarks to new `benches` crate (#1329, #1439) and migrate to Criterion (#1490)
+
+### Documentation
+- Improve `ThreadRng` related docs (#1257)
+- Docs: enable experimental `--generate-link-to-definition` feature (#1327)
+- Better doc of crate features, use `doc_auto_cfg` (#1411, #1450)
 
 ## [0.8.5] - 2021-08-20
 ### Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.9.0-beta.3"
+version = "0.9.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -72,14 +72,14 @@ members = [
 exclude = ["benches", "distr_test"]
 
 [dependencies]
-rand_core = { path = "rand_core", version = "=0.9.0-beta.1", default-features = false }
+rand_core = { path = "rand_core", version = "0.9.0", default-features = false }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
-rand_chacha = { path = "rand_chacha", version = "=0.9.0-beta.1", default-features = false, optional = true }
+rand_chacha = { path = "rand_chacha", version = "0.9.0", default-features = false, optional = true }
 zerocopy = { version = "0.8.0", default-features = false, features = ["simd"] }
 
 [dev-dependencies]
-rand_pcg = { path = "rand_pcg", version = "=0.9.0-beta.1" }
+rand_pcg = { path = "rand_pcg", version = "0.9.0" }
 # Only to test serde
 bincode = "1.2.1"
 rayon = "1.7"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ All with:
 
 Rand **is not**:
 
--   Small (LOC). Most low-level crates are small, but the higher-level `rand`
+-   Small (LoC). Most low-level crates are small, but the higher-level `rand`
     and `rand_distr` each contain a lot of functionality.
 -   Simple (implementation). We have a strong focus on correctness, speed and flexibility, but
     not simplicity. If you prefer a small-and-simple library, there are
@@ -53,29 +53,12 @@ Documentation:
 -   [API reference (docs.rs)](https://docs.rs/rand)
 
 
-## Usage
-
-Add this to your `Cargo.toml`:
-```toml
-[dependencies]
-rand = "0.8.5"
-```
-
-Or, to try the 0.9.0 beta release:
-```toml
-[dependencies]
-rand = "=0.9.0-beta.3"
-```
-
-To get started using Rand, see [The Book](https://rust-random.github.io/book).
-
 ## Versions
 
 Rand is *mature* (suitable for general usage, with infrequent breaking releases
 which minimise breakage) but not yet at 1.0. Current versions are:
 
--   Version 0.8 was released in December 2020 with many small changes.
--   Version 0.9 is in development with many small changes.
+-   Version 0.9 was released in January 2025.
 
 See the [CHANGELOG](CHANGELOG.md) or [Upgrade Guide](https://rust-random.github.io/book/update.html) for more details.
 

--- a/distr_test/Cargo.toml
+++ b/distr_test/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dev-dependencies]
-rand_distr = { path = "../rand_distr", version = "=0.5.0-beta.3", default-features = false, features = ["alloc"] }
-rand = { path = "..", version = "=0.9.0-beta.3", features = ["small_rng"] }
+rand_distr = { path = "../rand_distr", version = "0.5.0", default-features = false, features = ["alloc"] }
+rand = { path = "..", version = "0.9.0", features = ["small_rng"] }
 num-traits = "0.2.19"
 # Special functions for testing distributions
 special = "0.11.0"

--- a/rand_chacha/CHANGELOG.md
+++ b/rand_chacha/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0] - 2025-01-27
 ### Dependencies and features
-- Update to `rand_core` v0.9.0 (#1554)
+- Update to `rand_core` v0.9.0 (#1558)
 - Feature `std` now implies feature `rand_core/std` (#1153)
 - Rename feature `serde1` to `serde` (#1477)
 - Rename feature `getrandom` to `os_rng` (#1537)

--- a/rand_chacha/CHANGELOG.md
+++ b/rand_chacha/CHANGELOG.md
@@ -4,17 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.0-beta.1] - 2024-11-30
-- Bump `rand_core` version
-
-## [0.9.0-beta.0] - 2024-11-25
-This is a pre-release. To depend on this version, use `rand_chacha = "=0.9.0-beta.0"` to prevent automatic updates (which can be expected to include breaking changes).
-
-- Made `rand_chacha` propagate the `std` feature down to `rand_core` (#1153)
-- Remove usage of `unsafe` in `fn generate` (#1181) then optimise for AVX2 (~4-7%) (#1192)
-- The `serde1` feature has been renamed `serde` (#1477)
-- Revise crate docs (#1454)
+## [0.9.0] - 2025-01-27
+### Dependencies and features
+- Update to `rand_core` v0.9.0 (#1554)
+- Feature `std` now implies feature `rand_core/std` (#1153)
+- Rename feature `serde1` to `serde` (#1477)
 - Rename feature `getrandom` to `os_rng` (#1537)
+
+### Other changes
+- Remove usage of `unsafe` in `fn generate` (#1181) then optimise for AVX2 (~4-7%) (#1192)
+- Revise crate docs (#1454)
 
 ## [0.3.1] - 2021-06-09
 - add getters corresponding to existing setters: `get_seed`, `get_stream` (#1124)

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_chacha"
-version = "0.9.0-beta.1"
+version = "0.9.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers", "The CryptoCorrosion Contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -20,14 +20,14 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition"]
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "=0.9.0-beta.1" }
+rand_core = { path = "../rand_core", version = "0.9.0" }
 ppv-lite86 = { version = "0.2.14", default-features = false, features = ["simd"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 # Only to test serde
 serde_json = "1.0"
-rand_core = { path = "../rand_core", version = "=0.9.0-beta.1", features = ["os_rng"] }
+rand_core = { path = "../rand_core", version = "0.9.0", features = ["os_rng"] }
 
 [features]
 default = ["std"]

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,24 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.0-beta.1] - 2024-11-30
-- Update to `getrandom` v0.3.0-rc.0
-
-## [0.9.0-beta.0] - 2024-11-25
-This is a pre-release. To depend on this version, use `rand_core = "=0.9.0-beta.0"` to prevent automatic updates (which can be expected to include breaking changes).
-
-### Compilation options and unsafe
+## [0.9.0] - 2025-01-27
+### Dependencies and features
 - Bump the MSRV to 1.63.0 (#1207, #1246, #1269, #1341, #1416, #1536); note that 1.60.0 may work for dependents when using `--ignore-rust-version`
-- The `serde1` feature has been renamed `serde` (#1477)
+- Update to `getrandom` v0.3.0 (#1554)
 - Use `zerocopy` to replace some `unsafe` code (#1349, #1393, #1446, #1502)
+- Rename feature `serde1` to `serde` (#1477)
+- Rename feature `getrandom` to `os_rng` (#1537)
 
-### Other
+### API changes
 - Allow `rand_core::impls::fill_via_u*_chunks` to mutate source (#1182)
 - Add fn `RngCore::read_adapter` implementing `std::io::Read` (#1267)
 - Add trait `CryptoBlockRng: BlockRngCore`; make `trait CryptoRng: RngCore` (#1273)
 - Add traits `TryRngCore`, `TryCryptoRng` (#1424, #1499)
 - Add bounds `Clone` and `AsRef` to associated type `SeedableRng::Seed` (#1491)
-- Rename feature `getrandom` to `os_rng` (#1537)
 
 ## [0.6.4] - 2022-09-15
 - Fix unsoundness in `<BlockRng64 as RngCore>::next_u32` (#1160)

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.0] - 2025-01-27
 ### Dependencies and features
 - Bump the MSRV to 1.63.0 (#1207, #1246, #1269, #1341, #1416, #1536); note that 1.60.0 may work for dependents when using `--ignore-rust-version`
-- Update to `getrandom` v0.3.0 (#1554)
+- Update to `getrandom` v0.3.0 (#1558)
 - Use `zerocopy` to replace some `unsafe` code (#1349, #1393, #1446, #1502)
 - Rename feature `serde1` to `serde` (#1477)
 - Rename feature `getrandom` to `os_rng` (#1537)

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add fn `RngCore::read_adapter` implementing `std::io::Read` (#1267)
 - Add trait `CryptoBlockRng: BlockRngCore`; make `trait CryptoRng: RngCore` (#1273)
 - Add traits `TryRngCore`, `TryCryptoRng` (#1424, #1499)
+- Rename `fn SeedableRng::from_rng` -> `try_from_rng` and add infallible variant `fn from_rng` (#1424)
+- Rename `fn SeedableRng::from_entropy` -> `from_os_rng` and add fallible variant `fn try_from_os_rng` (#1424)
 - Add bounds `Clone` and `AsRef` to associated type `SeedableRng::Seed` (#1491)
 
 ## [0.6.4] - 2022-09-15

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -31,5 +31,5 @@ serde = ["dep:serde"] # enables serde for BlockRng wrapper
 
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }
-getrandom = { version = "0.3.0-rc.0", optional = true }
+getrandom = { version = "0.3.0", optional = true }
 zerocopy = { version = "0.8.0", default-features = false }

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.9.0-beta.1"
+version = "0.9.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -205,19 +205,18 @@ pub trait CryptoRng: RngCore {}
 
 impl<T: DerefMut> CryptoRng for T where T::Target: CryptoRng {}
 
-/// A potentially fallible version of [`RngCore`].
+/// A potentially fallible variant of [`RngCore`]
 ///
-/// This trait is primarily used for IO-based generators such as [`OsRng`].
+/// This trait is a generalization of [`RngCore`] to support potentially-
+/// fallible IO-based generators such as [`OsRng`].
 ///
-/// Most of higher-level generic code in the `rand` crate is built on top
-/// of the the [`RngCore`] trait. Users can transform a fallible RNG
-/// (i.e. [`TryRngCore`] implementor) into an "infallible" (but potentially
-/// panicking) RNG (i.e. [`RngCore`] implementor) using the [`UnwrapErr`] wrapper.
+/// All implementations of [`RngCore`] automatically support this `TryRngCore`
+/// trait, using [`Infallible`][core::convert::Infallible] as the associated
+/// `Error` type.
 ///
-/// [`RngCore`] implementors also usually implement [`TryRngCore`] with the `Error`
-/// associated type being equal to [`Infallible`][core::convert::Infallible].
-/// In other words, users can use [`TryRngCore`] to generalize over fallible and
-/// infallible RNGs.
+/// An implementation of this trait may be made compatible with code requiring
+/// an [`RngCore`] through [`TryRngCore::unwrap_err`]. The resulting RNG will
+/// panic in case the underlying fallible RNG yields an error.
 pub trait TryRngCore {
     /// The type returned in the event of a RNG error.
     type Error: fmt::Debug + fmt::Display;

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -4,28 +4,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0-beta.3] - 2025-01-03
-- Bump `rand` version (#1547)
+## [0.5.0] - 2025-01-27
+
+### Dependencies and features
+- Bump the MSRV to 1.61.0 (#1207, #1246, #1269, #1341, #1416); note that 1.60.0 may work for dependents when using `--ignore-rust-version`
+- Update to `rand` v0.9.0 (#1554)
+- Rename feature `serde1` to `serde` (#1477)
+
+### API changes
+- Make distributions comparable with `PartialEq` (#1218)
+- `Dirichlet` now uses `const` generics, which means that its size is required at compile time (#1292)
+- The `Dirichlet::new_with_size` constructor was removed (#1292)
+- Add `WeightedIndexTree` (#1372, #1444)
+- Add `PertBuilder` to allow specification of `mean` or `mode` (#1452)
+- Rename `Zeta`'s parameter `a` to `s` (#1466)
+- Mark `WeightError`, `PoissonError`, `BinomialError` as `#[non_exhaustive]` (#1480)
+- Remove support for usage of `isize` as a `WeightedAliasIndex` weight (#1487)
+- Change parameter type of `Zipf::new`: `n` is now floating-point (#1518)
+
+### API changes: renames
 - Move `Slice` -> `slice::Choose`, `EmptySlice` -> `slice::Empty` (#1548)
 - Rename trait `DistString` -> `SampleString` (#1548)
 - Rename `DistIter` -> `Iter`, `DistMap` -> `Map` (#1548)
 - Move `{Weight, WeightError, WeightedIndex}` -> `weighted::{Weight, Error, WeightedIndex}` (#1548)
 - Move `weighted_alias::{AliasableWeight, WeightedAliasIndex}` -> `weighted::{..}` (#1548)
 - Move `weighted_tree::WeightedTreeIndex` -> `weighted::WeightedTreeIndex` (#1548)
-
-## [0.5.0-beta.2] - 2024-11-30
-- Bump `rand` version
-
-## [0.5.0-beta.1] - 2024-11-27
-- Fix docs.rs build (#1539)
-
-## [0.5.0-beta.0] - 2024-11-25
-This is a pre-release. To depend on this version, use `rand = "=0.9.0-beta.0"` to prevent automatic updates (which can be expected to include breaking changes).
-
-### Compilation options
-- Target `rand` version `0.9.0-beta.0`
-- Bump the MSRV to 1.61.0 (#1207, #1246, #1269, #1341, #1416); note that 1.60.0 may work for dependents when using `--ignore-rust-version`
-- The `serde1` feature has been renamed `serde` (#1477)
 
 ### Testing
 - Add Kolmogorov Smirnov tests for distributions (#1494, #1504, #1525, #1530)
@@ -35,31 +38,16 @@ This is a pre-release. To depend on this version, use `rand = "=0.9.0-beta.0"` t
 - Fix `Poisson` distribution instantiation so it return an error if lambda is infinite (#1291)
 - Fix Dirichlet sample for small alpha values to avoid NaN samples (#1209)
 - Fix infinite loop in `Binomial` distribution (#1325)
+- Fix `Pert` distribution where `mode` is close to `(min + max) / 2` (#1452)
 - Fix panic in Binomial (#1484)
 - Limit the maximal acceptable lambda for `Poisson` to solve (#1312) (#1498)
 - Fix bug in `Hypergeometric`, this is a Value-breaking change (#1510)
 
-### Additions
-- Make distributions comparable with `PartialEq` (#1218)
-- Add `WeightedIndexTree` (#1372, #1444)
-
-### Changes
 ### Other changes
 - Remove unused fields from `Gamma`, `NormalInverseGaussian` and `Zipf` distributions (#1184)
   This breaks serialization compatibility with older versions.
-- `Dirichlet` now uses `const` generics, which means that its size is required at compile time (#1292)
-- The `Dirichlet::new_with_size` constructor was removed (#1292)
-- Add `PertBuilder`, fix case where mode ≅ mean (#1452)
-- Rename `Zeta`'s parameter `a` to `s` (#1466)
-- Mark `WeightError`, `PoissonError`, `BinomialError` as `#[non_exhaustive]` (#1480)
-- Remove support for usage of `isize` as a `WeightedAliasIndex` weight (#1487)
-- Change parameter type of `Zipf::new`: `n` is now floating-point (#1518)
-
-### Optimizations
-- Move some of the computations in Binomial from `sample` to `new` (#1484)
-
-### Documentation
 - Add plots for `rand_distr` distributions to documentation (#1434)
+- Move some of the computations in Binomial from `sample` to `new` (#1484)
 
 ## [0.4.3] - 2021-12-30
 - Fix `no_std` build (#1208)

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies and features
 - Bump the MSRV to 1.61.0 (#1207, #1246, #1269, #1341, #1416); note that 1.60.0 may work for dependents when using `--ignore-rust-version`
-- Update to `rand` v0.9.0 (#1554)
+- Update to `rand` v0.9.0 (#1558)
 - Rename feature `serde1` to `serde` (#1477)
 
 ### API changes

--- a/rand_distr/Cargo.toml
+++ b/rand_distr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_distr"
-version = "0.5.0-beta.3"
+version = "0.5.0"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -33,15 +33,15 @@ std_math = ["num-traits/std"]
 serde = ["dep:serde", "dep:serde_with", "rand/serde"]
 
 [dependencies]
-rand = { path = "..", version = "=0.9.0-beta.3", default-features = false }
+rand = { path = "..", version = "0.9.0", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 serde_with = { version = ">= 3.0, <= 3.11", optional = true }
 
 [dev-dependencies]
-rand_pcg = { version = "=0.9.0-beta.1", path = "../rand_pcg" }
+rand_pcg = { version = "0.9.0", path = "../rand_pcg" }
 # For inline examples
-rand = { path = "..", version = "=0.9.0-beta.3", features = ["small_rng"] }
+rand = { path = "..", version = "0.9.0", features = ["small_rng"] }
 # Histogram implementation for testing uniformity
 average = { version = "0.15", features = [ "std" ] }
 # Special functions for testing distributions

--- a/rand_pcg/CHANGELOG.md
+++ b/rand_pcg/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0] - 2025-01-27
 ### Dependencies and features
-- Update to `rand_core` v0.9.0 (#1554)
+- Update to `rand_core` v0.9.0 (#1558)
 - Rename feature `serde1` to `serde` (#1477)
 - Rename feature `getrandom` to `os_rng` (#1537)
 

--- a/rand_pcg/CHANGELOG.md
+++ b/rand_pcg/CHANGELOG.md
@@ -4,17 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.0-beta.1] - 2024-11-30
-- Bump `rand_core` version
-
-## [0.9.0-beta.0] - 2024-11-25
-This is a pre-release. To depend on this version, use `rand_chacha = "=0.9.0-beta.0"` to prevent automatic updates (which can be expected to include breaking changes).
-
-- The `serde1` feature has been renamed `serde` (#1477)
-- Add `Lcg128CmDxsm64` generator compatible with NumPy's `PCG64DXSM` (#1202)
-- Add examples for initializing the RNGs
-- Revise crate docs (#1454)
+## [0.9.0] - 2025-01-27
+### Dependencies and features
+- Update to `rand_core` v0.9.0 (#1554)
+- Rename feature `serde1` to `serde` (#1477)
 - Rename feature `getrandom` to `os_rng` (#1537)
+
+### Other changes
+- Add `Lcg128CmDxsm64` generator compatible with NumPy's `PCG64DXSM` (#1202)
+- Add examples for initializing the RNGs (#1352)
+- Revise crate docs (#1454)
 
 ## [0.3.1] - 2021-06-15
 - Add `advance` methods to RNGs (#1111)

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_pcg"
-version = "0.9.0-beta.1"
+version = "0.9.0"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -24,7 +24,7 @@ serde = ["dep:serde"]
 os_rng = ["rand_core/os_rng"]
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "=0.9.0-beta.1" }
+rand_core = { path = "../rand_core", version = "0.9.0" }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
@@ -32,4 +32,4 @@ serde = { version = "1", features = ["derive"], optional = true }
 # deps yet, see: https://github.com/rust-lang/cargo/issues/1596
 # Versions prior to 1.1.4 had incorrect minimal dependencies.
 bincode = { version = "1.1.4" }
-rand_core = { path = "../rand_core", version = "=0.9.0-beta.1", features = ["os_rng"] }
+rand_core = { path = "../rand_core", version = "0.9.0", features = ["os_rng"] }


### PR DESCRIPTION
# Summary

Prepare the 0.9.0 release (see #1165).

# Details

`getrandom` v0.3 is now published.

CHANGELOGs have been revised slightly, making clear which parts are API-breaking or reproducibility-breaking (with the former implying the latter).

# Related to-dos:

- [x] Update the book (version updates + update guide)
- [ ] Update rngs
- [x] Update rand-seeder
- [ ] Publish (provisionally tomorrow)