### PR TITLE
Rename `Rng` => `RngExt`; bump `rand_core` to v0.10.0-rc-6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Use `postcard` instead of `bincode` to test the serde feature (#1693)
 - Avoid excessive allocation in `IteratorRandom::sample` when `amount` is much larger than iterator size ([#1695])
 - Rename `os_rng` -> `sys_rng`, `OsRng` -> `SysRng`, `OsError` -> `SysError` ([#1697])
+- Rename `Rng` -> `RngExt` as upstream `rand_core` has renamed `RngCore` -> `Rng` ([#1717])
 
 ### Additions
 - Add fns `IndexedRandom::choose_iter`, `choose_weighted_iter` (#1632)
@@ -29,6 +30,7 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 
 [#1695]: https://github.com/rust-random/rand/pull/1695
 [#1697]: https://github.com/rust-random/rand/pull/1697
+[#1717]: https://github.com/rust-random/rand/pull/1717
 
 ## [0.9.2] - 2025-07-20
 ### Deprecated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,9 +22,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.8"
+version = "0.10.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31cd65b2ca03198c223cd9a8fa1152c4ec251cd79049f6dc584152ad3fb5ba9d"
+checksum = "c81d916c6ae06736ec667b51f95ee5ff660a75f4ea6ce1bd932c942365c0ea43"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -81,16 +93,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
-name = "getrandom"
-version = "0.4.0-rc.0"
+name = "equivalent"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b99f0d993a2b9b97b9a201193aa8ad21305cde06a3be9a7e1f8f4201e5cc27e"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74f70a332ddf75e5e5e43284304179ba02f391f82f692f030b08a8378adf3c99"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
  "rand_core",
  "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -98,6 +162,12 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -130,6 +200,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,7 +235,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.10.0-rc.7"
+version = "0.10.0-rc.8"
 dependencies = [
  "chacha20",
  "getrandom",
@@ -170,13 +250,13 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-5"
+version = "0.10.0-rc-6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a06e03bd1f2ae861ab9e7498b6c64ed3dadb9ce175c0464a2522a5f23c0045"
+checksum = "70765ff7112b0fb2d272d24d9a2f907fc206211304328fe58b2db15a5649ef28"
 
 [[package]]
 name = "rand_pcg"
-version = "0.10.0-rc.6"
+version = "0.10.0-rc.7"
 dependencies = [
  "postcard",
  "rand_core",
@@ -202,6 +282,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -284,12 +370,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.3.1+wasi-0.3.0-rc-2025-09-16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba4be47b1d11244670d11857eee0758a8f2c39aea64d80b78c1ce29b4642cd"
+dependencies = [
+ "wit-bindgen 0.48.1",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01164c9dda68301e34fdae536c23ed6fe90ce6d97213ccc171eebbd3d02d6b8"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876fe286f2fa416386deedebe8407e6f19e0b5aeaef3d03161e77a15fa80f167"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d90019b1afd4b808c263e428de644f3003691f243387d30d673211ee0cb8e8"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -297,6 +432,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8c2adb5f74ac9395bc3121c99a1254bf9310482c27b13f97167aedb5887138"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b881a098cae03686d7a0587f8f306f8a58102ad8da8b5599100fbe0e7f5800b"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69667efa439a453e1d50dac939c6cab6d2c3ac724a9d232b6631dad2472a5b70"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae2e22cceb5d105d52326c07e3e67603a861cc7add70fc467f7cc7ec5265017"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0c57df25e7ee612d946d3b7646c1ddb2310f8280aa2c17e543b66e0812241"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.241.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ef1c6ad67f35c831abd4039c02894de97034100899614d1c44e2268ad01c91"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.10.0-rc.7"
+version = "0.10.0-rc.8"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -72,11 +72,11 @@ members = [
 exclude = ["benches", "distr_test"]
 
 [dependencies]
-rand_core = { version = "0.10.0-rc-5", default-features = false }
+rand_core = { version = "0.10.0-rc-6", default-features = false }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
-chacha20 = { version = "0.10.0-rc.8", default-features = false, features = ["rng"], optional = true }
-getrandom = { version = "0.4.0-rc.0", optional = true }
+chacha20 = { version = "0.10.0-rc.9", default-features = false, features = ["rng"], optional = true }
+getrandom = { version = "0.4.0-rc.1", optional = true }
 
 [dev-dependencies]
 rand_pcg = { path = "rand_pcg", version = "0.10.0-rc.1" }

--- a/benches/benches/seq_choose.rs
+++ b/benches/benches/seq_choose.rs
@@ -99,29 +99,29 @@ pub fn bench(c: &mut Criterion) {
     bench_rng::<rand_pcg::Pcg64>(c, "Pcg64");
 }
 
-fn bench_rng<Rng: RngCore + SeedableRng>(c: &mut Criterion, rng_name: &'static str) {
+fn bench_rng<R: Rng + SeedableRng>(c: &mut Criterion, rng_name: &'static str) {
     for length in [1, 2, 3, 10, 100, 1000].map(black_box) {
         let name = format!("choose_size-hinted_from_{length}_{rng_name}");
         c.bench_function(name.as_str(), |b| {
-            let mut rng = Rng::seed_from_u64(123);
+            let mut rng = R::seed_from_u64(123);
             b.iter(|| choose_size_hinted(length, &mut rng))
         });
 
         let name = format!("choose_stable_from_{length}_{rng_name}");
         c.bench_function(name.as_str(), |b| {
-            let mut rng = Rng::seed_from_u64(123);
+            let mut rng = R::seed_from_u64(123);
             b.iter(|| choose_stable(length, &mut rng))
         });
 
         let name = format!("choose_unhinted_from_{length}_{rng_name}");
         c.bench_function(name.as_str(), |b| {
-            let mut rng = Rng::seed_from_u64(123);
+            let mut rng = R::seed_from_u64(123);
             b.iter(|| choose_unhinted(length, &mut rng))
         });
 
         let name = format!("choose_windowed_from_{length}_{rng_name}");
         c.bench_function(name.as_str(), |b| {
-            let mut rng = Rng::seed_from_u64(123);
+            let mut rng = R::seed_from_u64(123);
             b.iter(|| choose_windowed(length, 7, &mut rng))
         });
     }

--- a/benches/benches/shuffle.rs
+++ b/benches/benches/shuffle.rs
@@ -35,10 +35,10 @@ pub fn bench(c: &mut Criterion) {
     bench_rng::<rand_pcg::Pcg64>(c, "Pcg64");
 }
 
-fn bench_rng<Rng: RngCore + SeedableRng>(c: &mut Criterion, rng_name: &'static str) {
+fn bench_rng<R: Rng + SeedableRng>(c: &mut Criterion, rng_name: &'static str) {
     for length in [1, 2, 3, 10, 100, 1000, 10000].map(black_box) {
         c.bench_function(format!("shuffle_{length}_{rng_name}").as_str(), |b| {
-            let mut rng = Rng::seed_from_u64(123);
+            let mut rng = R::seed_from_u64(123);
             let mut vec: Vec<usize> = (0..length).collect();
             b.iter(|| {
                 vec.shuffle(&mut rng);
@@ -49,7 +49,7 @@ fn bench_rng<Rng: RngCore + SeedableRng>(c: &mut Criterion, rng_name: &'static s
         if length >= 10 {
             let name = format!("partial_shuffle_{length}_{rng_name}");
             c.bench_function(name.as_str(), |b| {
-                let mut rng = Rng::seed_from_u64(123);
+                let mut rng = R::seed_from_u64(123);
                 let mut vec: Vec<usize> = (0..length).collect();
                 b.iter(|| {
                     vec.partial_shuffle(&mut rng, length / 2);

--- a/examples/monty-hall.rs
+++ b/examples/monty-hall.rs
@@ -26,7 +26,7 @@
 //!
 //! [Monty Hall Problem]: https://en.wikipedia.org/wiki/Monty_Hall_problem
 
-use rand::Rng;
+use rand::RngExt;
 use rand::distr::{Distribution, Uniform};
 
 struct SimulationResult {
@@ -35,7 +35,7 @@ struct SimulationResult {
 }
 
 // Run a single simulation of the Monty Hall problem.
-fn simulate<R: Rng>(random_door: &Uniform<u32>, rng: &mut R) -> SimulationResult {
+fn simulate<R: RngExt>(random_door: &Uniform<u32>, rng: &mut R) -> SimulationResult {
     let car = random_door.sample(rng);
 
     // This is our initial choice
@@ -58,7 +58,7 @@ fn simulate<R: Rng>(random_door: &Uniform<u32>, rng: &mut R) -> SimulationResult
 
 // Returns the door the game host opens given our choice and knowledge of
 // where the car is. The game host will never open the door with the car.
-fn game_host_open<R: Rng>(car: u32, choice: u32, rng: &mut R) -> u32 {
+fn game_host_open<R: RngExt>(car: u32, choice: u32, rng: &mut R) -> u32 {
     use rand::seq::IndexedRandom;
     *free_doors(&[car, choice]).choose(rng).unwrap()
 }

--- a/examples/print-next.rs
+++ b/examples/print-next.rs
@@ -1,4 +1,4 @@
-use rand::RngCore;
+use rand::Rng;
 
 fn main() {
     let mut rng = rand::rng();

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_pcg"
-version = "0.10.0-rc.6"
+version = "0.10.0-rc.7"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_pcg/src/lib.rs
+++ b/rand_pcg/src/lib.rs
@@ -54,10 +54,10 @@
 //!
 //! ## Generation
 //!
-//! Generators implement [`RngCore`], whose methods may be used directly to
+//! Generators implement [`Rng`], whose methods may be used directly to
 //! generate unbounded integer or byte values.
 //! ```
-//! use rand_core::{SeedableRng, RngCore};
+//! use rand_core::{SeedableRng, Rng};
 //! use rand_pcg::Pcg64Mcg;
 //!
 //! let mut rng = Pcg64Mcg::seed_from_u64(0);
@@ -72,7 +72,7 @@
 //! [Reproducibility]: https://rust-random.github.io/book/crate-reprod.html
 //! [Seeding RNGs]: https://rust-random.github.io/book/guide-seeding.html
 //! [Random Values]: https://rust-random.github.io/book/guide-values.html
-//! [`RngCore`]: rand_core::RngCore
+//! [`Rng`]: rand_core::Rng
 //! [`SeedableRng`]: rand_core::SeedableRng
 //! [`SeedableRng::from_rng`]: rand_core::SeedableRng#method.from_rng
 //! [`rand::rng`]: https://docs.rs/rand/latest/rand/fn.rng.html

--- a/rand_pcg/src/pcg128.rs
+++ b/rand_pcg/src/pcg128.rs
@@ -13,8 +13,8 @@
 // This is the default multiplier used by PCG for 128-bit state.
 const MULTIPLIER: u128 = 0x2360_ED05_1FC6_5DA4_4385_DF64_9FCC_F645;
 
-use core::{convert::Infallible, fmt};
-use rand_core::{SeedableRng, TryRngCore, utils};
+use core::fmt;
+use rand_core::{Infallible, SeedableRng, TryRng, utils};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -135,7 +135,7 @@ impl SeedableRng for Lcg128Xsl64 {
     }
 }
 
-impl TryRngCore for Lcg128Xsl64 {
+impl TryRng for Lcg128Xsl64 {
     type Error = Infallible;
 
     #[inline]
@@ -239,7 +239,7 @@ impl SeedableRng for Mcg128Xsl64 {
     }
 }
 
-impl TryRngCore for Mcg128Xsl64 {
+impl TryRng for Mcg128Xsl64 {
     type Error = Infallible;
 
     #[inline]

--- a/rand_pcg/src/pcg128cm.rs
+++ b/rand_pcg/src/pcg128cm.rs
@@ -14,7 +14,7 @@
 const MULTIPLIER: u64 = 15750249268501108917;
 
 use core::{convert::Infallible, fmt};
-use rand_core::{SeedableRng, TryRngCore, utils};
+use rand_core::{SeedableRng, TryRng, utils};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -140,7 +140,7 @@ impl SeedableRng for Lcg128CmDxsm64 {
     }
 }
 
-impl TryRngCore for Lcg128CmDxsm64 {
+impl TryRng for Lcg128CmDxsm64 {
     type Error = Infallible;
 
     #[inline]

--- a/rand_pcg/src/pcg64.rs
+++ b/rand_pcg/src/pcg64.rs
@@ -11,7 +11,7 @@
 //! PCG random number generators
 
 use core::{convert::Infallible, fmt};
-use rand_core::{SeedableRng, TryRngCore, utils};
+use rand_core::{SeedableRng, TryRng, utils};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -134,7 +134,7 @@ impl SeedableRng for Lcg64Xsh32 {
     }
 }
 
-impl TryRngCore for Lcg64Xsh32 {
+impl TryRng for Lcg64Xsh32 {
     type Error = Infallible;
 
     #[inline]

--- a/rand_pcg/tests/lcg128cmdxsm64.rs
+++ b/rand_pcg/tests/lcg128cmdxsm64.rs
@@ -1,4 +1,4 @@
-use rand_core::{RngCore, SeedableRng};
+use rand_core::{Rng, SeedableRng};
 use rand_pcg::{Lcg128CmDxsm64, Pcg64Dxsm};
 
 #[test]

--- a/rand_pcg/tests/lcg128xsl64.rs
+++ b/rand_pcg/tests/lcg128xsl64.rs
@@ -1,4 +1,4 @@
-use rand_core::{RngCore, SeedableRng};
+use rand_core::{Rng, SeedableRng};
 use rand_pcg::{Lcg128Xsl64, Pcg64};
 
 #[test]

--- a/rand_pcg/tests/lcg64xsh32.rs
+++ b/rand_pcg/tests/lcg64xsh32.rs
@@ -1,4 +1,4 @@
-use rand_core::{RngCore, SeedableRng};
+use rand_core::{Rng, SeedableRng};
 use rand_pcg::{Lcg64Xsh32, Pcg32};
 
 #[test]

--- a/rand_pcg/tests/mcg128xsl64.rs
+++ b/rand_pcg/tests/mcg128xsl64.rs
@@ -1,4 +1,4 @@
-use rand_core::{RngCore, SeedableRng};
+use rand_core::{Rng, SeedableRng};
 use rand_pcg::{Mcg128Xsl64, Pcg64Mcg};
 
 #[test]

--- a/src/distr/bernoulli.rs
+++ b/src/distr/bernoulli.rs
@@ -8,8 +8,8 @@
 
 //! The Bernoulli distribution `Bernoulli(p)`.
 
-use crate::Rng;
 use crate::distr::Distribution;
+use crate::{Rng, RngExt};
 use core::fmt;
 
 #[cfg(feature = "serde")]
@@ -165,7 +165,7 @@ impl Distribution<bool> for Bernoulli {
 #[cfg(test)]
 mod test {
     use super::Bernoulli;
-    use crate::Rng;
+    use crate::RngExt;
     use crate::distr::Distribution;
 
     #[test]

--- a/src/distr/distribution.rs
+++ b/src/distr/distribution.rs
@@ -14,10 +14,13 @@ use crate::Rng;
 use alloc::string::String;
 use core::iter;
 
+#[cfg(doc)]
+use crate::RngExt;
+
 /// Types (distributions) that can be used to create a random instance of `T`.
 ///
 /// It is possible to sample from a distribution through both the
-/// `Distribution` and [`Rng`] traits, via `distr.sample(&mut rng)` and
+/// `Distribution` and [`RngExt`] traits, via `distr.sample(&mut rng)` and
 /// `rng.sample(distr)`. They also both offer the [`sample_iter`] method, which
 /// produces an iterator that samples from the distribution.
 ///
@@ -119,7 +122,7 @@ impl<T, D: Distribution<T> + ?Sized> Distribution<T> for &D {
 /// from a random generator of type `R`.
 ///
 /// Construct this `struct` using [`Distribution::sample_iter`] or
-/// [`Rng::sample_iter`]. It is also used by [`Rng::random_iter`] and
+/// [`RngExt::sample_iter`]. It is also used by [`RngExt::random_iter`] and
 /// [`crate::random_iter`].
 #[derive(Debug)]
 pub struct Iter<D, R, T> {

--- a/src/distr/float.rs
+++ b/src/distr/float.rs
@@ -8,9 +8,9 @@
 
 //! Basic floating-point number distributions
 
-use crate::Rng;
 use crate::distr::utils::{FloatAsSIMD, FloatSIMDUtils, IntAsSIMD};
 use crate::distr::{Distribution, StandardUniform};
+use crate::{Rng, RngExt};
 use core::mem;
 #[cfg(feature = "simd_support")]
 use core::simd::prelude::*;
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// # Example
 /// ```
-/// use rand::Rng;
+/// use rand::RngExt;
 /// use rand::distr::OpenClosed01;
 ///
 /// let val: f32 = rand::rng().sample(OpenClosed01);
@@ -59,7 +59,7 @@ pub struct OpenClosed01;
 ///
 /// # Example
 /// ```
-/// use rand::Rng;
+/// use rand::RngExt;
 /// use rand::distr::Open01;
 ///
 /// let val: f32 = rand::rng().sample(Open01);

--- a/src/distr/integer.rs
+++ b/src/distr/integer.rs
@@ -8,8 +8,8 @@
 
 //! The implementations of the `StandardUniform` distribution for integer types.
 
-use crate::Rng;
 use crate::distr::{Distribution, StandardUniform};
+use crate::{Rng, RngExt};
 #[cfg(all(target_arch = "x86", feature = "simd_support"))]
 use core::arch::x86::__m512i;
 #[cfg(target_arch = "x86")]

--- a/src/distr/mod.rs
+++ b/src/distr/mod.rs
@@ -11,8 +11,8 @@
 //!
 //! This module is the home of the [`Distribution`] trait and several of its
 //! implementations. It is the workhorse behind some of the convenient
-//! functionality of the [`Rng`] trait, e.g. [`Rng::random`] and of course
-//! [`Rng::sample`].
+//! functionality of the [`RngExt`] trait, e.g. [`RngExt::random`] and of course
+//! [`RngExt::sample`].
 //!
 //! Abstractly, a [probability distribution] describes the probability of
 //! occurrence of each value in its sample space.
@@ -31,13 +31,13 @@
 //! # The Standard Uniform distribution
 //!
 //! The [`StandardUniform`] distribution is important to mention. This is the
-//! distribution used by [`Rng::random`] and represents the "default" way to
+//! distribution used by [`RngExt::random`] and represents the "default" way to
 //! produce a random value for many different types, including most primitive
 //! types, tuples, arrays, and a few derived types. See the documentation of
 //! [`StandardUniform`] for more details.
 //!
 //! Implementing [`Distribution<T>`] for [`StandardUniform`] for user types `T` makes it
-//! possible to generate type `T` with [`Rng::random`], and by extension also
+//! possible to generate type `T` with [`RngExt::random`], and by extension also
 //! with the [`random`] function.
 //!
 //! ## Other standard uniform distributions
@@ -62,7 +62,7 @@
 //! range on a subset of the types supported by the above distributions.
 //!
 //! Implementations support single-value-sampling via
-//! [`Rng::random_range(Range)`](Rng::random_range).
+//! [`Rng::random_range(Range)`](RngExt::random_range).
 //! Where a fixed (non-`const`) range will be sampled many times, it is likely
 //! faster to pre-construct a [`Distribution`] object using
 //! [`Uniform::new`], [`Uniform::new_inclusive`] or `From<Range>`.
@@ -70,7 +70,7 @@
 //! # Non-uniform sampling
 //!
 //! Sampling a simple true/false outcome with a given probability has a name:
-//! the [`Bernoulli`] distribution (this is used by [`Rng::random_bool`]).
+//! the [`Bernoulli`] distribution (this is used by [`RngExt::random_bool`]).
 //!
 //! For weighted sampling of discrete values see the [`weighted`] module.
 //!
@@ -112,7 +112,7 @@ pub use self::other::{Alphabetic, Alphanumeric};
 pub use self::uniform::Uniform;
 
 #[allow(unused)]
-use crate::Rng;
+use crate::RngExt;
 
 /// The Standard Uniform distribution
 ///
@@ -147,7 +147,7 @@ use crate::Rng;
 ///   between elements).
 /// * Arrays `[T; n]` where `T` is supported. Each element is sampled
 ///   sequentially and independently. Note that for small `T` this usually
-///   results in the RNG discarding random bits; see also [`Rng::fill`] which
+///   results in the RNG discarding random bits; see also [`RngExt::fill`] which
 ///   offers a more efficient approach to filling an array of integer types
 ///   with random data.
 /// * SIMD types (requires [`simd_support`] feature) like x86's [`__m128i`]
@@ -163,7 +163,7 @@ use crate::Rng;
 ///
 /// ```
 /// # #![allow(dead_code)]
-/// use rand::Rng;
+/// use rand::{Rng, RngExt};
 /// use rand::distr::{Distribution, StandardUniform};
 ///
 /// struct MyF32 {

--- a/src/distr/other.rs
+++ b/src/distr/other.rs
@@ -14,10 +14,10 @@ use core::array;
 use core::char;
 use core::num::Wrapping;
 
-use crate::Rng;
 #[cfg(feature = "alloc")]
 use crate::distr::SampleString;
 use crate::distr::{Distribution, StandardUniform, Uniform};
+use crate::{Rng, RngExt};
 
 #[cfg(feature = "simd_support")]
 use core::simd::prelude::*;
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize};
 /// # Example
 ///
 /// ```
-/// use rand::Rng;
+/// use rand::RngExt;
 /// use rand::distr::Alphanumeric;
 ///
 /// let mut rng = rand::rng();
@@ -79,7 +79,7 @@ pub struct Alphanumeric;
 /// [`SampleString::sample_string`] method like so:
 ///
 /// ```
-/// use rand::Rng;
+/// use rand::RngExt;
 /// use rand::distr::{Alphabetic, SampleString};
 ///
 /// // Manual mapping
@@ -315,11 +315,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::RngCore;
+    use crate::Rng;
 
     #[test]
     fn test_misc() {
-        let rng: &mut dyn RngCore = &mut crate::test::rng(820);
+        let rng: &mut dyn Rng = &mut crate::test::rng(820);
 
         rng.sample::<char, _>(StandardUniform);
         rng.sample::<bool, _>(StandardUniform);

--- a/src/distr/slice.rs
+++ b/src/distr/slice.rs
@@ -10,6 +10,7 @@
 
 use core::num::NonZeroUsize;
 
+use crate::Rng;
 use crate::distr::Distribution;
 use crate::distr::uniform::{UniformSampler, UniformUsize};
 #[cfg(feature = "alloc")]
@@ -54,7 +55,7 @@ use alloc::string::String;
 /// ```
 ///
 /// [`IndexedRandom::choose`]: crate::seq::IndexedRandom::choose
-/// [`Rng::sample_iter`]: crate::Rng::sample_iter
+/// [`Rng::sample_iter`]: crate::RngExt::sample_iter
 #[derive(Debug, Clone, Copy)]
 pub struct Choose<'a, T> {
     slice: &'a [T],
@@ -83,7 +84,7 @@ impl<'a, T> Choose<'a, T> {
 }
 
 impl<'a, T> Distribution<&'a T> for Choose<'a, T> {
-    fn sample<R: crate::Rng + ?Sized>(&self, rng: &mut R) -> &'a T {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> &'a T {
         let idx = self.range.sample(rng);
 
         debug_assert!(
@@ -120,7 +121,7 @@ impl std::error::Error for Empty {}
 
 #[cfg(feature = "alloc")]
 impl super::SampleString for Choose<'_, char> {
-    fn append_string<R: crate::Rng + ?Sized>(&self, rng: &mut R, string: &mut String, len: usize) {
+    fn append_string<R: Rng + ?Sized>(&self, rng: &mut R, string: &mut String, len: usize) {
         // Get the max char length to minimize extra space.
         // Limit this check to avoid searching for long slice.
         let max_char_len = if self.slice.len() < 200 {

--- a/src/distr/uniform_float.rs
+++ b/src/distr/uniform_float.rs
@@ -10,9 +10,9 @@
 //! `UniformFloat` implementation
 
 use super::{Error, SampleBorrow, SampleUniform, UniformSampler};
-use crate::Rng;
 use crate::distr::float::IntoFloat;
 use crate::distr::utils::{BoolAsSIMD, FloatAsSIMD, FloatSIMDUtils, IntAsSIMD};
+use crate::{Rng, RngExt};
 
 #[cfg(feature = "simd_support")]
 use core::simd::prelude::*;

--- a/src/distr/uniform_int.rs
+++ b/src/distr/uniform_int.rs
@@ -10,10 +10,10 @@
 //! `UniformInt` implementation
 
 use super::{Error, SampleBorrow, SampleUniform, UniformSampler};
-use crate::Rng;
 use crate::distr::utils::WideningMultiply;
 #[cfg(feature = "simd_support")]
 use crate::distr::{Distribution, StandardUniform};
+use crate::{Rng, RngExt};
 
 #[cfg(feature = "simd_support")]
 use core::simd::prelude::*;

--- a/src/distr/uniform_other.rs
+++ b/src/distr/uniform_other.rs
@@ -246,6 +246,7 @@ impl UniformSampler for UniformDuration {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::RngExt;
 
     #[test]
     #[cfg(feature = "serde")]

--- a/src/distr/weighted/weighted_index.rs
+++ b/src/distr/weighted/weighted_index.rs
@@ -47,7 +47,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Sampling from `WeightedIndex` will result in a single call to
 /// `Uniform<X>::sample` (method of the [`Distribution`] trait), which typically
-/// will request a single value from the underlying [`RngCore`], though the
+/// will request a single value from the underlying [`Rng`], though the
 /// exact number depends on the implementation of `Uniform<X>::sample`.
 ///
 /// # Example
@@ -74,7 +74,7 @@ use serde::{Deserialize, Serialize};
 /// ```
 ///
 /// [`Uniform<X>`]: crate::distr::Uniform
-/// [`RngCore`]: crate::RngCore
+/// [`Rng`]: crate::Rng
 /// [`rand_distr::weighted`]: https://docs.rs/rand_distr/latest/rand_distr/weighted/index.html
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -370,6 +370,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::RngExt;
 
     #[cfg(feature = "serde")]
     #[test]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -32,4 +32,4 @@ pub use crate::rngs::ThreadRng;
 #[doc(no_inline)]
 pub use crate::seq::{IndexedMutRandom, IndexedRandom, IteratorRandom, SliceRandom};
 #[doc(no_inline)]
-pub use crate::{CryptoRng, Rng, RngCore, SeedableRng};
+pub use crate::{CryptoRng, Rng, RngExt, SeedableRng};

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -7,21 +7,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! [`Rng`] trait
+//! [`RngExt`] trait
 
 use crate::distr::uniform::{SampleRange, SampleUniform};
 use crate::distr::{self, Distribution, StandardUniform};
 use core::num::Wrapping;
 use core::{mem, slice};
-use rand_core::RngCore;
+use rand_core::Rng;
 
 /// User-level interface for RNGs
 ///
-/// [`RngCore`] is the `dyn`-safe implementation-level interface for Random
+/// [`Rng`] is the `dyn`-safe implementation-level interface for Random
 /// (Number) Generators. This trait, `Rng`, provides a user-level interface on
-/// RNGs. It is implemented automatically for any `R: RngCore`.
+/// RNGs. It is implemented automatically for any `R: Rng`.
 ///
-/// This trait must usually be brought into scope via `use rand::Rng;` or
+/// This trait must usually be brought into scope via `use rand::RngExt;` or
 /// `use rand::prelude::*;`.
 ///
 /// # Generic usage
@@ -29,11 +29,9 @@ use rand_core::RngCore;
 /// The basic pattern is `fn foo<R: Rng + ?Sized>(rng: &mut R)`. Some
 /// things are worth noting here:
 ///
-/// - Since `Rng: RngCore` and every `RngCore` implements `Rng`, it makes no
-///   difference whether we use `R: Rng` or `R: RngCore`.
-/// - The `+ ?Sized` un-bounding allows functions to be called directly on
-///   type-erased references; i.e. `foo(r)` where `r: &mut dyn RngCore`. Without
-///   this it would be necessary to write `foo(&mut r)`.
+/// - Since `RngExt: Rng` and every `RngExt` implements `Rng`, it makes no
+///   difference whether we use `R: Rng` or `R: RngExt` for `R: Sized`.
+/// - Only `Rng` is dyn safe, supporting `&mut dyn Rng` and `R: Rng + ?Sized`.
 ///
 /// An alternative pattern is possible: `fn foo<R: Rng>(rng: R)`. This has some
 /// trade-offs. It allows the argument to be consumed directly without a `&mut`
@@ -47,7 +45,7 @@ use rand_core::RngCore;
 /// Example:
 ///
 /// ```
-/// use rand::Rng;
+/// use rand::{Rng, RngExt};
 ///
 /// fn foo<R: Rng + ?Sized>(rng: &mut R) -> f32 {
 ///     rng.random()
@@ -55,13 +53,13 @@ use rand_core::RngCore;
 ///
 /// # let v = foo(&mut rand::rng());
 /// ```
-pub trait Rng: RngCore {
+pub trait RngExt: Rng {
     /// Return a random value via the [`StandardUniform`] distribution.
     ///
     /// # Example
     ///
     /// ```
-    /// use rand::Rng;
+    /// use rand::RngExt;
     ///
     /// let mut rng = rand::rng();
     /// let x: u32 = rng.random();
@@ -76,11 +74,11 @@ pub trait Rng: RngCore {
     /// generated.
     ///
     /// For arrays of integers, especially for those with small element types
-    /// (< 64 bit), it will likely be faster to instead use [`Rng::fill`],
+    /// (< 64 bit), it will likely be faster to instead use [`RngExt::fill`],
     /// though note that generated values will differ.
     ///
     /// ```
-    /// use rand::Rng;
+    /// use rand::RngExt;
     ///
     /// let mut rng = rand::rng();
     /// let tuple: (u8, i32, char) = rng.random(); // arbitrary tuple support
@@ -101,7 +99,7 @@ pub trait Rng: RngCore {
 
     /// Return an iterator over [`random`](Self::random) variates
     ///
-    /// This is a just a wrapper over [`Rng::sample_iter`] using
+    /// This is a just a wrapper over [`RngExt::sample_iter`] using
     /// [`distr::StandardUniform`].
     ///
     /// Note: this method consumes its argument. Use
@@ -110,7 +108,7 @@ pub trait Rng: RngCore {
     /// # Example
     ///
     /// ```
-    /// use rand::{rngs::SmallRng, Rng, SeedableRng};
+    /// use rand::{rngs::SmallRng, RngExt, SeedableRng};
     ///
     /// let rng = SmallRng::seed_from_u64(0);
     /// let v: Vec<i32> = rng.random_iter().take(5).collect();
@@ -141,7 +139,7 @@ pub trait Rng: RngCore {
     /// # Example
     ///
     /// ```
-    /// use rand::Rng;
+    /// use rand::RngExt;
     ///
     /// let mut rng = rand::rng();
     ///
@@ -175,7 +173,7 @@ pub trait Rng: RngCore {
     /// # Example
     ///
     /// ```
-    /// use rand::Rng;
+    /// use rand::RngExt;
     ///
     /// let mut rng = rand::rng();
     /// println!("{}", rng.random_bool(1.0 / 3.0));
@@ -213,7 +211,7 @@ pub trait Rng: RngCore {
     /// # Example
     ///
     /// ```
-    /// use rand::Rng;
+    /// use rand::RngExt;
     ///
     /// let mut rng = rand::rng();
     /// println!("{}", rng.random_ratio(2, 3));
@@ -237,7 +235,7 @@ pub trait Rng: RngCore {
     /// ### Example
     ///
     /// ```
-    /// use rand::Rng;
+    /// use rand::RngExt;
     /// use rand::distr::Uniform;
     ///
     /// let mut rng = rand::rng();
@@ -258,7 +256,7 @@ pub trait Rng: RngCore {
     /// # Example
     ///
     /// ```
-    /// use rand::Rng;
+    /// use rand::RngExt;
     /// use rand::distr::{Alphanumeric, Uniform, StandardUniform};
     ///
     /// let mut rng = rand::rng();
@@ -295,7 +293,7 @@ pub trait Rng: RngCore {
     ///
     /// This method is implemented for types which may be safely reinterpreted
     /// as an (aligned) `[u8]` slice then filled with random data. It is often
-    /// faster than using [`Rng::random`] but not value-equivalent.
+    /// faster than using [`RngExt::random`] but not value-equivalent.
     ///
     /// The distribution is expected to be uniform with portable results, but
     /// this cannot be guaranteed for third-party implementations.
@@ -303,19 +301,19 @@ pub trait Rng: RngCore {
     /// # Example
     ///
     /// ```
-    /// use rand::Rng;
+    /// use rand::RngExt;
     ///
     /// let mut arr = [0i8; 20];
     /// rand::rng().fill(&mut arr[..]);
     /// ```
     ///
-    /// [`fill_bytes`]: RngCore::fill_bytes
+    /// [`fill_bytes`]: Rng::fill_bytes
     #[track_caller]
     fn fill<T: Fill>(&mut self, dest: &mut [T]) {
         Fill::fill_slice(dest, self)
     }
 
-    /// Alias for [`Rng::random`].
+    /// Alias for [`RngExt::random`].
     #[inline]
     #[deprecated(
         since = "0.9.0",
@@ -328,7 +326,7 @@ pub trait Rng: RngCore {
         self.random()
     }
 
-    /// Alias for [`Rng::random_range`].
+    /// Alias for [`RngExt::random_range`].
     #[inline]
     #[deprecated(since = "0.9.0", note = "Renamed to `random_range`")]
     fn gen_range<T, R>(&mut self, range: R) -> T
@@ -339,14 +337,14 @@ pub trait Rng: RngCore {
         self.random_range(range)
     }
 
-    /// Alias for [`Rng::random_bool`].
+    /// Alias for [`RngExt::random_bool`].
     #[inline]
     #[deprecated(since = "0.9.0", note = "Renamed to `random_bool`")]
     fn gen_bool(&mut self, p: f64) -> bool {
         self.random_bool(p)
     }
 
-    /// Alias for [`Rng::random_ratio`].
+    /// Alias for [`RngExt::random_ratio`].
     #[inline]
     #[deprecated(since = "0.9.0", note = "Renamed to `random_ratio`")]
     fn gen_ratio(&mut self, numerator: u32, denominator: u32) -> bool {
@@ -354,7 +352,7 @@ pub trait Rng: RngCore {
     }
 }
 
-impl<R: RngCore + ?Sized> Rng for R {}
+impl<R: Rng + ?Sized> RngExt for R {}
 
 /// Support filling a slice with random data
 ///
@@ -563,7 +561,7 @@ mod test {
 
     #[test]
     fn test_rng_mut_ref() {
-        fn use_rng(mut r: impl Rng) {
+        fn use_rng(mut r: impl RngExt) {
             let _ = r.next_u32();
         }
 
@@ -575,7 +573,7 @@ mod test {
     fn test_rng_trait_object() {
         use crate::distr::{Distribution, StandardUniform};
         let mut rng = rng(109);
-        let mut r = &mut rng as &mut dyn RngCore;
+        let mut r = &mut rng as &mut dyn Rng;
         r.next_u32();
         r.random::<i32>();
         assert_eq!(r.random_range(0..1), 0);
@@ -587,7 +585,7 @@ mod test {
     fn test_rng_boxed_trait() {
         use crate::distr::{Distribution, StandardUniform};
         let rng = rng(110);
-        let mut r = Box::new(rng) as Box<dyn RngCore>;
+        let mut r = Box::new(rng) as Box<dyn Rng>;
         r.next_u32();
         r.random::<i32>();
         assert_eq!(r.random_range(0..1), 0);

--- a/src/rngs/mod.rs
+++ b/src/rngs/mod.rs
@@ -66,8 +66,8 @@
 //!
 //! ## Traits and functionality
 //!
-//! All generators implement [`TryRngCore`]. Most implement [`RngCore`] (i.e.
-//! `TryRngCore<Error = Infallible>`) and thus also implement [`Rng`][crate::Rng].
+//! All generators implement [`TryRng`]. Most implement [`Rng`] (i.e.
+//! `TryRng<Error = Infallible>`) and thus also implement [`Rng`][crate::Rng].
 //! See also the [Random Values] chapter in the book.
 //!
 //! Secure RNGs may additionally implement the [`CryptoRng`] trait.
@@ -80,9 +80,9 @@
 //! [Types of generators]: https://rust-random.github.io/book/guide-gen.html
 //! [Our RNGs]: https://rust-random.github.io/book/guide-rngs.html
 //! [Random Values]: https://rust-random.github.io/book/guide-values.html
+//! [`Rng`]: crate::RngExt
+//! [`TryRng`]: crate::TryRng
 //! [`Rng`]: crate::Rng
-//! [`TryRngCore`]: crate::TryRngCore
-//! [`RngCore`]: crate::RngCore
 //! [`CryptoRng`]: crate::CryptoRng
 //! [`SeedableRng`]: crate::SeedableRng
 //! [`rdrand`]: https://crates.io/crates/rdrand

--- a/src/rngs/reseeding.rs
+++ b/src/rngs/reseeding.rs
@@ -14,7 +14,7 @@ use core::convert::Infallible;
 use core::mem::size_of_val;
 
 use rand_core::block::{BlockRng, CryptoGenerator, Generator};
-use rand_core::{SeedableRng, TryCryptoRng, TryRngCore};
+use rand_core::{SeedableRng, TryCryptoRng, TryRng};
 
 /// A wrapper around any PRNG that implements [`Generator`], that adds the
 /// ability to reseed it.
@@ -71,12 +71,12 @@ use rand_core::{SeedableRng, TryCryptoRng, TryRngCore};
 pub struct ReseedingRng<G, Rsdr>(BlockRng<ReseedingCore<G, Rsdr>>)
 where
     G: Generator + SeedableRng,
-    Rsdr: TryRngCore;
+    Rsdr: TryRng;
 
 impl<const N: usize, G, Rsdr> ReseedingRng<G, Rsdr>
 where
     G: Generator<Output = [u32; N]> + SeedableRng,
-    Rsdr: TryRngCore,
+    Rsdr: TryRng,
 {
     /// Create a new `ReseedingRng` from an existing PRNG, combined with a RNG
     /// to use as reseeder.
@@ -100,11 +100,11 @@ where
 }
 
 // TODO: this should be implemented for any type where the inner type
-// implements TryRngCore, but we can't specify that because ReseedingCore is private
-impl<const N: usize, G, Rsdr> TryRngCore for ReseedingRng<G, Rsdr>
+// implements TryRng, but we can't specify that because ReseedingCore is private
+impl<const N: usize, G, Rsdr> TryRng for ReseedingRng<G, Rsdr>
 where
     G: Generator<Output = [u32; N]> + SeedableRng,
-    Rsdr: TryRngCore,
+    Rsdr: TryRng,
 {
     type Error = Infallible;
 
@@ -142,7 +142,7 @@ struct ReseedingCore<G, Rsdr> {
 impl<G, Rsdr> Generator for ReseedingCore<G, Rsdr>
 where
     G: Generator + SeedableRng,
-    Rsdr: TryRngCore,
+    Rsdr: TryRng,
 {
     type Output = <G as Generator>::Output;
 
@@ -162,7 +162,7 @@ where
 impl<G, Rsdr> ReseedingCore<G, Rsdr>
 where
     G: Generator + SeedableRng,
-    Rsdr: TryRngCore,
+    Rsdr: TryRng,
 {
     /// Create a new `ReseedingCore`.
     ///
@@ -225,7 +225,7 @@ where
 #[cfg(feature = "std_rng")]
 #[cfg(test)]
 mod test {
-    use crate::Rng;
+    use crate::RngExt;
     use crate::rngs::std::Core;
     use crate::test::const_rng;
 

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -9,7 +9,7 @@
 //! A small fast RNG
 
 use core::convert::Infallible;
-use rand_core::{SeedableRng, TryRngCore};
+use rand_core::{SeedableRng, TryRng};
 
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "16"))]
 type Rng = super::xoshiro128plusplus::Xoshiro128PlusPlus;
@@ -62,7 +62,7 @@ type Rng = super::xoshiro256plusplus::Xoshiro256PlusPlus;
 ///
 /// ## Generation
 ///
-/// The generators implements [`RngCore`] and thus also [`Rng`][crate::Rng].
+/// The generators implements [`Rng`] and thus also [`Rng`][crate::Rng].
 /// See also the [Random Values] chapter in the book.
 ///
 /// [portable]: https://rust-random.github.io/book/crate-reprod.html
@@ -73,7 +73,7 @@ type Rng = super::xoshiro256plusplus::Xoshiro256PlusPlus;
 /// [rand_pcg]: https://crates.io/crates/rand_pcg
 /// [rand_xoshiro]: https://crates.io/crates/rand_xoshiro
 /// [`rand_seeder`]: https://docs.rs/rand_seeder/latest/rand_seeder/
-/// [`RngCore`]: rand_core::RngCore
+/// [`Rng`]: rand_core::Rng
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SmallRng(Rng);
 
@@ -96,7 +96,7 @@ impl SeedableRng for SmallRng {
     }
 }
 
-impl TryRngCore for SmallRng {
+impl TryRng for SmallRng {
     type Error = Infallible;
 
     #[inline(always)]

--- a/src/rngs/std.rs
+++ b/src/rngs/std.rs
@@ -9,7 +9,7 @@
 //! The standard RNG
 
 use core::convert::Infallible;
-use rand_core::{SeedableRng, TryCryptoRng, TryRngCore};
+use rand_core::{SeedableRng, TryCryptoRng, TryRng};
 
 #[cfg(any(test, feature = "sys_rng"))]
 pub(crate) use chacha20::ChaCha12Core as Core;
@@ -57,7 +57,7 @@ use chacha20::ChaCha12Rng as Rng;
 ///
 /// ## Generation
 ///
-/// The generators implements [`RngCore`] and thus also [`Rng`][crate::Rng].
+/// The generators implements [`Rng`] and thus also [`Rng`][crate::Rng].
 /// See also the [Random Values] chapter in the book.
 ///
 /// [portable]: https://rust-random.github.io/book/crate-reprod.html
@@ -67,11 +67,11 @@ use chacha20::ChaCha12Rng as Rng;
 /// [CSPRNG]: https://rust-random.github.io/book/guide-gen.html#cryptographically-secure-pseudo-random-number-generator
 /// [chacha20]: https://crates.io/crates/chacha20
 /// [rand issue]: https://github.com/rust-random/rand/issues/932
-/// [`RngCore`]: rand_core::RngCore
+/// [`Rng`]: rand_core::Rng
 #[derive(Debug, PartialEq, Eq)]
 pub struct StdRng(Rng);
 
-impl TryRngCore for StdRng {
+impl TryRng for StdRng {
     type Error = Infallible;
 
     #[inline(always)]
@@ -105,7 +105,7 @@ impl TryCryptoRng for StdRng {}
 #[cfg(test)]
 mod test {
     use crate::rngs::StdRng;
-    use crate::{Rng, RngCore, SeedableRng};
+    use crate::{Rng, RngExt, SeedableRng};
 
     #[test]
     fn test_stdrng_construction() {

--- a/src/rngs/thread.rs
+++ b/src/rngs/thread.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 use std::thread_local;
 
 use super::{ReseedingRng, SysError, SysRng, std::Core};
-use rand_core::{TryCryptoRng, TryRngCore};
+use rand_core::{TryCryptoRng, TryRng};
 
 // Rationale for using `UnsafeCell` in `ThreadRng`:
 //
@@ -162,7 +162,7 @@ impl Default for ThreadRng {
     }
 }
 
-impl TryRngCore for ThreadRng {
+impl TryRng for ThreadRng {
     type Error = Infallible;
 
     #[inline(always)]
@@ -196,7 +196,7 @@ impl TryCryptoRng for ThreadRng {}
 mod test {
     #[test]
     fn test_thread_rng() {
-        use crate::Rng;
+        use crate::RngExt;
         let mut r = crate::rng();
         r.random::<i32>();
         assert_eq!(r.random_range(0..1), 0);

--- a/src/rngs/xoshiro128plusplus.rs
+++ b/src/rngs/xoshiro128plusplus.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use core::convert::Infallible;
-use rand_core::{SeedableRng, TryRngCore, utils};
+use rand_core::{SeedableRng, TryRng, utils};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -64,7 +64,7 @@ impl SeedableRng for Xoshiro128PlusPlus {
     }
 }
 
-impl TryRngCore for Xoshiro128PlusPlus {
+impl TryRng for Xoshiro128PlusPlus {
     type Error = Infallible;
 
     #[inline]
@@ -102,7 +102,7 @@ impl TryRngCore for Xoshiro128PlusPlus {
 #[cfg(test)]
 mod tests {
     use super::Xoshiro128PlusPlus;
-    use rand_core::{RngCore, SeedableRng};
+    use rand_core::{Rng, SeedableRng};
 
     #[test]
     fn reference() {

--- a/src/rngs/xoshiro256plusplus.rs
+++ b/src/rngs/xoshiro256plusplus.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use core::convert::Infallible;
-use rand_core::{SeedableRng, TryRngCore, utils};
+use rand_core::{SeedableRng, TryRng, utils};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -63,7 +63,7 @@ impl SeedableRng for Xoshiro256PlusPlus {
     }
 }
 
-impl TryRngCore for Xoshiro256PlusPlus {
+impl TryRng for Xoshiro256PlusPlus {
     type Error = Infallible;
 
     #[inline]
@@ -103,7 +103,7 @@ impl TryRngCore for Xoshiro256PlusPlus {
 #[cfg(test)]
 mod tests {
     use super::Xoshiro256PlusPlus;
-    use rand_core::{RngCore, SeedableRng};
+    use rand_core::{Rng, SeedableRng};
 
     #[test]
     fn reference() {

--- a/src/seq/coin_flipper.rs
+++ b/src/seq/coin_flipper.rs
@@ -6,15 +6,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::RngCore;
+use crate::Rng;
 
-pub(crate) struct CoinFlipper<R: RngCore> {
+pub(crate) struct CoinFlipper<R: Rng> {
     pub rng: R,
     chunk: u32, // TODO(opt): this should depend on RNG word size
     chunk_remaining: u32,
 }
 
-impl<R: RngCore> CoinFlipper<R> {
+impl<R: Rng> CoinFlipper<R> {
     pub fn new(rng: R) -> Self {
         Self {
             rng,

--- a/src/seq/increasing_uniform.rs
+++ b/src/seq/increasing_uniform.rs
@@ -6,11 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{Rng, RngCore};
+use crate::{Rng, RngExt};
 
 /// Similar to a Uniform distribution,
 /// but after returning a number in the range [0,n], n is increased by 1.
-pub(crate) struct IncreasingUniform<R: RngCore> {
+pub(crate) struct IncreasingUniform<R: Rng> {
     pub rng: R,
     n: u32,
     // Chunk is a random number in [0, (n + 1) * (n + 2) *..* (n + chunk_remaining) )
@@ -18,7 +18,7 @@ pub(crate) struct IncreasingUniform<R: RngCore> {
     chunk_remaining: u8,
 }
 
-impl<R: RngCore> IncreasingUniform<R> {
+impl<R: Rng> IncreasingUniform<R> {
     /// Create a dice roller.
     /// The next item returned will be a random number in the range [0,n]
     pub fn new(rng: R, n: u32) -> Self {

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -13,9 +13,9 @@ use core::{hash::Hash, ops::AddAssign};
 // BTreeMap is not as fast in tests, but better than nothing.
 #[cfg(feature = "std")]
 use super::WeightError;
-use crate::Rng;
 use crate::distr::uniform::SampleUniform;
 use crate::distr::{Distribution, Uniform};
+use crate::{Rng, RngExt};
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeSet;
 #[cfg(feature = "serde")]

--- a/src/seq/iterator.rs
+++ b/src/seq/iterator.rs
@@ -11,7 +11,7 @@
 #[allow(unused)]
 use super::IndexedRandom;
 use super::coin_flipper::CoinFlipper;
-use crate::Rng;
+use crate::{Rng, RngExt};
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 

--- a/src/seq/mod.rs
+++ b/src/seq/mod.rs
@@ -48,7 +48,7 @@ pub use slice::{IndexedMutRandom, IndexedRandom, SliceRandom};
 
 /// Low-level API for sampling indices
 pub mod index {
-    use crate::Rng;
+    use crate::{Rng, RngExt};
 
     #[cfg(feature = "alloc")]
     #[doc(inline)]

--- a/src/seq/slice.rs
+++ b/src/seq/slice.rs
@@ -10,11 +10,11 @@
 
 use super::increasing_uniform::IncreasingUniform;
 use super::index;
-use crate::Rng;
 #[cfg(feature = "alloc")]
 use crate::distr::uniform::{SampleBorrow, SampleUniform};
 #[cfg(feature = "alloc")]
 use crate::distr::weighted::{Error as WeightError, Weight};
+use crate::{Rng, RngExt};
 use core::ops::{Index, IndexMut};
 
 /// Extension trait on indexable lists, providing random sampling methods.

--- a/tests/fill.rs
+++ b/tests/fill.rs
@@ -8,7 +8,7 @@
 
 #![allow(unused)]
 
-use rand::{Fill, Rng};
+use rand::{Fill, Rng, RngExt};
 
 // Test that Fill may be implemented for externally-defined types
 struct MyInt(i32);


### PR DESCRIPTION
This prerelease of `rand_core` renamed `(Try)RngCore` => `(Try)Rng`.

Since `rand` previously defined an `Rng` trait, it now needs a new name, and `RngExt` was the one I saw suggested in rust-random/rand_core#54.

Also bumps:
- `chacha20` v0.10.0-rc.9
- `getrandom` v0.4.0-rc.1

- [x] Added a `CHANGELOG.md` entry