### PR TITLE
Remove unnecessary underscore from `impl<T, const N: usize> Distribution<[T; N]> for StandardUniform`

### DIFF
--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -237,8 +237,8 @@ where
     StandardUniform: Distribution<T>,
 {
     #[inline]
-    fn sample<R: Rng + ?Sized>(&self, _rng: &mut R) -> [T; N] {
-        array::from_fn(|_| _rng.random())
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> [T; N] {
+        array::from_fn(|_| rng.random())
     }
 }
 


### PR DESCRIPTION
- [ ] Added a `CHANGELOG.md` entry

# Summary

Remove the leading underscore from the `_rng` parameter of the `sample` method.

# Motivation

Because this parameter appears to be used. I think suppressing the `unused_variables` lint is unnecessary.