### PR TITLE
Update rand_core changelog link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+A [separate changelog is kept for rand_core](https://github.com/rust-random/core/blob/master/CHANGELOG.md).
+
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
 ## [0.10.0 — Unreleased]


### PR DESCRIPTION
rand_core was removed in 3948e19. Its changelog has moved to another repo.

This commit fixes the changelog link.
