### PR TITLE
Change to use `array::from_fn` in `Distribution<[T; N]> for StandardUniform`

### DIFF
--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -10,6 +10,7 @@
 
 #[cfg(feature = "alloc")]
 use alloc::string::String;
+use core::array;
 use core::char;
 use core::num::Wrapping;
 
@@ -18,7 +19,6 @@ use crate::distr::SampleString;
 use crate::distr::{Distribution, StandardUniform, Uniform};
 use crate::Rng;
 
-use core::mem::{self, MaybeUninit};
 #[cfg(feature = "simd_support")]
 use core::simd::prelude::*;
 #[cfg(feature = "simd_support")]
@@ -238,13 +238,7 @@ where
 {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, _rng: &mut R) -> [T; N] {
-        let mut buff: [MaybeUninit<T>; N] = unsafe { MaybeUninit::uninit().assume_init() };
-
-        for elem in &mut buff {
-            *elem = MaybeUninit::new(_rng.random());
-        }
-
-        unsafe { mem::transmute_copy::<_, _>(&buff) }
+        array::from_fn(|_| _rng.random())
     }
 }
 


### PR DESCRIPTION
- [ ] Added a `CHANGELOG.md` entry

# Summary

Change `Distribution<[T; N]> for StandardUniform` to use [`array::from_fn`](https://doc.rust-lang.org/core/array/fn.from_fn.html) to create an array.

# Motivation

- Reduce the `unsafe` code.
- Simplify the code.

# Details

I learned this function from <https://github.com/rust-lang/rust/pull/136732#discussion_r1947608014>.

The external behavior of this function should be preserved before and after this change. This function was stabilized in Rust 1.63.0, and the MSRV of `rand` crate is Rust 1.63, so we can use it.