### PR TITLE
Add `Alphabetic` distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 ## [Unreleased]
 - Fix feature `simd_support` for recent nightly rust (#1586)
 
+### Distributions
+- Add `Alphabetic` distribution. (#1587)
+
 ## [0.9.0] - 2025-01-27
 ### Security and unsafe
 - Policy: "rand is not a crypto library" (#1514)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 
 ## [Unreleased]
 - Fix feature `simd_support` for recent nightly rust (#1586)
-
-### Distributions
 - Add `Alphabetic` distribution. (#1587)
 
 ## [0.9.0] - 2025-01-27

--- a/benches/benches/standard.rs
+++ b/benches/benches/standard.rs
@@ -9,7 +9,7 @@
 use core::time::Duration;
 use criterion::measurement::WallTime;
 use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion};
-use rand::distr::{Alphanumeric, Open01, OpenClosed01, StandardUniform};
+use rand::distr::{Alphabetic, Alphanumeric, Open01, OpenClosed01, StandardUniform};
 use rand::prelude::*;
 use rand_pcg::Pcg64Mcg;
 
@@ -52,6 +52,7 @@ pub fn bench(c: &mut Criterion) {
     do_ty!(f32, f64);
     do_ty!(char);
 
+    bench_ty::<u8, Alphabetic>(&mut g, "Alphabetic");
     bench_ty::<u8, Alphanumeric>(&mut g, "Alphanumeric");
 
     bench_ty::<f32, Open01>(&mut g, "Open01/f32");

--- a/src/distr/distribution.rs
+++ b/src/distr/distribution.rs
@@ -250,7 +250,7 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn test_dist_string() {
-        use crate::distr::{Alphanumeric, SampleString, StandardUniform};
+        use crate::distr::{Alphabetic, Alphanumeric, SampleString, StandardUniform};
         use core::str;
         let mut rng = crate::test::rng(213);
 
@@ -261,5 +261,9 @@ mod tests {
         let s2 = StandardUniform.sample_string(&mut rng, 20);
         assert_eq!(s2.chars().count(), 20);
         assert_eq!(str::from_utf8(s2.as_bytes()), Ok(s2.as_str()));
+
+        let s3 = Alphabetic.sample_string(&mut rng, 20);
+        assert_eq!(s3.len(), 20);
+        assert_eq!(str::from_utf8(s3.as_bytes()), Ok(s3.as_str()));
     }
 }

--- a/src/distr/mod.rs
+++ b/src/distr/mod.rs
@@ -129,7 +129,8 @@ use crate::Rng;
 ///   code points in the range `0...0x10_FFFF`, except for the range
 ///   `0xD800...0xDFFF` (the surrogate code points). This includes
 ///   unassigned/reserved code points.
-///   For some uses, the [`Alphanumeric`] distribution will be more appropriate.
+///   For some uses, the [`Alphanumeric`] or [`Alphabetic`] distribution will be more
+///   appropriate.
 /// * `bool` samples `false` or `true`, each with probability 0.5.
 /// * Floating point types (`f32` and `f64`) are uniformly distributed in the
 ///   half-open range `[0, 1)`. See also the [notes below](#floating-point-implementation).

--- a/src/distr/mod.rs
+++ b/src/distr/mod.rs
@@ -46,6 +46,9 @@
 //! numbers of the `char` type; in contrast [`StandardUniform`] may sample any valid
 //! `char`.
 //!
+//! There's also an [`Alphabetic`] distribution which acts similarly to [`Alphanumeric`] but
+//! doesn't include digits.
+//!
 //! For floats (`f32`, `f64`), [`StandardUniform`] samples from `[0, 1)`. Also
 //! provided are [`Open01`] (samples from `(0, 1)`) and [`OpenClosed01`]
 //! (samples from `(0, 1]`). No option is provided to sample from `[0, 1]`; it

--- a/src/distr/mod.rs
+++ b/src/distr/mod.rs
@@ -104,7 +104,7 @@ pub use self::bernoulli::{Bernoulli, BernoulliError};
 pub use self::distribution::SampleString;
 pub use self::distribution::{Distribution, Iter, Map};
 pub use self::float::{Open01, OpenClosed01};
-pub use self::other::Alphanumeric;
+pub use self::other::{Alphabetic, Alphanumeric};
 #[doc(inline)]
 pub use self::uniform::Uniform;
 

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -70,7 +70,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Alphanumeric;
 
-/// Sample a [`u8`], uniformly distributed over ASCII letters:
+/// Sample a [`u8`], uniformly distributed over letters:
 /// a-z and A-Z.
 ///
 /// If you want to sample alphanumeric characters then refer to [`Alphanumeric`].

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -73,8 +73,6 @@ pub struct Alphanumeric;
 /// Sample a [`u8`], uniformly distributed over letters:
 /// a-z and A-Z.
 ///
-/// If you want to sample alphanumeric characters then refer to [`Alphanumeric`].
-///
 /// # Example
 ///
 /// You're able to generate random Alphabetic characters via mapping or via the

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -70,6 +70,10 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Alphanumeric;
 
+#[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Alphabetic;
+
 // ----- Implementations of distributions -----
 
 impl Distribution<char> for StandardUniform {

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -70,6 +70,38 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Alphanumeric;
 
+/// Sample a [`u8`], uniformly distributed over ASCII letters:
+/// a-z and A-Z.
+///
+/// If you want to sample alphanumeric characters then refer to [`Alphanumeric`].
+///
+/// # Example
+///
+/// You're able to generate random Alphabetic characters via mapping or via the
+/// [`SampleString::sample_string`] method like so:
+///
+/// ## Manual mapping
+///
+/// ```
+/// use rand::Rng;
+/// use rand::distr::Alphabetic;
+///
+/// let mut rng = rand::rng();
+/// let chars: String = (0..7).map(|_| rng.sample(Alphabetic) as char).collect();
+/// println!("Random chars: {}", chars);
+/// ```
+///
+/// ## Using [`SampleString::sample_string`]
+///
+/// ```
+/// use rand::distr::{Alphabetic, SampleString};
+/// let string = Alphabetic.sample_string(&mut rand::rng(), 16);
+/// println!("Random string: {}", string);
+/// ```
+///
+/// # Passwords
+///
+/// Refer to [`Alphanumeric#Passwords`].
 #[derive(Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Alphabetic;

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -319,6 +319,20 @@ mod tests {
     }
 
     #[test]
+    fn test_alphabetic() {
+        let mut rng = crate::test::rng(806);
+
+        // Test by generating a relatively large number of chars, so we also
+        // take the rejection sampling path.
+        let mut incorrect = false;
+        for _ in 0..100 {
+            let c: char = rng.sample(Alphabetic).into();
+            incorrect |= !c.is_ascii_alphabetic();
+        }
+        assert!(!incorrect);
+    }
+
+    #[test]
     fn value_stability() {
         fn test_samples<T: Copy + core::fmt::Debug + PartialEq, D: Distribution<T>>(
             distr: &D,
@@ -345,6 +359,7 @@ mod tests {
             ],
         );
         test_samples(&Alphanumeric, 0, &[104, 109, 101, 51, 77]);
+        test_samples(&Alphabetic, 0, &[97, 102, 89, 116, 75]);
         test_samples(&StandardUniform, false, &[true, true, false, true, false]);
         test_samples(
             &StandardUniform,

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -182,10 +182,7 @@ impl SampleString for Alphanumeric {
 #[cfg(feature = "alloc")]
 impl SampleString for Alphabetic {
     fn append_string<R: Rng + ?Sized>(&self, rng: &mut R, string: &mut String, len: usize) {
-        unsafe {
-            let v = string.as_mut_vec();
-            v.extend(self.sample_iter(rng).take(len));
-        }
+        string.extend(self.sample_iter(rng).take(len).map(char::from));
     }
 }
 

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -78,21 +78,16 @@ pub struct Alphanumeric;
 /// You're able to generate random Alphabetic characters via mapping or via the
 /// [`SampleString::sample_string`] method like so:
 ///
-/// ## Manual mapping
-///
 /// ```
 /// use rand::Rng;
-/// use rand::distr::Alphabetic;
+/// use rand::distr::{Alphabetic, SampleString};
 ///
+/// // Manual mapping
 /// let mut rng = rand::rng();
 /// let chars: String = (0..7).map(|_| rng.sample(Alphabetic) as char).collect();
 /// println!("Random chars: {}", chars);
-/// ```
 ///
-/// ## Using [`SampleString::sample_string`]
-///
-/// ```
-/// use rand::distr::{Alphabetic, SampleString};
+/// // Using [`SampleString::sample_string`]
 /// let string = Alphabetic.sample_string(&mut rand::rng(), 16);
 /// println!("Random string: {}", string);
 /// ```

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -127,6 +127,16 @@ impl Distribution<u8> for Alphanumeric {
     }
 }
 
+impl Distribution<u8> for Alphabetic {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u8 {
+        const RANGE: u32 = 26 + 26;
+        const GEN_ASCII_STR_CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
+                abcdefghijklmnopqrstuvwxyz";
+
+        GEN_ASCII_STR_CHARSET[rng.random_range(0..RANGE as usize)]
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl SampleString for Alphanumeric {
     fn append_string<R: Rng + ?Sized>(&self, rng: &mut R, string: &mut String, len: usize) {

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -155,10 +155,11 @@ impl Distribution<u8> for Alphanumeric {
 impl Distribution<u8> for Alphabetic {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u8 {
         const RANGE: u8 = 26 + 26;
-        const GEN_ASCII_STR_CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
-                abcdefghijklmnopqrstuvwxyz";
 
-        GEN_ASCII_STR_CHARSET[rng.random_range(0..RANGE) as usize]
+        let offset = rng.random_range(0..RANGE) + b'A';
+
+        // Account for upper-cases
+        offset + (offset > b'Z') as u8 * (b'a' - b'Z' - 1)
     }
 }
 

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -176,7 +176,14 @@ impl SampleString for Alphanumeric {
 #[cfg(feature = "alloc")]
 impl SampleString for Alphabetic {
     fn append_string<R: Rng + ?Sized>(&self, rng: &mut R, string: &mut String, len: usize) {
-        string.extend(self.sample_iter(rng).take(len).map(char::from));
+        // SAFETY: With this distribution we guarantee that we're working with valid ASCII
+        // characters.
+        // See [#1590](https://github.com/rust-random/rand/issues/1590).
+        unsafe {
+            let v = string.as_mut_vec();
+            v.reserve_exact(len);
+            v.extend(self.sample_iter(rng).take(len));
+        }
     }
 }
 

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -154,11 +154,11 @@ impl Distribution<u8> for Alphanumeric {
 
 impl Distribution<u8> for Alphabetic {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u8 {
-        const RANGE: u32 = 26 + 26;
+        const RANGE: u8 = 26 + 26;
         const GEN_ASCII_STR_CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
                 abcdefghijklmnopqrstuvwxyz";
 
-        GEN_ASCII_STR_CHARSET[rng.random_range(0..RANGE as usize)]
+        GEN_ASCII_STR_CHARSET[rng.random_range(0..RANGE) as usize]
     }
 }
 

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -147,6 +147,16 @@ impl SampleString for Alphanumeric {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl SampleString for Alphabetic {
+    fn append_string<R: Rng + ?Sized>(&self, rng: &mut R, string: &mut String, len: usize) {
+        unsafe {
+            let v = string.as_mut_vec();
+            v.extend(self.sample_iter(rng).take(len));
+        }
+    }
+}
+
 impl Distribution<bool> for StandardUniform {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> bool {


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Added an `Alphabetic` distribution similar to `Alphanumeric` with the same derives and similar: 
- tests;
- trait implementations;
- benches;
- documentation.

> [!NOTE]
> There's no documentation in: `src/lib.rs`, `src/rng.rs`. Saying this because there's documentation about `Alphanumeric` there.  The reason is that `Alphabetic` and `Alphanumeric` are pretty similar already so I didn't see much value in adding more generic examples compared to the type-level documentation.

# Motivation

Had the need for an alphabetic random generation and figured it'd be helpful to have it integrated directly into the library for easier usage.

# Details

Decided to use `rng.random_range` for the `Distribution<u8>` implementation due to it showing slightly better performance benchmarks (https://github.com/rust-random/rand/commit/69cc117ef2bacab57a870a120a099589e67abb5b). With three benchmark runs on my system, here are the results with 3 runs:

## Rejection sampling

```
random_bool/standard    time:   [1.1139 ns 1.1224 ns 1.1321 ns]
                        change: [+0.8541% +1.6869% +2.5284%] (p = 0.00 < 0.05)
                        Change within noise threshold. 
Found 114 outliers among 1000 measurements (11.40%)
  30 (3.00%) high mild
  84 (8.40%) high severe
random_bool/standard    time:   [1.1159 ns 1.1248 ns 1.1345 ns]
                        change: [-1.1600% -0.1566% +0.9021%] (p = 0.76 > 0.05)
                        No change in performance detected.
Found 134 outliers among 1000 measurements (13.40%)
  34 (3.40%) high mild
  100 (10.00%) high severe
random_bool/standard    time:   [1.1095 ns 1.1141 ns 1.1191 ns]
                        change: [-1.8864% -0.9835% -0.0256%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 67 outliers among 1000 measurements (6.70%)
  24 (2.40%) high mild
  43 (4.30%) high severe
```

## `rng.random_range`

```
random_bool/standard    time:   [1.0960 ns 1.1007 ns 1.1067 ns]
                        change: [-1.7071% -1.0058% -0.3238%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 80 outliers among 1000 measurements (8.00%)
  39 (3.90%) high mild
  41 (4.10%) high severe
random_bool/standard    time:   [1.1012 ns 1.1069 ns 1.1136 ns]
                        change: [-0.3371% +0.2525% +0.8818%] (p = 0.42 > 0.05)
                        No change in performance detected.
Found 80 outliers among 1000 measurements (8.00%)
  40 (4.00%) high mild
  40 (4.00%) high severe
random_bool/standard    time:   [1.0997 ns 1.1048 ns 1.1104 ns]
                        change: [-0.5032% +0.1257% +0.7238%] (p = 0.70 > 0.05)
                        No change in performance detected.
Found 90 outliers among 1000 measurements (9.00%)
  36 (3.60%) high mild
  54 (5.40%) high severe
```

## Specs

- Ryzen 5 3600X
- Arch Linux - `6.13.2-zen1-1-zen`
- i3wm

> [!NOTE]
> Did do all the benches with a lot of my desktop apps in the background. That shouldn't be a problem because I didn't open new apps or use my background apps a lot.

---

Also, I'm a first time contributor so if I missed some implementation details or additional required documentation, feel free to tell me about it.