### PR TITLE
rename extract to extract_lane

### DIFF
--- a/src/distr/uniform_float.rs
+++ b/src/distr/uniform_float.rs
@@ -248,31 +248,31 @@ mod tests {
                         let my_uniform = Uniform::new(low, high).unwrap();
                         let my_incl_uniform = Uniform::new_inclusive(low, high).unwrap();
                         for _ in 0..100 {
-                            let v = rng.sample(my_uniform).extract(lane);
+                            let v = rng.sample(my_uniform).extract_lane(lane);
                             assert!(low_scalar <= v && v <= high_scalar);
-                            let v = rng.sample(my_incl_uniform).extract(lane);
+                            let v = rng.sample(my_incl_uniform).extract_lane(lane);
                             assert!(low_scalar <= v && v <= high_scalar);
                             let v =
                                 <$ty as SampleUniform>::Sampler::sample_single(low, high, &mut rng)
                                     .unwrap()
-                                    .extract(lane);
+                                    .extract_lane(lane);
                             assert!(low_scalar <= v && v <= high_scalar);
                             let v = <$ty as SampleUniform>::Sampler::sample_single_inclusive(
                                 low, high, &mut rng,
                             )
                             .unwrap()
-                            .extract(lane);
+                            .extract_lane(lane);
                             assert!(low_scalar <= v && v <= high_scalar);
                         }
 
                         assert_eq!(
                             rng.sample(Uniform::new_inclusive(low, low).unwrap())
-                                .extract(lane),
+                                .extract_lane(lane),
                             low_scalar
                         );
 
-                        assert_eq!(zero_rng.sample(my_uniform).extract(lane), low_scalar);
-                        assert_eq!(zero_rng.sample(my_incl_uniform).extract(lane), low_scalar);
+                        assert_eq!(zero_rng.sample(my_uniform).extract_lane(lane), low_scalar);
+                        assert_eq!(zero_rng.sample(my_incl_uniform).extract_lane(lane), low_scalar);
                         assert_eq!(
                             <$ty as SampleUniform>::Sampler::sample_single(
                                 low,
@@ -280,7 +280,7 @@ mod tests {
                                 &mut zero_rng
                             )
                             .unwrap()
-                            .extract(lane),
+                            .extract_lane(lane),
                             low_scalar
                         );
                         assert_eq!(
@@ -290,12 +290,12 @@ mod tests {
                                 &mut zero_rng
                             )
                             .unwrap()
-                            .extract(lane),
+                            .extract_lane(lane),
                             low_scalar
                         );
 
-                        assert!(max_rng.sample(my_uniform).extract(lane) <= high_scalar);
-                        assert!(max_rng.sample(my_incl_uniform).extract(lane) <= high_scalar);
+                        assert!(max_rng.sample(my_uniform).extract_lane(lane) <= high_scalar);
+                        assert!(max_rng.sample(my_incl_uniform).extract_lane(lane) <= high_scalar);
                         // sample_single cannot cope with max_rng:
                         // assert!(<$ty as SampleUniform>::Sampler
                         //     ::sample_single(low, high, &mut max_rng).unwrap()
@@ -307,7 +307,7 @@ mod tests {
                                 &mut max_rng
                             )
                             .unwrap()
-                            .extract(lane)
+                            .extract_lane(lane)
                                 <= high_scalar
                         );
 
@@ -326,7 +326,7 @@ mod tests {
                                     &mut lowering_max_rng
                                 )
                                 .unwrap()
-                                .extract(lane)
+                                .extract_lane(lane)
                                     <= high_scalar
                             );
                         }

--- a/src/distr/utils.rs
+++ b/src/distr/utils.rs
@@ -236,7 +236,7 @@ pub(crate) trait FloatSIMDScalarUtils: FloatSIMDUtils {
     type Scalar;
 
     fn replace(self, index: usize, new_value: Self::Scalar) -> Self;
-    fn extract(self, index: usize) -> Self::Scalar;
+    fn extract_lane(self, index: usize) -> Self::Scalar;
 }
 
 /// Implement functions on f32/f64 to give them APIs similar to SIMD types
@@ -320,7 +320,7 @@ macro_rules! scalar_float_impl {
             }
 
             #[inline]
-            fn extract(self, index: usize) -> Self::Scalar {
+            fn extract_lane(self, index: usize) -> Self::Scalar {
                 debug_assert_eq!(index, 0);
                 self
             }
@@ -395,7 +395,7 @@ macro_rules! simd_impl {
             }
 
             #[inline]
-            fn extract(self, index: usize) -> Self::Scalar {
+            fn extract_lane(self, index: usize) -> Self::Scalar {
                 self.as_array()[index]
             }
         }


### PR DESCRIPTION

- [ ] Added a `CHANGELOG.md` entry

# Summary

Rename a function which is only used for testing because it clashes with `std::simd`

# Motivation

CI fails otherwise

# Details
