### PR TITLE
Implement `fill_via_chunks` without using zerocopy or `unsafe`.

### DIFF
--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -32,4 +32,3 @@ serde = ["dep:serde"] # enables serde for BlockRng wrapper
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }
 getrandom = { version = "0.3.0", optional = true }
-zerocopy = { version = "0.8.0", default-features = false }


### PR DESCRIPTION
- [ ] Added a `CHANGELOG.md` entry

# Summary

Reduce use of `zerocopy`.

# Motivation

Make progress towards reducing the set of dependencies.

# Details
