### PR TITLE
Consistent capitalization for deprecated function names in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub use crate::rngs::thread::rng;
 ///
 /// Use [`rand::rng()`](rng()) instead.
 #[cfg(feature = "thread_rng")]
-#[deprecated(since = "0.9.0", note = "renamed to `rng`")]
+#[deprecated(since = "0.9.0", note = "Renamed to `rng`")]
 #[inline]
 pub fn thread_rng() -> crate::rngs::ThreadRng {
     rng()


### PR DESCRIPTION
Since 0.9.0 deprecated a few functions, the documentation should use consistent capitalization for better user experience.

In rng.rs, `gen`, `gen_range`, `gen_bool` and `gen_ratio` use uppercase.