### PR TITLE
Bump rand_core version to 0.10.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ exclude = ["benches", "distr_test"]
 rand_core = { path = "rand_core" }
 
 [dependencies]
-rand_core = { path = "rand_core", version = "0.9.0", default-features = false }
+rand_core = { path = "rand_core", version = "0.10.0-rc.1", default-features = false }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 chacha20 = { version = "=0.10.0-rc.2", default-features = false, features = ["rng"], optional = true }

--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -20,14 +20,13 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition"]
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "0.9.0" }
+rand_core = { path = "../rand_core", version = "0.10.0-rc.1" }
 ppv-lite86 = { version = "0.2.14", default-features = false, features = ["simd"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 # Only to test serde
 serde_json = "1.0.120"
-rand_core = { path = "../rand_core", version = "0.9.0" }
 rand = { path = "..", version = "0.10.0-rc.0" }
 
 [features]

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.10.0-rc.1] — 2025-10-30
 ### API changes
 - Relax `Sized` bound on impls of `SeedableRng` (#1641)
 - Move `rand_core::impls::*` to `rand_core::le` module (#1667)

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.9.3"
+version = "0.10.0-rc.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -23,7 +23,7 @@ rustdoc-args = ["--generate-link-to-definition"]
 serde = ["dep:serde"]
 
 [dependencies]
-rand_core = { path = "../rand_core", version = "0.9.0" }
+rand_core = { path = "../rand_core", version = "0.10.0-rc.1" }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
@@ -31,4 +31,3 @@ serde = { version = "1", features = ["derive"], optional = true }
 # deps yet, see: https://github.com/rust-lang/cargo/issues/1596
 # Versions prior to 1.1.4 had incorrect minimal dependencies.
 bincode = { version = "1.1.4" }
-rand_core = { path = "../rand_core", version = "0.9.0" }


### PR DESCRIPTION
Prepare a pre-release.

CI is going to fail. @tarcieri you really use inter-repo dependencies this way?

The "best" option may be to move `rand_core` to a new repo, though that makes it harder to test breaking changes. *Or* we just push to stabilise `rand_core` v1.0 (already the plan) and accept that CI will fail sometimes in the mean-time.