### PR TITLE
chore: Replace `doc_auto_cfg` with `doc_cfg`

### DIFF
--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -33,7 +33,7 @@
 #![deny(missing_debug_implementations)]
 #![deny(clippy::undocumented_unsafe_blocks)]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
     all(feature = "simd_support", target_feature = "avx512bw"),
     feature(stdarch_x86_avx512)
 )]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(
     clippy::float_cmp,
     clippy::neg_cmp_op_on_partial_ord,


### PR DESCRIPTION
- [ ] Added a `CHANGELOG.md` entry

# Summary

Replace the removed `doc_auto_cfg` feature with the `doc_cfg` feature.

# Motivation

Avoid compilation errors when building documentation.

# Details

`doc_auto_cfg` was merged into `doc_cfg` in rust-lang/rust#138907.

When `docsrs` is enabled, the old `doc_auto_cfg` results in the following errors on the latest nightlies:

```
error[E0557]: feature has been removed
  --> src/lib.rs:56:29
   |
56 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
   |                             ^^^^^^^^^^^^ feature has been removed
   |
   = note: removed in CURRENT_RUSTC_VERSION; see <https://github.com/rust-lang/rust/pull/138907> for more information
   = note: merged into `doc_cfg`
```

```
error[E0557]: feature has been removed
  --> rand_core/src/lib.rs:36:29
   |
36 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
   |                             ^^^^^^^^^^^^ feature has been removed
   |
   = note: removed in CURRENT_RUSTC_VERSION; see <https://github.com/rust-lang/rust/pull/138907> for more information
   = note: merged into `doc_cfg`
```

The new `doc_cfg` retains the automatic `cfg` generation that `doc_auto_cfg` used to provide.