### PR TITLE
implement `Distribution<usize>` and `UniformSampler<isize>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 ## [Unreleased]
 - Fix feature `simd_support` for recent nightly rust (#1586)
 - Add `Alphabetic` distribution. (#1587)
-- Add `UniformSample<isize>` implementation. (#1599)
+- Add `UniformSample<isize>` implementation. (#1598)
+- Add `Distribution<usize>` implementation. (#1598)
 
 ## [0.9.0] - 2025-01-27
 ### Security and unsafe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 ## [Unreleased]
 - Fix feature `simd_support` for recent nightly rust (#1586)
 - Add `Alphabetic` distribution. (#1587)
+- Add `UniformSample<isize>` implementation. (#1599)
 
 ## [0.9.0] - 2025-01-27
 ### Security and unsafe

--- a/src/distr/integer.rs
+++ b/src/distr/integer.rs
@@ -63,6 +63,17 @@ impl Distribution<u128> for StandardUniform {
     }
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+impl Distribution<usize> for StandardUniform {
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
+        #[cfg(target_pointer_width = "32")]
+        return rng.next_u32() as usize;
+        #[cfg(target_pointer_width = "64")]
+        return rng.next_u64() as usize;
+    }
+}
+
 macro_rules! impl_int_from_uint {
     ($ty:ty, $uty:ty) => {
         impl Distribution<$ty> for StandardUniform {
@@ -79,6 +90,7 @@ impl_int_from_uint! { i16, u16 }
 impl_int_from_uint! { i32, u32 }
 impl_int_from_uint! { i64, u64 }
 impl_int_from_uint! { i128, u128 }
+impl_int_from_uint! { isize, usize }
 
 macro_rules! impl_nzint {
     ($ty:ty, $new:path) => {

--- a/src/distr/uniform_int.rs
+++ b/src/distr/uniform_int.rs
@@ -271,6 +271,8 @@ uniform_int_impl! { u32, u32, u32 }
 uniform_int_impl! { u64, u64, u64 }
 uniform_int_impl! { u128, u128, u128 }
 
+uniform_int_impl! { isize, usize, usize }
+
 #[cfg(feature = "simd_support")]
 macro_rules! uniform_simd_int_impl {
     ($ty:ident, $unsigned:ident) => {


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

# Motivation
This API is used in the `proptest` crate  (https://github.com/proptest-rs/proptest/pull/550)

# Details
