### PR TITLE
Drop dependency on rand_core/serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ features = ["small_rng", "serde"]
 # Meta-features:
 default = ["std", "std_rng", "os_rng", "small_rng", "thread_rng"]
 nightly = [] # some additions requiring nightly Rust
-serde = ["dep:serde", "rand_core/serde"]
+serde = ["dep:serde"]
 
 # Option (enabled by default): without "std" rand uses libcore; this option
 # enables functionality expected to be available on a standard platform.


### PR DESCRIPTION
rand_core dropped feature `serde` in rust-random/rand_core#28 so we must here too.

Since this wasn't used by `rand` in any way, this dependency was a mistake and can be removed without issue.