### PR TITLE
Update lib.rs to remove unnecessary `extern crate`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,11 +61,6 @@
 )]
 #![deny(clippy::undocumented_unsafe_blocks)]
 
-#[cfg(feature = "alloc")]
-extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std;
-
 #[allow(unused)]
 macro_rules! trace { ($($x:tt)*) => (
     #[cfg(feature = "log")] {


### PR DESCRIPTION
- [ ] Added a `CHANGELOG.md` entry

I'm not sure how to do this.

# Summary

Removed `extern crate` decl.

# Motivation

In Rust 2018, `extern crate` is no longer required for imports. Everything else seems to have moved on, so I just removed those 4 lines

# Details

None. Just removed `extern crate alloc` and `extern crate std`
