### PR TITLE
Update WASM JS feature flag name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Seeding entropy from OS on WASM target `wasm32-unknown-unknown` is not
 seeding the generator manually, you can disable the `os_rng` feature
 and use the methods on the `SeedableRng` trait. To enable seeding from OS,
 either use a different target such as `wasm32-wasi` or add a direct
-dependency on [getrandom] with the `js` feature (if the target supports
+dependency on [getrandom] with the `wasm_js` feature (if the target supports
 JavaScript). See
 [getrandom#WebAssembly support](https://docs.rs/getrandom/latest/getrandom/#webassembly-support).
 


### PR DESCRIPTION
- [ ] Added a `CHANGELOG.md` entry

Not sure if this requires one, but happy to add one if requested!

# Summary

The feature flag name was changed from `js` to `wasm_js` in a recent release of `getrandom`.