### PR TITLE
Update rand_core version number in Readme

### DIFF
--- a/rand_core/README.md
+++ b/rand_core/README.md
@@ -43,7 +43,7 @@ The traits and error types are also available via `rand`.
 The current version is:
 
 ```toml
-rand_core = "0.9.0"
+rand_core = "0.9.3"
 ```
 
 


### PR DESCRIPTION
# Summary

Updates the rand_core version number in the rand_core Readme.

# Motivation

The version was out of date.