### PR TITLE
Cargo.toml: loosen dependency version on `chacha20`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ exclude = ["benches", "distr_test"]
 rand_core = { version = "0.10.0-rc-2", default-features = false }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
-chacha20 = { version = "=0.10.0-rc.5", default-features = false, features = ["rng"], optional = true }
+chacha20 = { version = "0.10.0-rc.5", default-features = false, features = ["rng"], optional = true }
 getrandom = { version = "0.3.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
# Summary

Not binding to a strict version of chacha20 (only a minimum) would  make for a much smoother release process. Especially to get over the API breaks humps coming in rand_core 0.10.0-rc.3

# Motivation

# Details
