### PR TITLE
rand_core: relax requirements on the param for `SeedableRng`

### DIFF
--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### API changes
+- Relax `Sized` bound on impls of `SeedableRng` (#1641)
+
 ## [0.9.3] — 2025-02-29
 ### Other
 - Remove `zerocopy` dependency (#1607)

--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -248,12 +248,12 @@ impl<R: BlockRngCore + SeedableRng> SeedableRng for BlockRng<R> {
     }
 
     #[inline(always)]
-    fn from_rng(rng: &mut impl RngCore) -> Self {
+    fn from_rng<S: RngCore + ?Sized>(rng: &mut S) -> Self {
         Self::new(R::from_rng(rng))
     }
 
     #[inline(always)]
-    fn try_from_rng<S: TryRngCore>(rng: &mut S) -> Result<Self, S::Error> {
+    fn try_from_rng<S: TryRngCore + ?Sized>(rng: &mut S) -> Result<Self, S::Error> {
         R::try_from_rng(rng).map(Self::new)
     }
 }
@@ -411,12 +411,12 @@ impl<R: BlockRngCore + SeedableRng> SeedableRng for BlockRng64<R> {
     }
 
     #[inline(always)]
-    fn from_rng(rng: &mut impl RngCore) -> Self {
+    fn from_rng<S: RngCore + ?Sized>(rng: &mut S) -> Self {
         Self::new(R::from_rng(rng))
     }
 
     #[inline(always)]
-    fn try_from_rng<S: TryRngCore>(rng: &mut S) -> Result<Self, S::Error> {
+    fn try_from_rng<S: TryRngCore + ?Sized>(rng: &mut S) -> Result<Self, S::Error> {
         R::try_from_rng(rng).map(Self::new)
     }
 }

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -519,7 +519,7 @@ pub trait SeedableRng: Sized {
     /// (in prior versions this was not required).
     ///
     /// [`rand`]: https://docs.rs/rand
-    fn from_rng(rng: &mut impl RngCore) -> Self {
+    fn from_rng<R: RngCore + ?Sized>(rng: &mut R) -> Self {
         let mut seed = Self::Seed::default();
         rng.fill_bytes(seed.as_mut());
         Self::from_seed(seed)
@@ -528,7 +528,7 @@ pub trait SeedableRng: Sized {
     /// Create a new PRNG seeded from a potentially fallible `Rng`.
     ///
     /// See [`from_rng`][SeedableRng::from_rng] docs for more information.
-    fn try_from_rng<R: TryRngCore>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         let mut seed = Self::Seed::default();
         rng.try_fill_bytes(seed.as_mut())?;
         Ok(Self::from_seed(seed))


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

This relax the `Sized` requirements on `SeedableRng`

# Motivation

Mostly for API consistency

# Details

This is an API break, but this should mostly be transparent as the default implementation is provided.