### PR TITLE
Implement `Distribution` for `hybrid_array::Array`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Add fns `IndexedRandom::choose_iter`, `choose_weighted_iter` (#1632)
 - Pub export `Xoshiro128PlusPlus`, `Xoshiro256PlusPlus` prngs (#1649)
 - Pub export `ChaCha8Rng`, `ChaCha12Rng`, `ChaCha20Rng` behind `chacha` feature (#1659)
+- Implement `Distribution` for `hybrid_array::Array` behind `hybrid-array` feature (#1663)
 
 ## [0.9.2 — 2025-07-20]
 ### Deprecated

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,9 @@ unbiased = []
 # Option: enable logging
 log = ["dep:log"]
 
+# Option: implement `Distribution` for `hybrid_array::Array`
+hybrid-array = ["dep:hybrid-array"]
+
 [workspace]
 members = [
     "rand_core",
@@ -79,6 +82,7 @@ exclude = ["benches", "distr_test"]
 rand_core = { path = "rand_core" }
 
 [dependencies]
+hybrid-array = { version = "0.4", optional = true }
 rand_core = { path = "rand_core", version = "0.9.0", default-features = false }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Additionally, these features configure Rand:
 -   `simd_support` (experimental) enables sampling of SIMD values
     (uniformly random SIMD integers and floats), requiring nightly Rust
 -   `unbiased` use unbiased sampling for algorithms supporting this option: Uniform distribution.
+-   `hybrid-array` implement `Distribution` for `hybrid_array::Array`
 
     (By default, bias affecting no more than one in  2^48 samples is accepted.)
 

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -302,6 +302,17 @@ where
     }
 }
 
+#[cfg(feature = "hybrid-array")]
+impl<T, L: hybrid_array::ArraySize> Distribution<hybrid_array::Array<T, L>> for StandardUniform
+where
+    StandardUniform: Distribution<T>,
+{
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> hybrid_array::Array<T, L> {
+        hybrid_array::Array::from_fn(|_| rng.random())
+    }
+}
+
 impl<T> Distribution<Wrapping<T>> for StandardUniform
 where
     StandardUniform: Distribution<T>,


### PR DESCRIPTION
This PR implements `Distribution<hybrid_array::Array<T, L>> for StandardUniform` behind a new `hybrid-array` crate feature.

This is unusual, because `rand` doesn't implement `Distribution` for any external types. However, because `rand` depends on `chacha20`, which has `hybrid-array` in its dependency tree, it isn't possible for `hybrid-array` to do this implementation themselves.

Resolves #1662.