### PR TITLE
Adapt to chacha20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 
 ## [0.10.0 — Unreleased]
 ### Changes
-- The dependency on `rand_chacha` has been replaced with a dependency on `chacha20`. This changes the implementation behind `StdRng`, but the output remains the same. There may be some API breakage when using the ChaCha-types directly as these are now the ones in `chacha20` instead of `rand_chacha`.
+- The dependency on `rand_chacha` has been replaced with a dependency on `chacha20`. This changes the implementation behind `StdRng`, but the output remains the same. There may be some API breakage when using the ChaCha-types directly as these are now the ones in `chacha20` instead of `rand_chacha` (#1642).
 - Rename fns `IndexedRandom::choose_multiple` -> `sample`, `choose_multiple_array` -> `sample_array`, `choose_multiple_weighted` -> `sample_weighted`, struct `SliceChooseIter` -> `IndexedSamples` and fns `IteratorRandom::choose_multiple` -> `sample`, `choose_multiple_fill` -> `sample_fill` (#1632)
 - Use Edition 2024 and MSRV 1.85 (#1653)
 - Let `Fill` be implemented for element types, not sliceable types (#1652)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 
 ## [0.10.0 — Unreleased]
 ### Changes
+- The dependency on `rand_chacha` has been replaced with a dependency on `chacha20`. This changes the implementation behind `StdRng`, but the output remains the same. There may be some API breakage when using the ChaCha-types directly as these are now the ones in `chacha20` instead of `rand_chacha`.
 - Rename fns `IndexedRandom::choose_multiple` -> `sample`, `choose_multiple_array` -> `sample_array`, `choose_multiple_weighted` -> `sample_weighted`, struct `SliceChooseIter` -> `IndexedSamples` and fns `IteratorRandom::choose_multiple` -> `sample`, `choose_multiple_fill` -> `sample_fill` (#1632)
 - Use Edition 2024 and MSRV 1.85 (#1653)
 - Let `Fill` be implemented for element types, not sliceable types (#1652)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ rand_core = { path = "rand_core" }
 rand_core = { path = "rand_core", version = "0.9.0", default-features = false }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
-chacha20 = { version = "=0.10.0-rc.0", default-features = false, features = ["rng"], optional = true }
+chacha20 = { version = "=0.10.0-rc.1", default-features = false, features = ["rng", "legacy"], optional = true }
 
 [dev-dependencies]
 rand_pcg = { path = "rand_pcg", version = "0.9.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ rand_core = { path = "rand_core" }
 rand_core = { path = "rand_core", version = "0.9.0", default-features = false }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
+# ToDo: Remove the "legacy" feature from chacha20 when this is not longer necessary
 chacha20 = { version = "=0.10.0-rc.1", default-features = false, features = ["rng", "legacy"], optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,7 @@ rand_core = { path = "rand_core" }
 rand_core = { path = "rand_core", version = "0.9.0", default-features = false }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
-# ToDo: Remove the "legacy" feature from chacha20 when this is not longer necessary
-chacha20 = { version = "=0.10.0-rc.1", default-features = false, features = ["rng", "legacy"], optional = true }
+chacha20 = { version = "=0.10.0-rc.2", default-features = false, features = ["rng"], optional = true }
 
 [dev-dependencies]
 rand_pcg = { path = "rand_pcg", version = "0.9.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde = ["dep:serde", "rand_core/serde"]
 
 # Option (enabled by default): without "std" rand uses libcore; this option
 # enables functionality expected to be available on a standard platform.
-std = ["rand_core/std", "rand_chacha?/std", "alloc"]
+std = ["rand_core/std", "alloc"]
 
 # Option: "alloc" enables support for Vec and Box when not using "std"
 alloc = []
@@ -46,7 +46,7 @@ os_rng = ["rand_core/os_rng"]
 simd_support = []
 
 # Option (enabled by default): enable StdRng
-std_rng = ["dep:rand_chacha"]
+std_rng = ["dep:chacha20"]
 
 # Option: enable SmallRng
 small_rng = []
@@ -70,11 +70,16 @@ members = [
 ]
 exclude = ["benches", "distr_test"]
 
+# Force chacha20 to use the local rand_code to avoid compiling two different "rand_core"s.
+# This is necessary even if the specified versions are the same.
+[patch.crates-io]
+rand_core = { path = "rand_core" }
+
 [dependencies]
 rand_core = { path = "rand_core", version = "0.9.0", default-features = false }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
-rand_chacha = { path = "rand_chacha", version = "0.9.0", default-features = false, optional = true }
+chacha20 = { version = "=0.10.0-rc.0", default-features = false, features = ["rng"], optional = true }
 
 [dev-dependencies]
 rand_pcg = { path = "rand_pcg", version = "0.9.0" }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -8,6 +8,11 @@ publish = false
 # Option (requires nightly Rust): experimental SIMD support
 simd_support = ["rand/simd_support"]
 
+# Force chacha20 to use the local rand_code to avoid compiling two different "rand_core"s.
+# This is necessary even if the specified versions are the same.
+[patch.crates-io]
+rand_core = { path = "../rand_core" }
+
 [dependencies]
 
 [dev-dependencies]

--- a/examples/rayon-monte-carlo.rs
+++ b/examples/rayon-monte-carlo.rs
@@ -57,7 +57,7 @@ fn main() {
             // We chose ChaCha because it's fast, has suitable statistical properties for simulation,
             // and because it supports this set_stream() api, which lets us choose a different stream
             // per work item. ChaCha supports 2^64 independent streams.
-            rng.set_stream(u128::from(i));
+            rng.set_stream(u64::from(i));
             let mut count = 0;
             for _ in 0..BATCH_SIZE {
                 let a = range.sample(&mut rng);

--- a/examples/rayon-monte-carlo.rs
+++ b/examples/rayon-monte-carlo.rs
@@ -38,8 +38,9 @@
 //! over BATCH_SIZE trials. Manually batching also turns out to be faster
 //! for the nondeterministic version of this program as well.
 
+use chacha20::ChaCha8Rng;
 use rand::distr::{Distribution, Uniform};
-use rand_chacha::{ChaCha8Rng, rand_core::SeedableRng};
+use rand_core::SeedableRng;
 use rayon::prelude::*;
 
 static SEED: u64 = 0;
@@ -56,7 +57,7 @@ fn main() {
             // We chose ChaCha because it's fast, has suitable statistical properties for simulation,
             // and because it supports this set_stream() api, which lets us choose a different stream
             // per work item. ChaCha supports 2^64 independent streams.
-            rng.set_stream(i);
+            rng.set_stream(u128::from(i));
             let mut count = 0;
             for _ in 0..BATCH_SIZE {
                 let a = range.sample(&mut rng);

--- a/examples/rayon-monte-carlo.rs
+++ b/examples/rayon-monte-carlo.rs
@@ -57,7 +57,7 @@ fn main() {
             // We chose ChaCha because it's fast, has suitable statistical properties for simulation,
             // and because it supports this set_stream() api, which lets us choose a different stream
             // per work item. ChaCha supports 2^64 independent streams.
-            rng.set_stream(u64::from(i));
+            rng.set_stream(i);
             let mut count = 0;
             for _ in 0..BATCH_SIZE {
                 let a = range.sample(&mut rng);

--- a/src/rngs/reseeding.rs
+++ b/src/rngs/reseeding.rs
@@ -53,9 +53,9 @@ use rand_core::{CryptoRng, RngCore, SeedableRng, TryCryptoRng, TryRngCore};
 /// # Example
 ///
 /// ```
+/// use chacha20::ChaCha20Core; // Internal part of ChaChaRng that
+///                             // implements BlockRngCore
 /// use rand::prelude::*;
-/// use rand_chacha::ChaCha20Core; // Internal part of ChaChaRng that
-///                              // implements BlockRngCore
 /// use rand::rngs::OsRng;
 /// use rand::rngs::ReseedingRng;
 ///

--- a/src/rngs/std.rs
+++ b/src/rngs/std.rs
@@ -217,7 +217,7 @@ mod test {
         ];
         let iv = [0x1a, 0xda, 0x31, 0xd5, 0xcf, 0x68, 0x82, 0x21];
         let mut rng = StdRng::from_seed(seed);
-        rng.0.set_stream(u128::from(u64::from_le_bytes(iv)));
+        rng.0.set_stream(u64::from_le_bytes(iv));
 
         let mut results = [0u128; 8];
         rng.fill(&mut results);
@@ -248,7 +248,7 @@ mod test {
         let mut rng = StdRng::from_seed(seed);
         let block = u32::MAX;
         let words_per_block = 16;
-        rng.0.set_word_pos((block as u64) * words_per_block);
+        rng.0.set_word_pos((block as u128) * words_per_block);
 
         let mut results = [0u128; 4 * 6];
         rng.fill(&mut results);
@@ -280,6 +280,6 @@ mod test {
         ];
         assert_eq!(results, expected);
 
-        assert_eq!(rng.0.get_word_pos(), (block as u64) * words_per_block + 96);
+        assert_eq!(rng.0.get_word_pos(), (block as u128) * words_per_block + 96);
     }
 }

--- a/src/rngs/std.rs
+++ b/src/rngs/std.rs
@@ -217,7 +217,7 @@ mod test {
         ];
         let iv = [0x1a, 0xda, 0x31, 0xd5, 0xcf, 0x68, 0x82, 0x21];
         let mut rng = StdRng::from_seed(seed);
-        rng.0.set_stream(u64::from_le_bytes(iv));
+        rng.0.set_stream(u128::from(u64::from_le_bytes(iv)));
 
         let mut results = [0u128; 8];
         rng.fill(&mut results);
@@ -248,7 +248,7 @@ mod test {
         let mut rng = StdRng::from_seed(seed);
         let block = u32::MAX;
         let words_per_block = 16;
-        rng.0.set_word_pos((block as u128) * words_per_block);
+        rng.0.set_word_pos((block as u64) * words_per_block);
 
         let mut results = [0u128; 4 * 6];
         rng.fill(&mut results);
@@ -280,6 +280,6 @@ mod test {
         ];
         assert_eq!(results, expected);
 
-        assert_eq!(rng.0.get_word_pos(), (block as u128) * words_per_block + 96);
+        assert_eq!(rng.0.get_word_pos(), (block as u64) * words_per_block + 96);
     }
 }

--- a/src/rngs/std.rs
+++ b/src/rngs/std.rs
@@ -11,9 +11,9 @@
 use rand_core::{CryptoRng, RngCore, SeedableRng};
 
 #[cfg(any(test, feature = "os_rng"))]
-pub(crate) use rand_chacha::ChaCha12Core as Core;
+pub(crate) use chacha20::ChaCha12Core as Core;
 
-use rand_chacha::ChaCha12Rng as Rng;
+use chacha20::ChaCha12Rng as Rng;
 
 /// A strong, fast (amortized), non-portable RNG
 ///


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Replaced the dependency on `rand_chacha` with one on `chacha20`. Added some tests to `std.rs` to ensure that the output of `StdRng` did not change.

Fixes #934.

# Motivation

Reduces total code size and the total amount of unsafe code.

# Details

Changes to config.toml and some replacement of `rand_chacha::` with `chacha20::`.

Added three new unit tests to std.rs. These were based on tests of IETF test vectors from `rand_chacha`, but the actual `expected` values had to be replaced, as the IETF test vectors are for ChaCha20 while `rand` uses ChaCha12. The `expected` values were generated by using `rand_chacha` (before `chacha20` was used) to verify that the algorithm change did not affect the output.