### PR TITLE
rand_core: implement reborrow for `UnwrapMut`

### DIFF
--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### API changes
 - Relax `Sized` bound on impls of `TryRngCore`, `TryCryptoRng` and `UnwrapMut` (#1593)
+- Add `UnwrapMut::re` to reborrow the inner rng with a tighter lifetime (#1595)
 
 ## [0.9.1] - 2025-02-16
 ### API changes

--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -197,7 +197,7 @@ impl<R: BlockRngCore<Item = u32>> RngCore for BlockRng<R> {
     fn next_u64(&mut self) -> u64 {
         let read_u64 = |results: &[u32], index| {
             let data = &results[index..=index + 1];
-            u64::from(data[1]) << 32 | u64::from(data[0])
+            (u64::from(data[1]) << 32) | u64::from(data[0])
         };
 
         let len = self.results.as_ref().len();

--- a/rand_pcg/src/pcg128.rs
+++ b/rand_pcg/src/pcg128.rs
@@ -234,7 +234,7 @@ impl SeedableRng for Mcg128Xsl64 {
         // Read as if a little-endian u128 value:
         let mut seed_u64 = [0u64; 2];
         le::read_u64_into(&seed, &mut seed_u64);
-        let state = u128::from(seed_u64[0]) | u128::from(seed_u64[1]) << 64;
+        let state = u128::from(seed_u64[0]) | (u128::from(seed_u64[1]) << 64);
         Mcg128Xsl64::new(state)
     }
 }


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

# Motivation

reborrow support was missing from #1589 

# Details
