### PR TITLE
Cargo.toml: bump `chacha20` to v0.10.0-rc.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ exclude = ["benches", "distr_test"]
 rand_core = { version = "0.10.0-rc-2", default-features = false }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
-chacha20 = { version = "=0.10.0-rc.3", default-features = false, features = ["rng"], optional = true }
+chacha20 = { version = "=0.10.0-rc.5", default-features = false, features = ["rng"], optional = true }
 getrandom = { version = "0.3.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Bumps `chacha20` to the latest prerelease version
