### PR TITLE
rand_core: introduce `Seed` trait

### DIFF
--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -407,7 +407,7 @@ pub trait SeedableRng: Sized {
             x.to_le_bytes()
         }
 
-        let seed = Self::Seed::from_bytes(|buf| {
+        let seed = Self::Seed::from_fill(|buf| {
             let mut iter = buf.chunks_exact_mut(4);
             for chunk in &mut iter {
                 chunk.copy_from_slice(&pcg32(&mut state));
@@ -446,7 +446,7 @@ pub trait SeedableRng: Sized {
     ///
     /// [`rand`]: https://docs.rs/rand
     fn from_rng<R: RngCore + ?Sized>(rng: &mut R) -> Self {
-        let Ok(seed) = Self::Seed::try_from_bytes(|buf| rng.try_fill_bytes(buf));
+        let Ok(seed) = Self::Seed::try_from_fill(|buf| rng.try_fill_bytes(buf));
         Self::from_seed(seed)
     }
 
@@ -454,7 +454,7 @@ pub trait SeedableRng: Sized {
     ///
     /// See [`from_rng`][SeedableRng::from_rng] docs for more information.
     fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        let seed = Self::Seed::try_from_bytes(|buf| rng.try_fill_bytes(buf))?;
+        let seed = Self::Seed::try_from_fill(|buf| rng.try_fill_bytes(buf))?;
         Ok(Self::from_seed(seed))
     }
 
@@ -494,7 +494,7 @@ pub trait SeedableRng: Sized {
     /// [`getrandom`]: https://docs.rs/getrandom
     #[cfg(feature = "os_rng")]
     fn try_from_os_rng() -> Result<Self, getrandom::Error> {
-        let seed = Self::Seed::try_from_bytes(getrandom::fill)?;
+        let seed = Self::Seed::try_from_fill(getrandom::fill)?;
         Ok(Self::from_seed(seed))
     }
 }

--- a/rand_core/src/seed.rs
+++ b/rand_core/src/seed.rs
@@ -1,0 +1,48 @@
+/// Trait implemented by types used for seeding PRNG.
+///
+/// This crate provides implementations for `[u8; N]`, `u32`, `u64`, and `u128`.
+pub trait Seed: Sized {
+    /// Create seed from a fallible closure which fills the provided buffer.
+    fn try_from_bytes<E>(fill: impl FnOnce(&mut [u8]) -> Result<(), E>) -> Result<Self, E>;
+
+    /// Create seed from an infallible closure which fills the provided buffer.
+    fn from_bytes(fill: impl FnOnce(&mut [u8])) -> Self {
+        let Ok(seed) = Self::try_from_bytes::<core::convert::Infallible>(|buf| {
+            fill(buf);
+            Ok(())
+        });
+        seed
+    }
+}
+
+impl<const N: usize> Seed for [u8; N] {
+    fn try_from_bytes<E>(fill: impl FnOnce(&mut [u8]) -> Result<(), E>) -> Result<Self, E> {
+        let mut buf = [0u8; N];
+        fill(&mut buf)?;
+        Ok(buf)
+    }
+}
+
+impl Seed for u32 {
+    fn try_from_bytes<E>(fill: impl FnOnce(&mut [u8]) -> Result<(), E>) -> Result<Self, E> {
+        let mut buf = [0u8; 4];
+        fill(&mut buf)?;
+        Ok(u32::from_le_bytes(buf))
+    }
+}
+
+impl Seed for u64 {
+    fn try_from_bytes<E>(fill: impl FnOnce(&mut [u8]) -> Result<(), E>) -> Result<Self, E> {
+        let mut buf = [0u8; 8];
+        fill(&mut buf)?;
+        Ok(u64::from_le_bytes(buf))
+    }
+}
+
+impl Seed for u128 {
+    fn try_from_bytes<E>(fill: impl FnOnce(&mut [u8]) -> Result<(), E>) -> Result<Self, E> {
+        let mut buf = [0u8; 16];
+        fill(&mut buf)?;
+        Ok(u128::from_le_bytes(buf))
+    }
+}

--- a/rand_core/src/seed.rs
+++ b/rand_core/src/seed.rs
@@ -3,11 +3,11 @@
 /// This crate provides implementations for `[u8; N]`, `u32`, `u64`, and `u128`.
 pub trait Seed: Sized {
     /// Create seed from a fallible closure which fills the provided buffer.
-    fn try_from_bytes<E>(fill: impl FnOnce(&mut [u8]) -> Result<(), E>) -> Result<Self, E>;
+    fn try_from_fill<E>(fill: impl FnOnce(&mut [u8]) -> Result<(), E>) -> Result<Self, E>;
 
     /// Create seed from an infallible closure which fills the provided buffer.
-    fn from_bytes(fill: impl FnOnce(&mut [u8])) -> Self {
-        let Ok(seed) = Self::try_from_bytes::<core::convert::Infallible>(|buf| {
+    fn from_fill(fill: impl FnOnce(&mut [u8])) -> Self {
+        let Ok(seed) = Self::try_from_fill::<core::convert::Infallible>(|buf| {
             fill(buf);
             Ok(())
         });
@@ -16,7 +16,7 @@ pub trait Seed: Sized {
 }
 
 impl<const N: usize> Seed for [u8; N] {
-    fn try_from_bytes<E>(fill: impl FnOnce(&mut [u8]) -> Result<(), E>) -> Result<Self, E> {
+    fn try_from_fill<E>(fill: impl FnOnce(&mut [u8]) -> Result<(), E>) -> Result<Self, E> {
         let mut buf = [0u8; N];
         fill(&mut buf)?;
         Ok(buf)
@@ -24,7 +24,7 @@ impl<const N: usize> Seed for [u8; N] {
 }
 
 impl Seed for u32 {
-    fn try_from_bytes<E>(fill: impl FnOnce(&mut [u8]) -> Result<(), E>) -> Result<Self, E> {
+    fn try_from_fill<E>(fill: impl FnOnce(&mut [u8]) -> Result<(), E>) -> Result<Self, E> {
         let mut buf = [0u8; 4];
         fill(&mut buf)?;
         Ok(u32::from_le_bytes(buf))
@@ -32,7 +32,7 @@ impl Seed for u32 {
 }
 
 impl Seed for u64 {
-    fn try_from_bytes<E>(fill: impl FnOnce(&mut [u8]) -> Result<(), E>) -> Result<Self, E> {
+    fn try_from_fill<E>(fill: impl FnOnce(&mut [u8]) -> Result<(), E>) -> Result<Self, E> {
         let mut buf = [0u8; 8];
         fill(&mut buf)?;
         Ok(u64::from_le_bytes(buf))
@@ -40,7 +40,7 @@ impl Seed for u64 {
 }
 
 impl Seed for u128 {
-    fn try_from_bytes<E>(fill: impl FnOnce(&mut [u8]) -> Result<(), E>) -> Result<Self, E> {
+    fn try_from_fill<E>(fill: impl FnOnce(&mut [u8]) -> Result<(), E>) -> Result<Self, E> {
         let mut buf = [0u8; 16];
         fill(&mut buf)?;
         Ok(u128::from_le_bytes(buf))


### PR DESCRIPTION
This resolves the issue with longer arrays, makes the code slightly more concise, and allows to use `u32`/`u64`/`u128` as seeds.

Discussed in rust-random/rand#1643 and rust-random/core#13.