### PR TITLE
Use chacha20::ChaChaCore directly

### DIFF
--- a/src/rngs/reseeding.rs
+++ b/src/rngs/reseeding.rs
@@ -53,13 +53,14 @@ use rand_core::{SeedableRng, TryCryptoRng, TryRng};
 /// # Example
 ///
 /// ```
-/// use chacha20::ChaCha20Core; // Internal part of ChaChaRng that
-///                             // implements Generator
+/// // Internal part of ChaChaRng that implements Generator
+/// type Core = chacha20::ChaChaCore<chacha20::R20, chacha20::variants::Legacy>;
+///
 /// use rand::prelude::*;
 /// use rand::rngs::SysRng;
 /// use rand::rngs::ReseedingRng;
 ///
-/// let mut reseeding_rng = ReseedingRng::<ChaCha20Core, _>::new(0, SysRng).unwrap();
+/// let mut reseeding_rng = ReseedingRng::<Core, _>::new(0, SysRng).unwrap();
 ///
 /// println!("{}", reseeding_rng.random::<u64>());
 /// ```

--- a/src/rngs/std.rs
+++ b/src/rngs/std.rs
@@ -12,7 +12,7 @@ use core::convert::Infallible;
 use rand_core::{SeedableRng, TryCryptoRng, TryRng};
 
 #[cfg(any(test, feature = "sys_rng"))]
-pub(crate) use chacha20::ChaCha12Core as Core;
+pub(crate) type Core = chacha20::ChaChaCore<chacha20::R12, chacha20::variants::Legacy>;
 
 use chacha20::ChaCha12Rng as Rng;
 


### PR DESCRIPTION
(Pending a new chacha20 release.)

Compatibility with https://github.com/RustCrypto/stream-ciphers/pull/512.