### PR TITLE
Prepare rand_core v0.9.3

### DIFF
--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.3] — 2025-02-29
 ### Other
 - Remove `zerocopy` dependency (#1607)
+- Deprecate `rand_core::impls::fill_via_u32_chunks`, `fill_via_u64_chunks` (#1607)
 
 ## [0.9.2] - 2025-02-22
 ### API changes

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This is just for #1607. Marked for release tomorrow because I'm not around today.