### PR TITLE
Allow fn choose_multiple_weighted to return fewer than amount elts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Fix feature `simd_support` for recent nightly rust (#1586)
 - Add `Alphabetic` distribution. (#1587)
 - Re-export `rand_core` (#1602)
+- Allow `fn rand::seq::index::sample_weighted` and `fn IndexedRandom::choose_multiple_weighted` to return fewer than `amount` results (#1623), reverting an undocumented change (#1382) to the previous release.
 
 ## [0.9.0] - 2025-01-27
 ### Security and unsafe

--- a/src/seq/iterator.rs
+++ b/src/seq/iterator.rs
@@ -134,6 +134,10 @@ pub trait IteratorRandom: Iterator + Sized {
     /// force every element to be created regardless call `.inspect(|e| ())`.
     ///
     /// [`choose`]: IteratorRandom::choose
+    //
+    // Clippy is wrong here: we need to iterate over all entries with the RNG to
+    // ensure that choosing is *stable*.
+    #[allow(clippy::double_ended_iterator_last)]
     fn choose_stable<R>(mut self, rng: &mut R) -> Option<Self::Item>
     where
         R: Rng + ?Sized,

--- a/src/seq/slice.rs
+++ b/src/seq/slice.rs
@@ -173,16 +173,15 @@ pub trait IndexedRandom: Index<usize> {
 
     /// Biased sampling of `amount` distinct elements
     ///
-    /// Similar to [`choose_multiple`], but where the likelihood of each element's
-    /// inclusion in the output may be specified. The elements are returned in an
-    /// arbitrary, unspecified order.
+    /// Similar to [`choose_multiple`], but where the likelihood of each
+    /// element's inclusion in the output may be specified. Zero-weighted
+    /// elements are never returned; the result may therefore contain fewer
+    /// elements than `amount` even when `self.len() >= amount`. The elements
+    /// are returned in an arbitrary, unspecified order.
     ///
     /// The specified function `weight` maps each item `x` to a relative
     /// likelihood `weight(x)`. The probability of each item being selected is
     /// therefore `weight(x) / s`, where `s` is the sum of all `weight(x)`.
-    ///
-    /// If all of the weights are equal, even if they are all zero, each element has
-    /// an equal likelihood of being selected.
     ///
     /// This implementation uses `O(length + amount)` space and `O(length)` time
     /// if the "nightly" feature is enabled, or `O(length)` space and
@@ -687,7 +686,7 @@ mod test {
         // Case 2: All of the weights are 0
         let choices = [('a', 0), ('b', 0), ('c', 0)];
         let r = choices.choose_multiple_weighted(&mut rng, 2, |item| item.1);
-        assert_eq!(r.unwrap_err(), WeightError::InsufficientNonZero);
+        assert_eq!(r.unwrap().len(), 0);
 
         // Case 3: Negative weights
         let choices = [('a', -1), ('b', 1), ('c', 1)];

--- a/src/seq/slice.rs
+++ b/src/seq/slice.rs
@@ -183,15 +183,8 @@ pub trait IndexedRandom: Index<usize> {
     /// likelihood `weight(x)`. The probability of each item being selected is
     /// therefore `weight(x) / s`, where `s` is the sum of all `weight(x)`.
     ///
-    /// This implementation uses `O(length + amount)` space and `O(length)` time
-    /// if the "nightly" feature is enabled, or `O(length)` space and
-    /// `O(length + amount * log length)` time otherwise.
-    ///
-    /// # Known issues
-    ///
-    /// The algorithm currently used to implement this method loses accuracy
-    /// when small values are used for weights.
-    /// See [#1476](https://github.com/rust-random/rand/issues/1476).
+    /// This implementation uses `O(length + amount)` space and `O(length)` time.
+    /// See [`index::sample_weighted`] for details.
     ///
     /// # Example
     ///


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary
Allow `fn rand::seq::index::sample_weighted` and `fn IndexedRandom::choose_multiple_weighted` to return fewer than `amount` results.

# Details
This restriction was added in #1382 without being mentioned in the changelog, and it appears best to revert this behaviour (#1619).
