### PR TITLE
Add 'unbiased' to 'Crate Features' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ Additionally, these features configure Rand:
 -   `nightly` includes some additions requiring nightly Rust
 -   `simd_support` (experimental) enables sampling of SIMD values
     (uniformly random SIMD integers and floats), requiring nightly Rust
+-   `unbiased` use unbiased sampling for algorithms supporting this option: Uniform distribution.
+
+    (By default, bias affecting no more than one in  2^48 samples is accepted.)
+
+    Note: enabling this option is expected to affect reproducibility of results.
 
 Note that nightly features are not stable and therefore not all library and
 compiler versions will be compatible. This is especially true of Rand's


### PR DESCRIPTION
Wording taken directly from Cargo.toml

Fixes https://github.com/rust-random/rand/issues/1615

- [ ] ~~Added a `CHANGELOG.md` entry~~
*not a notable change*

# Summary

'unbiased' feature lacked a description in README.md
