### PR TITLE
Change glob pattern for tags used by release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Publish to crates.io and create GitHub release
 on:
   push:
-    tags: ['v*']
+    tags: ['[0-9]+.[0-9]+.*']
 
 jobs:
   # Source: https://crates.io/docs/trusted-publishing


### PR DESCRIPTION
I copied `release.yml` from `rand_core` in #1714. This doesn't work here since our release tag names do not start with a `v`.

Reference: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet