### PR TITLE
perf: optimize performance of sample_floyd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Fix feature `simd_support` for recent nightly rust (#1586)
 - Add `Alphabetic` distribution. (#1587)
 - Re-export `rand_core` (#1602)
+- Boost performance of `sample_floyd` (#1621)
 
 ## [0.9.0] - 2025-01-27
 ### Security and unsafe


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

This PR uses unsafe APIs to boost performance of `sample_floyd`. The optimization is totally safe because the index is bounded by the length of the vec.

# Motivation

Rust's bounds checking are sometimes unnecessary. Removing bounds checking by unsafe APIs can boost its performance.This optimization makes related functions more faster with safety ensured.

# Details

The benchmark results is listed as below. 
```
seq_slice_choose_multiple_1_of_1000
                        time:   [17.081 ns 17.221 ns 17.376 ns]
                        change: [-5.8051% -4.7440% -3.7121%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

seq_slice_choose_multiple_10_of_100
                        time:   [37.808 ns 38.055 ns 38.322 ns]
                        change: [-32.749% -32.136% -31.545%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
```