### PR TITLE
Prepare 0.10.0-rc.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.9.2"
+version = "0.10.0-rc.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
I checked repo history; doesn't look like anything is missing from the CHANGELOG.

The only significant change outside the `rand` crate is #1641 which is technically a breaking change to `rand_core`, but it doesn't look like it will affect any of our implementations, so I think we're safe ignoring this discrepancy between `master` and `rand_core v0.9.3` (everything else should be using the published version anyway).

*Insignificant* changes include #1653 which affects `rand_pcg`, but I see no need for a new release of that crate.

`rand_distr` will require an update; lets publish a `rand` pre-release first then update `rand_distr` to use that.