### PR TITLE
rand_core: introduce an UnwrapMut wrapper

### DIFF
--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### API changes
+- Add `TryRngCore::unwrap_ref` to only take a mutable reference of the rng (#1589)
+
 ## [0.9.0] - 2025-01-27
 ### Dependencies and features
 - Bump the MSRV to 1.63.0 (#1207, #1246, #1269, #1341, #1416, #1536); note that 1.60.0 may work for dependents when using `--ignore-rust-version`


### PR DESCRIPTION
# Summary

# Motivation

This is used when a method takes in a `&mut impl TryRngCore` but the inner method requires an `&mut impl RngCore`.

An `UnwrapErr` can not be used as it requires ownership of the rng.

# Details
