### PR TITLE
rand: re-export `UnwrapMut` & `UnwrapErr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 ## [Unreleased]
 - Fix feature `simd_support` for recent nightly rust (#1586)
 - Add `Alphabetic` distribution. (#1587)
+- Re-export `UnwrapMut` and `UnwrapErr` from `rand_core` (#1594)
 
 ## [0.9.0] - 2025-01-27
 ### Security and unsafe

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ members = [
 exclude = ["benches", "distr_test"]
 
 [dependencies]
-rand_core = { path = "rand_core", version = "0.9.0", default-features = false }
+rand_core = { path = "rand_core", version = "0.9.1", default-features = false }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 rand_chacha = { path = "rand_chacha", version = "0.9.0", default-features = false, optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,9 @@ macro_rules! error { ($($x:tt)*) => (
 ) }
 
 // Re-exports from rand_core
-pub use rand_core::{CryptoRng, RngCore, SeedableRng, TryCryptoRng, TryRngCore};
+pub use rand_core::{
+    CryptoRng, RngCore, SeedableRng, TryCryptoRng, TryRngCore, UnwrapErr, UnwrapMut,
+};
 
 // Public modules
 pub mod distr;


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

# Motivation

Consumers may not directly depend on `rand_core` and those unwrap wrappers may be convenient.

# Details
