### PR TITLE
Replaces the Poisson rejection method implementation

### DIFF
--- a/distr_test/tests/cdf.rs
+++ b/distr_test/tests/cdf.rs
@@ -427,8 +427,7 @@ fn hypergeometric() {
 fn poisson() {
     use rand_distr::Poisson;
     let parameters = [
-        0.1, 1.0, 7.5, 15.0, 45.0, 75.0,
-        100.0,
+        0.1, 1.0, 7.5, 15.0, 45.0, 98.0, 230.0, 4567.5, 4.4541e7
         // 1e10, //passed case but too slow
         // 1.844E+19,  // fail case
     ];

--- a/distr_test/tests/cdf.rs
+++ b/distr_test/tests/cdf.rs
@@ -427,9 +427,10 @@ fn hypergeometric() {
 fn poisson() {
     use rand_distr::Poisson;
     let parameters = [
-        0.1, 1.0, 7.5,
-        45.0, // 1e9, passed case but too slow
-             // 1.844E+19,  // fail case
+        0.1, 1.0, 7.5, 15.0, 45.0, 75.0,
+        100.0,
+        // 1e10, //passed case but too slow
+        // 1.844E+19,  // fail case
     ];
 
     for (seed, lambda) in parameters.into_iter().enumerate() {

--- a/distr_test/tests/cdf.rs
+++ b/distr_test/tests/cdf.rs
@@ -427,9 +427,9 @@ fn hypergeometric() {
 fn poisson() {
     use rand_distr::Poisson;
     let parameters = [
-        0.1, 1.0, 7.5, 15.0, 45.0, 98.0, 230.0, 4567.5, 4.4541e7
-        // 1e10, //passed case but too slow
-        // 1.844E+19,  // fail case
+        0.1, 1.0, 7.5, 15.0, 45.0, 98.0, 230.0, 4567.5,
+        4.4541e7, // 1e10, //passed case but too slow
+                 // 1.844E+19,  // fail case
     ];
 
     for (seed, lambda) in parameters.into_iter().enumerate() {

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This breaks serialization compatibility with older versions.
 - Add plots for `rand_distr` distributions to documentation (#1434)
 - Move some of the computations in Binomial from `sample` to `new` (#1484)
-- Reimplement `Poisson`'s rejection method to improve performance (#1560)
+- Reimplement `Poisson`'s rejection method to improve performance and correct sampling inaccuracies for large lambda values, this is a Value-breaking change (#1560)
 
 ## [0.4.3] - 2021-12-30
 - Fix `no_std` build (#1208)

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix panic in Binomial (#1484)
 - Limit the maximal acceptable lambda for `Poisson` to solve (#1312) (#1498)
 - Fix bug in `Hypergeometric`, this is a Value-breaking change (#1510)
+- Reimplement `Poisson`'s rejection method to improve performance (#1560)
 
 ### Other changes
 - Remove unused fields from `Gamma`, `NormalInverseGaussian` and `Zipf` distributions (#1184)

--- a/rand_distr/CHANGELOG.md
+++ b/rand_distr/CHANGELOG.md
@@ -42,13 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix panic in Binomial (#1484)
 - Limit the maximal acceptable lambda for `Poisson` to solve (#1312) (#1498)
 - Fix bug in `Hypergeometric`, this is a Value-breaking change (#1510)
-- Reimplement `Poisson`'s rejection method to improve performance (#1560)
 
 ### Other changes
 - Remove unused fields from `Gamma`, `NormalInverseGaussian` and `Zipf` distributions (#1184)
   This breaks serialization compatibility with older versions.
 - Add plots for `rand_distr` distributions to documentation (#1434)
 - Move some of the computations in Binomial from `sample` to `new` (#1484)
+- Reimplement `Poisson`'s rejection method to improve performance (#1560)
 
 ## [0.4.3] - 2021-12-30
 - Fix `no_std` build (#1208)

--- a/rand_distr/src/poisson.rs
+++ b/rand_distr/src/poisson.rs
@@ -327,35 +327,6 @@ where
 mod test {
     use super::*;
 
-    fn test_poisson_avg_gen<F: Float + FloatConst>(lambda: F, tol: F)
-    where
-        StandardUniform: Distribution<F>,
-        StandardNormal: Distribution<F>,
-        Exp1: Distribution<F>,
-    {
-        let poisson = Poisson::new(lambda).unwrap();
-        let mut rng = crate::test::rng(123);
-        let mut sum = F::zero();
-        for _ in 0..1000 {
-            sum = sum + poisson.sample(&mut rng);
-        }
-        let avg = sum / F::from(1000.0).unwrap();
-        assert!((avg - lambda).abs() < tol);
-    }
-
-    #[test]
-    fn test_poisson_avg() {
-        test_poisson_avg_gen::<f64>(10.0, 0.1);
-        test_poisson_avg_gen::<f64>(15.0, 0.1);
-
-        test_poisson_avg_gen::<f32>(10.0, 0.1);
-        test_poisson_avg_gen::<f32>(15.0, 0.1);
-
-        // Small lambda will use Knuth's method with exp_lambda == 1.0
-        test_poisson_avg_gen::<f32>(0.00000000000000005, 0.1);
-        test_poisson_avg_gen::<f64>(0.00000000000000005, 0.1);
-    }
-
     #[test]
     #[should_panic]
     fn test_poisson_invalid_lambda_zero() {

--- a/rand_distr/src/poisson.rs
+++ b/rand_distr/src/poisson.rs
@@ -9,7 +9,7 @@
 
 //! The Poisson distribution `Poisson(λ)`.
 
-use crate::{Cauchy, Distribution, Exp1, Normal, StandardNormal, StandardUniform};
+use crate::{Distribution, Exp1, Normal, StandardNormal, StandardUniform};
 use core::fmt;
 use num_traits::{Float, FloatConst};
 use rand::Rng;
@@ -233,8 +233,7 @@ where
             ]; // coefficients from Table 1
             let (px, py) = if k < F::from(10.0).unwrap() {
                 let px = -self.lambda;
-                let py = self.lambda.powf(k)
-                    / F::from(FACT[k.to_usize().unwrap()]).unwrap();
+                let py = self.lambda.powf(k) / F::from(FACT[k.to_usize().unwrap()]).unwrap();
 
                 (px, py)
             } else {

--- a/rand_distr/src/utils.rs
+++ b/rand_distr/src/utils.rs
@@ -9,51 +9,8 @@
 //! Math helper functions
 
 use crate::ziggurat_tables;
-use num_traits::Float;
 use rand::distr::hidden_export::IntoFloat;
 use rand::Rng;
-
-/// Calculates ln(gamma(x)) (natural logarithm of the gamma
-/// function) using the Lanczos approximation.
-///
-/// The approximation expresses the gamma function as:
-/// `gamma(z+1) = sqrt(2*pi)*(z+g+0.5)^(z+0.5)*exp(-z-g-0.5)*Ag(z)`
-/// `g` is an arbitrary constant; we use the approximation with `g=5`.
-///
-/// Noting that `gamma(z+1) = z*gamma(z)` and applying `ln` to both sides:
-/// `ln(gamma(z)) = (z+0.5)*ln(z+g+0.5)-(z+g+0.5) + ln(sqrt(2*pi)*Ag(z)/z)`
-///
-/// `Ag(z)` is an infinite series with coefficients that can be calculated
-/// ahead of time - we use just the first 6 terms, which is good enough
-/// for most purposes.
-pub(crate) fn log_gamma<F: Float>(x: F) -> F {
-    // precalculated 6 coefficients for the first 6 terms of the series
-    let coefficients: [F; 6] = [
-        F::from(76.18009172947146).unwrap(),
-        F::from(-86.50532032941677).unwrap(),
-        F::from(24.01409824083091).unwrap(),
-        F::from(-1.231739572450155).unwrap(),
-        F::from(0.1208650973866179e-2).unwrap(),
-        F::from(-0.5395239384953e-5).unwrap(),
-    ];
-
-    // (x+0.5)*ln(x+g+0.5)-(x+g+0.5)
-    let tmp = x + F::from(5.5).unwrap();
-    let log = (x + F::from(0.5).unwrap()) * tmp.ln() - tmp;
-
-    // the first few terms of the series for Ag(x)
-    let mut a = F::from(1.000000000190015).unwrap();
-    let mut denom = x;
-    for &coeff in &coefficients {
-        denom = denom + F::one();
-        a = a + (coeff / denom);
-    }
-
-    // get everything together
-    // a is Ag(x)
-    // 2.5066... is sqrt(2pi)
-    log + (F::from(2.5066282746310005).unwrap() * a / x).ln()
-}
 
 /// Sample a random number using the Ziggurat method (specifically the
 /// ZIGNOR variant from Doornik 2005). Most of the arguments are

--- a/rand_distr/tests/value_stability.rs
+++ b/rand_distr/tests/value_stability.rs
@@ -207,7 +207,7 @@ fn poisson_stability() {
     test_samples(
         223,
         Poisson::new(27.0).unwrap(),
-        &[28.0f32, 32.0, 36.0, 36.0],
+        &[30.0f32, 33.0, 23.0, 25.0],
     );
 }
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

As discussed in #1515, this PR replaces the implementation of `poisson::RejectionMethod` with a new algorithm based on the [paper ](https://dl.acm.org/doi/10.1145/355993.355997).

# Motivation

The new implementation offers improved performance and maintains better sampling distribution, especially for extreme values of lambda (> 1e9).

# Details

In terms of performance, here are the benchmarks I ran, with the current implementation as the baseline:

```text
poisson/100             time:   [45.5242 cycles 45.6734 cycles 45.8337 cycles]
                        change: [-86.572% -86.507% -86.438%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
poisson/variable        time:   [5494.6626 cycles 5508.2882 cycles 5523.2298 cycles]
                        thrpt:  [5523.2298 cycles/100 5508.2882 cycles/100 5494.6626 cycles/100]
                 change:
                        time:   [-76.728% -76.573% -76.430%] (p = 0.00 < 0.05)
                        thrpt:  [+324.27% +326.85% +329.69%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
```