### PR TITLE
Update rand_core version number in Readme

### DIFF
--- a/rand_core/README.md
+++ b/rand_core/README.md
@@ -41,8 +41,9 @@ The traits and error types are also available via `rand`.
 ## Versions
 
 The current version is:
-```
-rand_core = "=0.9.0-beta.1"
+
+```toml
+rand_core = "0.9.0"
 ```
 
 


### PR DESCRIPTION
# Summary

Update the rand_core version number in its Readme. Also made some minor formatting changes.

# Motivation

The version number was out of date.