### PR TITLE
correct getrandom wasm feature name

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Seeding entropy from OS on WASM target `wasm32-unknown-unknown` is not
 seeding the generator manually, you can disable the `os_rng` feature
 and use the methods on the `SeedableRng` trait. To enable seeding from OS,
 either use a different target such as `wasm32-wasi` or add a direct
-dependency on [getrandom] with the `js` feature (if the target supports
+dependency on [getrandom] with the `wasm_js` feature (if the target supports
 JavaScript). See
 [getrandom#WebAssembly support](https://docs.rs/getrandom/latest/getrandom/#webassembly-support).
 


### PR DESCRIPTION
since getrandom `3.x` the feature is called `wasm_js`