### PR TITLE
Use dependabot to update benches's Cargo.lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,17 @@ updates:
     all-deps:
       patterns:
         - "*"
+- package-ecosystem: cargo
+  directory: "/benches"
+  versioning-strategy: lockfile-only
+  allow:
+    - dependency-type: "all"
+  schedule:
+    interval: weekly
+  groups:
+    all-deps:
+      patterns:
+        - "*"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
We have two lock files; this one is out of date.