### PR TITLE
Change glob expression used in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Publish to crates.io and create GitHub release
 on:
   push:
-    tags: ['[0-9]+.[0-9]+.*']
+    tags: ['[0-9].[0-9].*', '[0-9].[1-9][0-9].*']
 
 jobs:
   # Source: https://crates.io/docs/trusted-publishing


### PR DESCRIPTION
~~This job didn't run on tag `0.10.0-rc.8`.~~ It turns out that it did run, however GitHub did not confirm the release with me.

~~I *think* the reason is that `+` doesn't work with range expressions like `[0-9]` in glob patterns.~~ Hey GitHub, can we please use regexps already?

Reference (such as it is): https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet