### PR TITLE
Add trait ReproducibleRng

### DIFF
--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -306,12 +306,7 @@ impl<R: TryCryptoRng> CryptoRng for UnwrapErr<R> {}
 /// This trait encapsulates the low-level functionality common to all
 /// pseudo-random number generators (PRNGs, or algorithmic generators).
 ///
-/// Note that this trait does not imply
-/// [reproducibility](https://rust-random.github.io/book/crate-reprod.html)
-/// of results; this is an optional property which RNGs should mention in their
-/// documentation.
-///
-/// [`rand`]: https://docs.rs/rand
+/// This trait does not imply reproducibility; see [`ReproducibleRng`].
 pub trait SeedableRng: Sized {
     /// Seed type, which is restricted to types mutably-dereferenceable as `u8`
     /// arrays (we recommend `[u8; N]` for some `N`).
@@ -519,6 +514,13 @@ pub trait SeedableRng: Sized {
         Ok(res)
     }
 }
+
+/// A reproducible random number generator
+///
+/// This is a marker trait indicating that the implementation commits to
+/// [reproducibility](https://rust-random.github.io/book/crate-reprod.html)
+/// of results across platforms and at least patch versions.
+pub trait ReproducibleRng: SeedableRng {}
 
 /// Adapter that enables reading through a [`io::Read`](std::io::Read) from a [`RngCore`].
 ///

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -306,6 +306,11 @@ impl<R: TryCryptoRng> CryptoRng for UnwrapErr<R> {}
 /// This trait encapsulates the low-level functionality common to all
 /// pseudo-random number generators (PRNGs, or algorithmic generators).
 ///
+/// Note that this trait does not imply
+/// [reproducibility](https://rust-random.github.io/book/crate-reprod.html)
+/// of results; this is an optional property which RNGs should mention in their
+/// documentation.
+///
 /// [`rand`]: https://docs.rs/rand
 pub trait SeedableRng: Sized {
     /// Seed type, which is restricted to types mutably-dereferenceable as `u8`


### PR DESCRIPTION
# Summary

```rust
pub trait ReproducibleRng: SeedableRng {}
```

# Motivation

Clarify that `SeedableRng` does not imply reproducibility and what RNGs do have this property.

# Details

I'm somewhat loathe to do this since in part, reproducibility is a special property that `StdRng` and `SmallRng` opt out of. On the other hand, this is a property not implied by the API or the semver model.

So does this form of formal documentation make sense?

Obviously this PR is incomplete: the ChaCha and Pcg RNGs in this repo should implement the trait, and also `StepRng` and most of the `rngs` repo.