### PR TITLE
fixup clippy 1.85 warnings

### DIFF
--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### API changes
 - Relax `Sized` bound on impls of `TryRngCore`, `TryCryptoRng` and `UnwrapMut` (#1593)
 
+### Other
+- Fixup clippy warnings (#1601)
+
 ## [0.9.1] - 2025-02-16
 ### API changes
 - Add `TryRngCore::unwrap_mut`, providing an impl of `RngCore` over `&mut rng` (#1589)

--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -197,7 +197,7 @@ impl<R: BlockRngCore<Item = u32>> RngCore for BlockRng<R> {
     fn next_u64(&mut self) -> u64 {
         let read_u64 = |results: &[u32], index| {
             let data = &results[index..=index + 1];
-            u64::from(data[1]) << 32 | u64::from(data[0])
+            (u64::from(data[1]) << 32) | u64::from(data[0])
         };
 
         let len = self.results.as_ref().len();

--- a/rand_pcg/CHANGELOG.md
+++ b/rand_pcg/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Other changes
+- Fixup clippy warnings (#1601)
+
 ## [0.9.0] - 2025-01-27
 ### Dependencies and features
 - Update to `rand_core` v0.9.0 (#1558)

--- a/rand_pcg/src/pcg128.rs
+++ b/rand_pcg/src/pcg128.rs
@@ -234,7 +234,7 @@ impl SeedableRng for Mcg128Xsl64 {
         // Read as if a little-endian u128 value:
         let mut seed_u64 = [0u64; 2];
         le::read_u64_into(&seed, &mut seed_u64);
-        let state = u128::from(seed_u64[0]) | u128::from(seed_u64[1]) << 64;
+        let state = u128::from(seed_u64[0]) | (u128::from(seed_u64[1]) << 64);
         Mcg128Xsl64::new(state)
     }
 }


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

# Motivation

Rust 1.85 released today and brings new lints:
https://rust-lang.github.io/rust-clippy/master/index.html#precedence

# Details
