### PR TITLE
Let Fill target element types; move to rand_core; support min_specialization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: rand
         run: cargo doc --all-features --no-deps
       - name: rand_core
-        run: cargo doc --all-features --package rand_core --no-deps
+        run: cargo doc --features std,os_rng,serde --package rand_core --no-deps
       - name: rand_chacha
         run: cargo doc --all-features --package rand_chacha --no-deps
       - name: rand_pcg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 ## Additions
 - Pub export `Xoshiro128PlusPlus`, `Xoshiro256PlusPlus` prngs (#1649)
 
+### Changes
+- Move `Fill` trait to `rand_core` (#1651)
+
 ## [0.9.2 — 2025-07-20]
 ### Deprecated
 - Deprecate `rand::rngs::mock` module and `StepRng` generator (#1634)

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Additions
+- Add `Fill` trait (#1651)
+
 ## [0.9.3] — 2025-02-29
 ### Other
 - Remove `zerocopy` dependency (#1607)

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -27,7 +27,13 @@ all-features = true
 [features]
 std = ["getrandom?/std"]
 os_rng = ["dep:getrandom"]
-serde = ["dep:serde"] # enables serde for BlockRng wrapper
+
+# Enable serde for BlockRng wrapper
+serde = ["dep:serde"]
+
+# Enable specialization of Fill for RNGs
+# This is an unstable feature!
+min_specialization = []
 
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -17,8 +17,8 @@ rust-version = "1.63"
 
 [package.metadata.docs.rs]
 # To build locally:
-# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --open
-all-features = true
+# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --features std,os_rng,serde --no-deps --open
+features = ["std", "os_rng", "serde"]
 rustdoc-args = ["--generate-link-to-definition"]
 
 [package.metadata.playground]

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -34,6 +34,9 @@ serde = ["dep:serde"]
 # Enable specialization of Fill for RNGs
 # This is an unstable feature!
 min_specialization = []
+# Enable specialized Fill impls for BlockRng
+# This requires an even less stable feature!
+specialization = ["min_specialization"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }

--- a/rand_core/src/block.rs
+++ b/rand_core/src/block.rs
@@ -234,6 +234,24 @@ impl<R: BlockRngCore<Item = u32>> RngCore for BlockRng<R> {
     }
 }
 
+#[cfg(feature = "specialization")]
+impl<R: BlockRngCore<Item = u32>> crate::Fill<BlockRng<R>> for u32 {
+    fn fill_slice(mut this: &mut [Self], rng: &mut BlockRng<R>) {
+        while !this.is_empty() {
+            if rng.index >= rng.results.as_ref().len() {
+                rng.generate_and_set(0);
+            }
+
+            let len = core::cmp::min(this.len(), rng.results.as_ref().len() - rng.index);
+            let next_index = rng.index + len;
+            this[..len].copy_from_slice(&rng.results.as_ref()[rng.index..next_index]);
+
+            rng.index = next_index;
+            this = &mut this[len..];
+        }
+    }
+}
+
 impl<R: BlockRngCore + SeedableRng> SeedableRng for BlockRng<R> {
     type Seed = R::Seed;
 
@@ -393,6 +411,24 @@ impl<R: BlockRngCore<Item = u64>> RngCore for BlockRng64<R> {
 
             self.index += consumed_u64;
             read_len += filled_u8;
+        }
+    }
+}
+
+#[cfg(feature = "specialization")]
+impl<R: BlockRngCore<Item = u64>> crate::Fill<BlockRng64<R>> for u64 {
+    fn fill_slice(mut this: &mut [Self], rng: &mut BlockRng64<R>) {
+        while !this.is_empty() {
+            if rng.index >= rng.results.as_ref().len() {
+                rng.generate_and_set(0);
+            }
+
+            let len = core::cmp::min(this.len(), rng.results.as_ref().len() - rng.index);
+            let next_index = rng.index + len;
+            this[..len].copy_from_slice(&rng.results.as_ref()[rng.index..next_index]);
+
+            rng.index = next_index;
+            this = &mut this[len..];
         }
     }
 }

--- a/rand_core/src/fill.rs
+++ b/rand_core/src/fill.rs
@@ -1,0 +1,108 @@
+// Copyright 2025 Developers of the Rand project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! `Fill` trait
+
+use super::RngCore;
+use core::num::Wrapping;
+use core::{mem, slice};
+
+/// Support filling a slice with random data
+///
+/// This trait allows slices of "plain data" types to be efficiently filled
+/// with random data.
+///
+/// Implementations are expected to be portable across machines unless
+/// clearly documented otherwise (see the
+/// [Chapter on Portability](https://rust-random.github.io/book/portability.html)).
+/// The implementations provided achieve this by byte-swapping on big-endian
+/// machines.
+pub trait Fill: Sized {
+    /// Fill this with random data
+    fn fill<R: RngCore + ?Sized>(this: &mut [Self], rng: &mut R);
+}
+
+impl Fill for u8 {
+    fn fill<R: RngCore + ?Sized>(this: &mut [Self], rng: &mut R) {
+        rng.fill_bytes(this)
+    }
+}
+
+/// Call target for unsafe macros
+const unsafe fn __unsafe() {}
+
+/// Implement `Fill` for given type `$t`.
+///
+/// # Safety
+/// All bit patterns of `[u8; size_of::<$t>()]` must represent values of `$t`.
+macro_rules! impl_fill {
+    () => {};
+    ($t:ty) => {{
+        // Force caller to wrap with an `unsafe` block
+        __unsafe();
+
+        impl Fill for $t {
+            fn fill<R: RngCore + ?Sized>(this: &mut [Self], rng: &mut R) {
+                if this.len() > 0 {
+                    let size = mem::size_of_val(this);
+                    rng.fill_bytes(
+                        // SAFETY: `this` non-null and valid for reads and writes within its `size`
+                        // bytes. `this` meets the alignment requirements of `&mut [u8]`.
+                        // The contents of `this` are initialized. Both `[u8]` and `[$t]` are valid
+                        // for all bit-patterns of their contents (note that the SAFETY requirement
+                        // on callers of this macro). `this` is not borrowed.
+                        unsafe {
+                            slice::from_raw_parts_mut(this.as_mut_ptr()
+                                as *mut u8,
+                                size
+                            )
+                        }
+                    );
+                    for x in this {
+                        *x = x.to_le();
+                    }
+                }
+            }
+        }
+
+        impl Fill for Wrapping<$t> {
+            fn fill<R: RngCore + ?Sized>(this: &mut [Self], rng: &mut R) {
+                if this.len() > 0 {
+                    let size = this.len() * mem::size_of::<$t>();
+                    rng.fill_bytes(
+                        // SAFETY: `this` non-null and valid for reads and writes within its `size`
+                        // bytes. `this` meets the alignment requirements of `&mut [u8]`.
+                        // The contents of `this` are initialized. Both `[u8]` and `[$t]` are valid
+                        // for all bit-patterns of their contents (note that the SAFETY requirement
+                        // on callers of this macro). `this` is not borrowed.
+                        unsafe {
+                            slice::from_raw_parts_mut(this.as_mut_ptr()
+                                as *mut u8,
+                                size
+                            )
+                        }
+                    );
+                    for x in this {
+                        *x = Wrapping(x.0.to_le());
+                    }
+                }
+            }
+        }}
+    };
+    ($t:ty, $($tt:ty,)*) => {{
+        impl_fill!($t);
+        // TODO: this could replace above impl once Rust #32463 is fixed
+        // impl_fill!(Wrapping<$t>);
+        impl_fill!($($tt,)*);
+    }}
+}
+
+// SAFETY: All bit patterns of `[u8; size_of::<$t>()]` represent values of `u*`.
+const _: () = unsafe { impl_fill!(u16, u32, u64, u128,) };
+// SAFETY: All bit patterns of `[u8; size_of::<$t>()]` represent values of `i*`.
+const _: () = unsafe { impl_fill!(i8, i16, i32, i64, i128,) };

--- a/rand_core/src/fill.rs
+++ b/rand_core/src/fill.rs
@@ -24,11 +24,11 @@ use core::{mem, slice};
 /// machines.
 pub trait Fill: Sized {
     /// Fill this with random data
-    fn fill<R: RngCore + ?Sized>(this: &mut [Self], rng: &mut R);
+    fn fill_slice<R: RngCore + ?Sized>(this: &mut [Self], rng: &mut R);
 }
 
 impl Fill for u8 {
-    fn fill<R: RngCore + ?Sized>(this: &mut [Self], rng: &mut R) {
+    fn fill_slice<R: RngCore + ?Sized>(this: &mut [Self], rng: &mut R) {
         rng.fill_bytes(this)
     }
 }
@@ -47,7 +47,7 @@ macro_rules! impl_fill {
         __unsafe();
 
         impl Fill for $t {
-            fn fill<R: RngCore + ?Sized>(this: &mut [Self], rng: &mut R) {
+            fn fill_slice<R: RngCore + ?Sized>(this: &mut [Self], rng: &mut R) {
                 if this.len() > 0 {
                     let size = mem::size_of_val(this);
                     rng.fill_bytes(
@@ -71,7 +71,7 @@ macro_rules! impl_fill {
         }
 
         impl Fill for Wrapping<$t> {
-            fn fill<R: RngCore + ?Sized>(this: &mut [Self], rng: &mut R) {
+            fn fill_slice<R: RngCore + ?Sized>(this: &mut [Self], rng: &mut R) {
                 if this.len() > 0 {
                     let size = this.len() * mem::size_of::<$t>();
                     rng.fill_bytes(

--- a/rand_core/src/fill.rs
+++ b/rand_core/src/fill.rs
@@ -22,13 +22,13 @@ use core::{mem, slice};
 /// [Chapter on Portability](https://rust-random.github.io/book/portability.html)).
 /// The implementations provided achieve this by byte-swapping on big-endian
 /// machines.
-pub trait Fill: Sized {
+pub trait Fill<R: RngCore + ?Sized>: Sized {
     /// Fill this with random data
-    fn fill_slice<R: RngCore + ?Sized>(this: &mut [Self], rng: &mut R);
+    fn fill_slice(this: &mut [Self], rng: &mut R);
 }
 
-impl Fill for u8 {
-    fn fill_slice<R: RngCore + ?Sized>(this: &mut [Self], rng: &mut R) {
+impl<R: RngCore + ?Sized> Fill<R> for u8 {
+    fn fill_slice(this: &mut [Self], rng: &mut R) {
         rng.fill_bytes(this)
     }
 }
@@ -46,8 +46,8 @@ macro_rules! impl_fill {
         // Force caller to wrap with an `unsafe` block
         __unsafe();
 
-        impl Fill for $t {
-            fn fill_slice<R: RngCore + ?Sized>(this: &mut [Self], rng: &mut R) {
+        impl<R: RngCore + ?Sized> Fill<R> for $t {
+            fn fill_slice(this: &mut [Self], rng: &mut R) {
                 if this.len() > 0 {
                     let size = mem::size_of_val(this);
                     rng.fill_bytes(
@@ -70,8 +70,8 @@ macro_rules! impl_fill {
             }
         }
 
-        impl Fill for Wrapping<$t> {
-            fn fill_slice<R: RngCore + ?Sized>(this: &mut [Self], rng: &mut R) {
+        impl<R: RngCore + ?Sized> Fill<R> for Wrapping<$t> {
+            fn fill_slice(this: &mut [Self], rng: &mut R) {
                 if this.len() > 0 {
                     let size = this.len() * mem::size_of::<$t>();
                     rng.fill_bytes(

--- a/rand_core/src/fill.rs
+++ b/rand_core/src/fill.rs
@@ -82,16 +82,16 @@ macro_rules! impl_fill {
         __unsafe();
 
         impl<R: RngCore + ?Sized> Fill<R> for $t {
-            #[cfg(feature = "min_specialization")]
+            #[cfg(any(feature = "min_specialization", feature = "specialization"))]
             impl_fill!(fill_slice! $t, plain default);
-            #[cfg(not(feature = "min_specialization"))]
+            #[cfg(not(any(feature = "min_specialization", feature = "specialization")))]
             impl_fill!(fill_slice! $t, plain);
         }
 
         impl<R: RngCore + ?Sized> Fill<R> for Wrapping<$t> {
-            #[cfg(feature = "min_specialization")]
+            #[cfg(any(feature = "min_specialization", feature = "specialization"))]
             impl_fill!(fill_slice! $t, wrapping default);
-            #[cfg(not(feature = "min_specialization"))]
+            #[cfg(not(any(feature = "min_specialization", feature = "specialization")))]
             impl_fill!(fill_slice! $t, wrapping);
         }}
     };

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -35,6 +35,7 @@
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]
+#![cfg_attr(feature = "min_specialization", feature(min_specialization))]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -35,7 +35,11 @@
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]
-#![cfg_attr(feature = "min_specialization", feature(min_specialization))]
+#![cfg_attr(feature = "specialization", feature(specialization))]
+#![cfg_attr(
+    all(feature = "min_specialization", not(feature = "specialization")),
+    feature(min_specialization)
+)]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -42,11 +42,13 @@ extern crate std;
 use core::{fmt, ops::DerefMut};
 
 pub mod block;
+mod fill;
 pub mod impls;
 pub mod le;
 #[cfg(feature = "os_rng")]
 mod os;
 
+pub use fill::Fill;
 #[cfg(feature = "os_rng")]
 pub use os::{OsError, OsRng};
 

--- a/rand_core/tests/fill.rs
+++ b/rand_core/tests/fill.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 #![allow(unused)]
+#![cfg_attr(feature = "min_specialization", feature(min_specialization))]
 
 use rand_core::{Fill, RngCore};
 
@@ -14,6 +15,26 @@ use rand_core::{Fill, RngCore};
 struct MyInt(i32);
 impl<R: RngCore + ?Sized> Fill<R> for MyInt {
     fn fill_slice(this: &mut [Self], rng: &mut R) {
+        todo!()
+    }
+}
+
+// Test specialization on a local RNG
+struct MyRng;
+impl RngCore for MyRng {
+    fn next_u32(&mut self) -> u32 {
+        todo!()
+    }
+    fn next_u64(&mut self) -> u64 {
+        todo!()
+    }
+    fn fill_bytes(&mut self, _: &mut [u8]) {
+        todo!()
+    }
+}
+#[cfg(feature = "min_specialization")]
+impl Fill<MyRng> for u64 {
+    fn fill_slice(this: &mut [Self], rng: &mut MyRng) {
         todo!()
     }
 }

--- a/rand_core/tests/fill.rs
+++ b/rand_core/tests/fill.rs
@@ -1,0 +1,19 @@
+// Copyright 2025 Developers of the Rand project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(unused)]
+
+use rand_core::{Fill, RngCore};
+
+// Test that Fill may be implemented for externally-defined types
+struct MyInt(i32);
+impl<R: RngCore + ?Sized> Fill<R> for MyInt {
+    fn fill_slice(this: &mut [Self], rng: &mut R) {
+        todo!()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,7 +294,7 @@ pub fn random_ratio(numerator: u32, denominator: u32) -> bool {
 #[inline]
 #[track_caller]
 pub fn fill<T: Fill>(dest: &mut [T]) {
-    Fill::fill(dest, &mut rng())
+    Fill::fill_slice(dest, &mut rng())
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,7 @@ pub fn random_ratio(numerator: u32, denominator: u32) -> bool {
 #[cfg(feature = "thread_rng")]
 #[inline]
 #[track_caller]
-pub fn fill<T: Fill>(dest: &mut [T]) {
+pub fn fill<T: Fill<rngs::ThreadRng>>(dest: &mut [T]) {
     Fill::fill_slice(dest, &mut rng())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ macro_rules! error { ($($x:tt)*) => (
 pub use rand_core;
 
 // Re-exports from rand_core
-pub use rand_core::{CryptoRng, RngCore, SeedableRng, TryCryptoRng, TryRngCore};
+pub use rand_core::{CryptoRng, Fill, RngCore, SeedableRng, TryCryptoRng, TryRngCore};
 
 // Public modules
 pub mod distr;
@@ -124,7 +124,7 @@ pub fn thread_rng() -> crate::rngs::ThreadRng {
     rng()
 }
 
-pub use rng::{Fill, Rng};
+pub use rng::Rng;
 
 #[cfg(feature = "thread_rng")]
 use crate::distr::{Distribution, StandardUniform};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,8 +293,8 @@ pub fn random_ratio(numerator: u32, denominator: u32) -> bool {
 #[cfg(feature = "thread_rng")]
 #[inline]
 #[track_caller]
-pub fn fill<T: Fill + ?Sized>(dest: &mut T) {
-    dest.fill(&mut rng())
+pub fn fill<T: Fill>(dest: &mut [T]) {
+    Fill::fill(dest, &mut rng())
 }
 
 #[cfg(test)]

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -309,7 +309,7 @@ pub trait Rng: RngCore {
     ///
     /// [`fill_bytes`]: RngCore::fill_bytes
     #[track_caller]
-    fn fill<T: Fill>(&mut self, dest: &mut [T]) {
+    fn fill<T: Fill<Self>>(&mut self, dest: &mut [T]) {
         Fill::fill_slice(dest, self)
     }
 

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -368,25 +368,6 @@ pub trait Fill {
     fn fill<R: Rng + ?Sized>(&mut self, rng: &mut R);
 }
 
-macro_rules! impl_fill_each {
-    () => {};
-    ($t:ty) => {
-        impl Fill for [$t] {
-            fn fill<R: Rng + ?Sized>(&mut self, rng: &mut R) {
-                for elt in self.iter_mut() {
-                    *elt = rng.random();
-                }
-            }
-        }
-    };
-    ($t:ty, $($tt:ty,)*) => {
-        impl_fill_each!($t);
-        impl_fill_each!($($tt,)*);
-    };
-}
-
-impl_fill_each!(bool, char, f32, f64,);
-
 impl Fill for [u8] {
     fn fill<R: Rng + ?Sized>(&mut self, rng: &mut R) {
         rng.fill_bytes(self)
@@ -525,12 +506,6 @@ mod test {
         rng.fill(&mut warray[..]);
         assert_eq!(array[0], warray[0].0);
         assert_eq!(array[1], warray[1].0);
-
-        // Check equivalence for generated floats
-        let mut array = [0f32; 2];
-        rng.fill(&mut array);
-        let arr2: [f32; 2] = rng.random();
-        assert_eq!(array, arr2);
     }
 
     #[test]

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -310,7 +310,7 @@ pub trait Rng: RngCore {
     /// [`fill_bytes`]: RngCore::fill_bytes
     #[track_caller]
     fn fill<T: Fill>(&mut self, dest: &mut [T]) {
-        Fill::fill(dest, self)
+        Fill::fill_slice(dest, self)
     }
 
     /// Alias for [`Rng::random`].


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

- Restrict provided `Fill` impls to types safely reinterpretable as a byte-slice. This removes additional capability gained in #940.
- Change impl target of `Fill` to the element type, not slice/array. This supports external impls on externally-defined types. Fixes #1650.
- Move to `rand_core` crate, rename, move RNG generic parameter to trait
- Support `min_specialization` for RNGs

# Motivation

This trait was added to fill a capability gap: a safe interface for fast filling of slices like `[i16]`. The impls for `[bool]`, `[f32]` etc. are extra complexity beyond this and unnecessary since they offer no benefit over element-wise generation in user-code.

Further, we can now support specialization like this:
```rust
struct MyRng;

impl RngCore for MyRng {
    // [method impls omitted]
}

#[cfg(feature = "min_specialization")]
impl Fill<MyRng> for u64 {
    fn fill_slice(this: &mut [Self], rng: &mut MyRng) {
        todo!()
    }
}
```

# Alternatives

The specialization option motivated removal of support for element-wise types (`[f32]` etc.), moving to `rand_core` and moving the generics to the trait. I don't think any of these are bad changes however.

### Via RngCore

We could add `fill_u32_slice`, `fill_u64_slice` to `RngCore`. Adding these methods would be more disruptive, but possibly more useful overall (`dyn` trait support, no dependence on unstable features).

### Forget these specializations

... there's no strong evidence we need them.