### PR TITLE
`examples/print-next.rs`

### DIFF
--- a/examples/print-next.rs
+++ b/examples/print-next.rs
@@ -1,0 +1,7 @@
+use rand::RngCore;
+
+fn main() {
+    let mut rng = rand::rng();
+    println!("Next u32: {0:>#18X} = {0:>20}", rng.next_u32());
+    println!("Next u64: {0:>#18X} = {0:>20}", rng.next_u64());
+}


### PR DESCRIPTION
Sometimes you just want a random number. It seems strange that we didn't already have a handy example to print this:
```
Next u32:           1035878085 = 0x3DBE3EC5
Next u64:  9250892210303435489 = 0x8061C573B29082E1
```

Also a fix for the new `mismatched_lifetime_syntaxes` lint.