### PR TITLE
Inherit common package properties from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,35 @@
+[workspace]
+members = [
+    "rand_core",
+    "rand_chacha",
+    "rand_pcg",
+]
+exclude = ["benches", "distr_test"]
+
+[workspace.package]
+repository = "https://github.com/rust-random/rand"
+homepage = "https://rust-random.github.io/book"
+rust-version = "1.63"
+edition = "2021"
+
 [package]
 name = "rand"
 version = "0.9.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/rust-random/rand"
 documentation = "https://docs.rs/rand"
-homepage = "https://rust-random.github.io/book"
 description = """
 Random number generators and other randomness functionality.
 """
 keywords = ["random", "rng"]
 categories = ["algorithms", "no-std"]
 autobenches = true
-edition = "2021"
-rust-version = "1.63"
 include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
+repository.workspace = true
+homepage.workspace = true
+rust-version.workspace = true
+edition.workspace = true
 
 [package.metadata.docs.rs]
 # To build locally:
@@ -61,14 +75,6 @@ unbiased = []
 
 # Option: enable logging
 log = ["dep:log"]
-
-[workspace]
-members = [
-    "rand_core",
-    "rand_chacha",
-    "rand_pcg",
-]
-exclude = ["benches", "distr_test"]
 
 [dependencies]
 rand_core = { path = "rand_core", version = "0.9.0", default-features = false }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "benches"
 version = "0.1.0"
-edition = "2021"
 publish = false
+rust-version.workspace = true
+edition.workspace = true
 
 [features]
 # Option (requires nightly Rust): experimental SIMD support

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -4,16 +4,16 @@ version = "0.9.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers", "The CryptoCorrosion Contributors"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/rust-random/rand"
 documentation = "https://docs.rs/rand_chacha"
-homepage = "https://rust-random.github.io/book"
 description = """
 ChaCha random number generator
 """
 keywords = ["random", "rng", "chacha"]
 categories = ["algorithms", "no-std"]
-edition = "2021"
-rust-version = "1.63"
+repository.workspace = true
+homepage.workspace = true
+rust-version.workspace = true
+edition.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -4,16 +4,16 @@ version = "0.9.3"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/rust-random/rand"
 documentation = "https://docs.rs/rand_core"
-homepage = "https://rust-random.github.io/book"
 description = """
 Core random number generator traits and tools for implementation.
 """
 keywords = ["random", "rng"]
 categories = ["algorithms", "no-std"]
-edition = "2021"
-rust-version = "1.63"
+repository.workspace = true
+homepage.workspace = true
+rust-version.workspace = true
+edition.workspace = true
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -4,16 +4,16 @@ version = "0.9.0"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/rust-random/rand"
 documentation = "https://docs.rs/rand_pcg"
-homepage = "https://rust-random.github.io/book"
 description = """
 Selected PCG random number generators
 """
 keywords = ["random", "rng", "pcg"]
 categories = ["algorithms", "no-std"]
-edition = "2021"
-rust-version = "1.63"
+repository.workspace = true
+homepage.workspace = true
+rust-version.workspace = true
+edition.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
# Summary

Reduce repetition; make MSRV / Edition changes simpler.

`authors` was omitted since it varies; `license` was omitted for clarity and since we don't want to change it anyway.