### PR TITLE
rand_core: relax sizing requirement on blanket implementations

### DIFF
--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### API changes
+- Relax sizing requirement on blanket implementation of `TryCryptoRng` and `TryRngCore` (#1592)
+
 ## [0.9.1] - 2025-02-16
 ### API changes
 - Add `TryRngCore::unwrap_mut`, providing an impl of `RngCore` over `&mut rng` (#1589)

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -254,7 +254,7 @@ pub trait TryRngCore {
 // Note that, unfortunately, this blanket impl prevents us from implementing
 // `TryRngCore` for types which can be dereferenced to `TryRngCore`, i.e. `TryRngCore`
 // will not be automatically implemented for `&mut R`, `Box<R>`, etc.
-impl<R: RngCore> TryRngCore for R {
+impl<R: RngCore + ?Sized> TryRngCore for R {
     type Error = core::convert::Infallible;
 
     #[inline]
@@ -290,7 +290,7 @@ impl<R: RngCore> TryRngCore for R {
 /// (like [`OsRng`]) or if the `default()` instance uses a strong, fresh seed.
 pub trait TryCryptoRng: TryRngCore {}
 
-impl<R: CryptoRng> TryCryptoRng for R {}
+impl<R: CryptoRng + ?Sized> TryCryptoRng for R {}
 
 /// Wrapper around [`TryRngCore`] implementation which implements [`RngCore`]
 /// by panicking on potential errors.


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Relax the sizing requirements for the blanket implementations of `TryCryptoRng` and `TryRngCore`.

# Motivation

When using a `&mut CryptoRng` in a `&mut TryCryptoRng` we should not require the rng to be `Sized`.

# Details
