### PR TITLE
rand: re-export `rand_core`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 ## [Unreleased]
 - Fix feature `simd_support` for recent nightly rust (#1586)
 - Add `Alphabetic` distribution. (#1587)
+- Re-export `rand_core` (#1602)
 
 ## [0.9.0] - 2025-01-27
 ### Security and unsafe

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,9 @@ macro_rules! error { ($($x:tt)*) => (
     }
 ) }
 
+// Re-export rand_core itself
+pub use rand_core;
+
 // Re-exports from rand_core
 pub use rand_core::{CryptoRng, RngCore, SeedableRng, TryCryptoRng, TryRngCore};
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

# Motivation

Some structs defined in `rand_core` like `UnwrapMut` or `UnwrapErr` may be used by a consumer of `rand`. Re-exporting `rand_core` is an easier alternative than having the consumer depend `rand` and `rand_core`.

# Details
