### PR TITLE
Implement `Distribution<usize>` for `StandardUniform`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 ## [Unreleased]
 - Fix feature `simd_support` for recent nightly rust (#1586)
 - Add `Alphabetic` distribution. (#1587)
+- Implement `Distribution<usize>` for `StandardUniform`. (#1606)
 - Re-export `rand_core` (#1602)
 
 ## [0.9.0] - 2025-01-27

--- a/src/distr/integer.rs
+++ b/src/distr/integer.rs
@@ -80,6 +80,13 @@ impl_int_from_uint! { i32, u32 }
 impl_int_from_uint! { i64, u64 }
 impl_int_from_uint! { i128, u128 }
 
+#[cfg(target_pointer_width = "16")]
+impl_int_from_uint! { usize, u16 }
+#[cfg(target_pointer_width = "32")]
+impl_int_from_uint! { usize, u32 }
+#[cfg(target_pointer_width = "64")]
+impl_int_from_uint! { usize, u64 }
+
 macro_rules! impl_nzint {
     ($ty:ty, $new:path) => {
         impl Distribution<$ty> for StandardUniform {
@@ -185,6 +192,7 @@ mod tests {
         rng.sample::<u32, _>(StandardUniform);
         rng.sample::<u64, _>(StandardUniform);
         rng.sample::<u128, _>(StandardUniform);
+        rng.sample::<usize, _>(StandardUniform);
     }
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Implements `Distribution<usize>` for `StandardUniform`.

# Motivation

The ability to do `rng.random::<usize>()` was lost in v0.9

# Details

Re-used existing macros plus pointer width selection for the impls.
