### PR TITLE
Remove zerocopy from rand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
 ## [Unreleased]
+- Remove `zerocopy` dependency (#1579)
 - Fix feature `simd_support` for recent nightly rust (#1586)
 - Add `Alphabetic` distribution. (#1587)
 - Re-export `rand_core` (#1602)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ alloc = []
 os_rng = ["rand_core/os_rng"]
 
 # Option (requires nightly Rust): experimental SIMD support
-simd_support = ["zerocopy/simd-nightly"]
+simd_support = []
 
 # Option (enabled by default): enable StdRng
 std_rng = ["dep:rand_chacha"]
@@ -75,7 +75,6 @@ rand_core = { path = "rand_core", version = "0.9.0", default-features = false }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 rand_chacha = { path = "rand_chacha", version = "0.9.0", default-features = false, optional = true }
-zerocopy = { version = "0.8.0", default-features = false, features = ["simd"] }
 
 [dev-dependencies]
 rand_pcg = { path = "rand_pcg", version = "0.9.0" }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 # Option (requires nightly Rust): experimental SIMD support
 simd_support = ["rand/simd_support"]
 
-
 [dependencies]
 
 [dev-dependencies]
@@ -36,6 +35,10 @@ harness = false
 
 [[bench]]
 name = "shuffle"
+harness = false
+
+[[bench]]
+name = "simd"
 harness = false
 
 [[bench]]

--- a/benches/benches/simd.rs
+++ b/benches/benches/simd.rs
@@ -1,0 +1,76 @@
+// Copyright 2018-2023 Developers of the Rand project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Generating SIMD / wide types
+
+#![cfg_attr(feature = "simd_support", feature(portable_simd))]
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = simd
+);
+criterion_main!(benches);
+
+#[cfg(not(feature = "simd_support"))]
+pub fn simd(_: &mut Criterion) {}
+
+#[cfg(feature = "simd_support")]
+pub fn simd(c: &mut Criterion) {
+    use rand::prelude::*;
+    use rand_pcg::Pcg64Mcg;
+
+    let mut g = c.benchmark_group("random_simd");
+
+    g.bench_function("u128", |b| {
+        let mut rng = Pcg64Mcg::from_rng(&mut rand::rng());
+        b.iter(|| rng.random::<u128>());
+    });
+
+    g.bench_function("m128i", |b| {
+        let mut rng = Pcg64Mcg::from_rng(&mut rand::rng());
+        b.iter(|| rng.random::<core::arch::x86_64::__m128i>());
+    });
+
+    g.bench_function("m256i", |b| {
+        let mut rng = Pcg64Mcg::from_rng(&mut rand::rng());
+        b.iter(|| rng.random::<core::arch::x86_64::__m256i>());
+    });
+
+    g.bench_function("m512i", |b| {
+        let mut rng = Pcg64Mcg::from_rng(&mut rand::rng());
+        b.iter(|| rng.random::<core::arch::x86_64::__m512i>());
+    });
+
+    g.bench_function("u64x2", |b| {
+        let mut rng = Pcg64Mcg::from_rng(&mut rand::rng());
+        b.iter(|| rng.random::<core::simd::u64x2>());
+    });
+
+    g.bench_function("u32x4", |b| {
+        let mut rng = Pcg64Mcg::from_rng(&mut rand::rng());
+        b.iter(|| rng.random::<core::simd::u64x4>());
+    });
+
+    g.bench_function("u32x8", |b| {
+        let mut rng = Pcg64Mcg::from_rng(&mut rand::rng());
+        b.iter(|| rng.random::<core::simd::u8x32>());
+    });
+
+    g.bench_function("u16x8", |b| {
+        let mut rng = Pcg64Mcg::from_rng(&mut rand::rng());
+        b.iter(|| rng.random::<core::simd::u8x32>());
+    });
+
+    g.bench_function("u8x16", |b| {
+        let mut rng = Pcg64Mcg::from_rng(&mut rand::rng());
+        b.iter(|| rng.random::<core::simd::u8x32>());
+    });
+}

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -31,6 +31,7 @@
 )]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
+#![deny(clippy::undocumented_unsafe_blocks)]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]

--- a/src/distr/integer.rs
+++ b/src/distr/integer.rs
@@ -107,21 +107,50 @@ impl_nzint!(NonZeroI64, NonZeroI64::new);
 impl_nzint!(NonZeroI128, NonZeroI128::new);
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-macro_rules! x86_intrinsic_impl {
-    ($meta:meta, $($intrinsic:ident),+) => {$(
-        #[cfg($meta)]
-        impl Distribution<$intrinsic> for StandardUniform {
-            #[inline]
-            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $intrinsic {
-                // On proper hardware, this should compile to SIMD instructions
-                // Verified on x86 Haswell with __m128i, __m256i
-                let mut buf = [0_u8; core::mem::size_of::<$intrinsic>()];
-                rng.fill_bytes(&mut buf);
-                // x86 is little endian so no need for conversion
-                zerocopy::transmute!(buf)
-            }
-        }
-    )+};
+impl Distribution<__m128i> for StandardUniform {
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> __m128i {
+        // NOTE: It's tempting to use the u128 impl here, but confusingly this
+        // results in different code (return via rdx, r10 instead of rax, rdx
+        // with u128 impl) and is much slower (+130 time). This version calls
+        // impls::fill_bytes_via_next but performs well.
+
+        let mut buf = [0_u8; core::mem::size_of::<__m128i>()];
+        rng.fill_bytes(&mut buf);
+        // x86 is little endian so no need for conversion
+
+        // SAFETY: both source and result types are valid for all values.
+        unsafe { core::mem::transmute(buf) }
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+impl Distribution<__m256i> for StandardUniform {
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> __m256i {
+        let mut buf = [0_u8; core::mem::size_of::<__m256i>()];
+        rng.fill_bytes(&mut buf);
+        // x86 is little endian so no need for conversion
+
+        // SAFETY: both source and result types are valid for all values.
+        unsafe { core::mem::transmute(buf) }
+    }
+}
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    feature = "simd_support"
+))]
+impl Distribution<__m512i> for StandardUniform {
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> __m512i {
+        let mut buf = [0_u8; core::mem::size_of::<__m512i>()];
+        rng.fill_bytes(&mut buf);
+        // x86 is little endian so no need for conversion
+
+        // SAFETY: both source and result types are valid for all values.
+        unsafe { core::mem::transmute(buf) }
+    }
 }
 
 #[cfg(feature = "simd_support")]
@@ -147,24 +176,6 @@ macro_rules! simd_impl {
 
 #[cfg(feature = "simd_support")]
 simd_impl!(u8, i8, u16, i16, u32, i32, u64, i64);
-
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-x86_intrinsic_impl!(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    __m128i,
-    __m256i
-);
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    feature = "simd_support"
-))]
-x86_intrinsic_impl!(
-    all(
-        any(target_arch = "x86", target_arch = "x86_64"),
-        feature = "simd_support"
-    ),
-    __m512i
-);
 
 #[cfg(test)]
 mod tests {

--- a/src/distr/integer.rs
+++ b/src/distr/integer.rs
@@ -119,7 +119,7 @@ impl Distribution<__m128i> for StandardUniform {
         rng.fill_bytes(&mut buf);
         // x86 is little endian so no need for conversion
 
-        // SAFETY: All representations of the source are also representations of the target.
+        // SAFETY: All byte sequences of `buf` represent values of the output type.
         unsafe { core::mem::transmute(buf) }
     }
 }
@@ -132,7 +132,7 @@ impl Distribution<__m256i> for StandardUniform {
         rng.fill_bytes(&mut buf);
         // x86 is little endian so no need for conversion
 
-        // SAFETY: All representations of the source are also representations of the target.
+        // SAFETY: All byte sequences of `buf` represent values of the output type.
         unsafe { core::mem::transmute(buf) }
     }
 }
@@ -148,7 +148,7 @@ impl Distribution<__m512i> for StandardUniform {
         rng.fill_bytes(&mut buf);
         // x86 is little endian so no need for conversion
 
-        // SAFETY: All representations of the source are also representations of the target.
+        // SAFETY: All byte sequences of `buf` represent values of the output type.
         unsafe { core::mem::transmute(buf) }
     }
 }

--- a/src/distr/integer.rs
+++ b/src/distr/integer.rs
@@ -119,7 +119,7 @@ impl Distribution<__m128i> for StandardUniform {
         rng.fill_bytes(&mut buf);
         // x86 is little endian so no need for conversion
 
-        // SAFETY: both source and result types are valid for all values.
+        // SAFETY: All representations of the source are also representations of the target.
         unsafe { core::mem::transmute(buf) }
     }
 }
@@ -132,7 +132,7 @@ impl Distribution<__m256i> for StandardUniform {
         rng.fill_bytes(&mut buf);
         // x86 is little endian so no need for conversion
 
-        // SAFETY: both source and result types are valid for all values.
+        // SAFETY: All representations of the source are also representations of the target.
         unsafe { core::mem::transmute(buf) }
     }
 }
@@ -148,7 +148,7 @@ impl Distribution<__m512i> for StandardUniform {
         rng.fill_bytes(&mut buf);
         // x86 is little endian so no need for conversion
 
-        // SAFETY: both source and result types are valid for all values.
+        // SAFETY: All representations of the source are also representations of the target.
         unsafe { core::mem::transmute(buf) }
     }
 }

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -170,7 +170,11 @@ impl SampleString for Alphanumeric {
         // SAFETY: `self` only samples alphanumeric characters, which are valid UTF-8.
         unsafe {
             let v = string.as_mut_vec();
-            v.extend(self.sample_iter(rng).take(len));
+            v.extend(
+                self.sample_iter(rng)
+                    .take(len)
+                    .inspect(|b| debug_assert!(b.is_ascii_alphanumeric())),
+            );
         }
     }
 }

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -118,6 +118,7 @@ impl Distribution<char> for StandardUniform {
         if n <= 0xDFFF {
             n -= GAP_SIZE;
         }
+        // SAFETY: The representation of `n` is a valid representation of `u32`.
         unsafe { char::from_u32_unchecked(n) }
     }
 }
@@ -166,6 +167,7 @@ impl Distribution<u8> for Alphabetic {
 #[cfg(feature = "alloc")]
 impl SampleString for Alphanumeric {
     fn append_string<R: Rng + ?Sized>(&self, rng: &mut R, string: &mut String, len: usize) {
+        // SAFETY: `self` only samples alphanumeric characters, which are valid UTF-8.
         unsafe {
             let v = string.as_mut_vec();
             v.extend(self.sample_iter(rng).take(len));

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -118,7 +118,7 @@ impl Distribution<char> for StandardUniform {
         if n <= 0xDFFF {
             n -= GAP_SIZE;
         }
-        // SAFETY: The representation of `n` is a valid representation of `u32`.
+        // SAFETY: We ensure above that `n` represents a `char`.
         unsafe { char::from_u32_unchecked(n) }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@
     clippy::neg_cmp_op_on_partial_ord,
     clippy::nonminimal_bool
 )]
+#![deny(clippy::undocumented_unsafe_blocks)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -397,7 +397,6 @@ macro_rules! impl_fill {
     () => {};
     ($t:ty) => {
         impl Fill for [$t] {
-            #[inline(never)] // in micro benchmarks, this improves performance
             fn fill<R: Rng + ?Sized>(&mut self, rng: &mut R) {
                 if self.len() > 0 {
                     rng.fill_bytes(self.as_mut_bytes());
@@ -409,7 +408,6 @@ macro_rules! impl_fill {
         }
 
         impl Fill for [Wrapping<$t>] {
-            #[inline(never)]
             fn fill<R: Rng + ?Sized>(&mut self, rng: &mut R) {
                 if self.len() > 0 {
                     rng.fill_bytes(self.as_mut_bytes());

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -12,8 +12,8 @@
 use crate::distr::uniform::{SampleRange, SampleUniform};
 use crate::distr::{self, Distribution, StandardUniform};
 use core::num::Wrapping;
+use core::{mem, slice};
 use rand_core::RngCore;
-use zerocopy::IntoBytes;
 
 /// User-level interface for RNGs
 ///
@@ -393,13 +393,20 @@ impl Fill for [u8] {
     }
 }
 
-macro_rules! impl_fill {
+// This macro is unsafe to call: target types must support transmute from
+// random bits (i.e. all bit representations are valid).
+macro_rules! unsafe_impl_fill {
     () => {};
     ($t:ty) => {
         impl Fill for [$t] {
             fn fill<R: Rng + ?Sized>(&mut self, rng: &mut R) {
                 if self.len() > 0 {
-                    rng.fill_bytes(self.as_mut_bytes());
+                    rng.fill_bytes(unsafe {
+                        slice::from_raw_parts_mut(self.as_mut_ptr()
+                            as *mut u8,
+                            mem::size_of_val(self)
+                        )
+                    });
                     for x in self {
                         *x = x.to_le();
                     }
@@ -410,24 +417,29 @@ macro_rules! impl_fill {
         impl Fill for [Wrapping<$t>] {
             fn fill<R: Rng + ?Sized>(&mut self, rng: &mut R) {
                 if self.len() > 0 {
-                    rng.fill_bytes(self.as_mut_bytes());
+                    rng.fill_bytes(unsafe {
+                        slice::from_raw_parts_mut(self.as_mut_ptr()
+                            as *mut u8,
+                            self.len() * mem::size_of::<$t>()
+                        )
+                    });
                     for x in self {
-                    *x = Wrapping(x.0.to_le());
+                        *x = Wrapping(x.0.to_le());
                     }
                 }
             }
         }
     };
     ($t:ty, $($tt:ty,)*) => {
-        impl_fill!($t);
+        unsafe_impl_fill!($t);
         // TODO: this could replace above impl once Rust #32463 is fixed
-        // impl_fill!(Wrapping<$t>);
-        impl_fill!($($tt,)*);
+        // unsafe_impl_fill!(Wrapping<$t>);
+        unsafe_impl_fill!($($tt,)*);
     }
 }
 
-impl_fill!(u16, u32, u64, u128,);
-impl_fill!(i8, i16, i32, i64, i128,);
+unsafe_impl_fill!(u16, u32, u64, u128,);
+unsafe_impl_fill!(i8, i16, i32, i64, i128,);
 
 impl<T, const N: usize> Fill for [T; N]
 where

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -393,10 +393,10 @@ impl Fill for [u8] {
     }
 }
 
-/// Implement `Fill` for given type `T`.
+/// Implement `Fill` for given type `$t`.
 ///
 /// # Safety
-/// All bit patterns of `[u8; size_of::<T>()]` represent values of `T`.
+/// All bit patterns of `[u8; size_of::<$t>()]` must represent values of `$t`.
 macro_rules! unsafe_impl_fill {
     () => {};
     ($t:ty) => {
@@ -405,7 +405,11 @@ macro_rules! unsafe_impl_fill {
                 if self.len() > 0 {
                     let size = mem::size_of_val(self);
                     rng.fill_bytes(
-                        // SAFETY: `self` is not borrowed and all byte sequences represent values of `T`.
+                        // SAFETY: `self` non-null and valid for reads and writes within its `size`
+                        // bytes. `self` meets the alignment requirements of `&mut [u8]`.
+                        // The contents of `self` are initialized. Both `[u8]` and `[$t]` are valid
+                        // for all bit-patterns of their contents (note that the SAFETY requirement
+                        // on callers of this macro). `self` is not borrowed.
                         unsafe {
                             slice::from_raw_parts_mut(self.as_mut_ptr()
                                 as *mut u8,
@@ -425,7 +429,11 @@ macro_rules! unsafe_impl_fill {
                 if self.len() > 0 {
                     let size = self.len() * mem::size_of::<$t>();
                     rng.fill_bytes(
-                        // SAFETY: `self` is not borrowed and all byte sequences represent values of `T`.
+                        // SAFETY: `self` non-null and valid for reads and writes within its `size`
+                        // bytes. `self` meets the alignment requirements of `&mut [u8]`.
+                        // The contents of `self` are initialized. Both `[u8]` and `[$t]` are valid
+                        // for all bit-patterns of their contents (note that the SAFETY requirement
+                        // on callers of this macro). `self` is not borrowed.
                         unsafe {
                             slice::from_raw_parts_mut(self.as_mut_ptr()
                                 as *mut u8,
@@ -448,9 +456,9 @@ macro_rules! unsafe_impl_fill {
     }
 }
 
-// SAFETY: All bit patterns of `[u8; size_of::<T>()]` represent values of `u*`.
+// SAFETY: All bit patterns of `[u8; size_of::<$t>()]` represent values of `u*`.
 unsafe_impl_fill!(u16, u32, u64, u128,);
-// SAFETY: All bit patterns of `[u8; size_of::<T>()]` represent values of `i*`.
+// SAFETY: All bit patterns of `[u8; size_of::<$t>()]` represent values of `i*`.
 unsafe_impl_fill!(i8, i16, i32, i64, i128,);
 
 impl<T, const N: usize> Fill for [T; N]

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -396,7 +396,7 @@ impl Fill for [u8] {
 /// Implement `Fill` for given type `T`.
 ///
 /// # Safety
-/// All representations of `[u8; size_of::<T>()]` are also representations of `T`.
+/// All bit patterns of `[u8; size_of::<T>()]` represent values of `T`.
 macro_rules! unsafe_impl_fill {
     () => {};
     ($t:ty) => {
@@ -405,7 +405,7 @@ macro_rules! unsafe_impl_fill {
                 if self.len() > 0 {
                     let size = mem::size_of_val(self);
                     rng.fill_bytes(
-                        // SAFETY: `self` is not borrowed and all byte sequences are representations of `T`.
+                        // SAFETY: `self` is not borrowed and all byte sequences represent values of `T`.
                         unsafe {
                             slice::from_raw_parts_mut(self.as_mut_ptr()
                                 as *mut u8,
@@ -425,7 +425,7 @@ macro_rules! unsafe_impl_fill {
                 if self.len() > 0 {
                     let size = self.len() * mem::size_of::<$t>();
                     rng.fill_bytes(
-                        // SAFETY: `self` is not borrowed and all byte sequences are representations of `T`.
+                        // SAFETY: `self` is not borrowed and all byte sequences represent values of `T`.
                         unsafe {
                             slice::from_raw_parts_mut(self.as_mut_ptr()
                                 as *mut u8,
@@ -448,9 +448,9 @@ macro_rules! unsafe_impl_fill {
     }
 }
 
-// SAFETY: All representations of `[u8; size_of::<u*>()]` are representations of `u*`.
+// SAFETY: All bit patterns of `[u8; size_of::<T>()]` represent values of `u*`.
 unsafe_impl_fill!(u16, u32, u64, u128,);
-// SAFETY: All representations of `[u8; size_of::<i*>()]` are representations of `i*`.
+// SAFETY: All bit patterns of `[u8; size_of::<T>()]` represent values of `i*`.
 unsafe_impl_fill!(i8, i16, i32, i64, i128,);
 
 impl<T, const N: usize> Fill for [T; N]

--- a/src/seq/iterator.rs
+++ b/src/seq/iterator.rs
@@ -134,6 +134,10 @@ pub trait IteratorRandom: Iterator + Sized {
     /// force every element to be created regardless call `.inspect(|e| ())`.
     ///
     /// [`choose`]: IteratorRandom::choose
+    //
+    // Clippy is wrong here: we need to iterate over all entries with the RNG to
+    // ensure that choosing is *stable*.
+    #[allow(clippy::double_ended_iterator_last)]
     fn choose_stable<R>(mut self, rng: &mut R) -> Option<Self::Item>
     where
         R: Rng + ?Sized,


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Replace `zerocopy` dependency with `unsafe` code (up from 12 to 17 instances).

Add benchmarks for some SIMD / wide types.

Remove two `#[inline(never)]` attributes which were apparently motivated by benchmark results, but caused more harm than help with the new benches.

# Motivation

- #1574: zerocopy is "a big crate with a huge amount of unsafe code"
- I've also seen some chatter about compile time increase in rand v0.9 due to now depending on two versions of `zerocopy`

I'm not a *big* fan of this, but together with #1575 it removes the dependency on `zerocopy` v0.8, so is probably an improvement.

## Project Safe Transmute

If [this project](https://rust-lang.github.io/rfcs/2835-project-safe-transmute.html) lands safe transmute support into the standard library, we would of course want to use that.

# Details

Replacing `zerocopy::transmute!` with `core::mem::transmute` is easy and results in identical code generation (tested with `StdRng` and `SmallRng`); this reverts a change in #1349.

Replacing the `fill` impls is more complex but I believe acceptable; this reverts a change in #1502.

In both cases, this would have resulted in a usage of `unsafe` in a macro where safety depends on a type passed by the macro caller. In the first case I decided to inline the three macro usages while in the second I prefixed the macro name with `unsafe_`.

# Benchmark results
```
$ cargo bench --bench simd --features simd_support -- --baseline master 
   Compiling rand v0.9.0 (/home/dhardy/projects/rand/rand)
   Compiling rand_distr v0.5.0 (/home/dhardy/projects/rand/rand/rand_distr)
   Compiling benches v0.1.0 (/home/dhardy/projects/rand/rand/benches)
    Finished `bench` profile [optimized] target(s) in 1.38s
     Running benches/simd.rs (target/release/deps/simd-2905efe84e67fa8e)
random_simd/u128        time:   [1.8751 ns 1.8831 ns 1.8948 ns]
                        change: [-0.1321% +0.6261% +1.4131%] (p = 0.12 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  5 (5.00%) high mild
  10 (10.00%) high severe
random_simd/m128i       time:   [1.9753 ns 1.9790 ns 1.9833 ns]
                        change: [+5.4631% +5.6551% +5.8561%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) high mild
  13 (13.00%) high severe
random_simd/m256i       time:   [3.7588 ns 3.7755 ns 3.7931 ns]
                        change: [-0.0698% +0.3828% +0.7685%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 17 outliers among 100 measurements (17.00%)
  4 (4.00%) high mild
  13 (13.00%) high severe
random_simd/m512i       time:   [6.8739 ns 6.8901 ns 6.9097 ns]
                        change: [+0.1511% +0.3741% +0.6309%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe
random_simd/u64x2       time:   [1.9767 ns 1.9817 ns 1.9875 ns]
                        change: [-72.129% -72.012% -71.890%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe
random_simd/u32x4       time:   [3.9506 ns 3.9572 ns 3.9651 ns]
                        change: [-50.352% -50.035% -49.827%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low severe
  1 (1.00%) high mild
  9 (9.00%) high severe
random_simd/u32x8       time:   [3.7498 ns 3.7598 ns 3.7717 ns]
                        change: [-0.0915% +0.3002% +0.8262%] (p = 0.20 > 0.05)
                        No change in performance detected.
Found 16 outliers among 100 measurements (16.00%)
  5 (5.00%) high mild
  11 (11.00%) high severe
random_simd/u16x8       time:   [3.7647 ns 3.7792 ns 3.7953 ns]
                        change: [-0.0710% +0.6785% +1.3454%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
random_simd/u8x16       time:   [3.7806 ns 3.7950 ns 3.8118 ns]
                        change: [+1.1070% +1.5527% +2.1092%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) high mild
  8 (8.00%) high severe
```

# Unfinished business?

The `Simd` and `m128i` etc. type generation should be equivalent, but they're not in terms of code; the `Simd` impls currently use `fill` to avoid more `unsafe` code here.

Notice from the above that `u32x4`, `u16x8` and `u8x16` are the same size as `u128` and `m128i` but cost about twice as much to generate here. This indicates the `fill` code may be sub-optimal.

Additionally, the `m128i` impl performed even worse when transmuting a `u128` value (~4.3ns or +%130) which, as far as I can tell, is purely because the `u128` value is returned via `rax, rdx` while the `__m128i` value is returned via `rdx, r10` (with `rax` equal to the struct address). I don't understand this.