### PR TITLE
Update chacha20 and use chacha20::ChaChaCore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.9"
+version = "0.10.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c81d916c6ae06736ec667b51f95ee5ff660a75f4ea6ce1bd932c942365c0ea43"
+checksum = "c536927023d1c432e6e23a25ef45f6756094eac2ab460db5fb17a772acdfd312"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70765ff7112b0fb2d272d24d9a2f907fc206211304328fe58b2db15a5649ef28"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_pcg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ exclude = ["benches", "distr_test"]
 rand_core = { version = "0.10.0-rc-6", default-features = false }
 log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
-chacha20 = { version = "0.10.0-rc.9", default-features = false, features = ["rng"], optional = true }
+chacha20 = { version = "0.10.0-rc.10", default-features = false, features = ["rng"], optional = true }
 getrandom = { version = "0.4.0-rc.1", optional = true }
 
 [dev-dependencies]

--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -72,9 +72,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.9"
+version = "0.10.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c81d916c6ae06736ec667b51f95ee5ff660a75f4ea6ce1bd932c942365c0ea43"
+checksum = "c536927023d1c432e6e23a25ef45f6756094eac2ab460db5fb17a772acdfd312"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70765ff7112b0fb2d272d24d9a2f907fc206211304328fe58b2db15a5649ef28"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_pcg"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -13,7 +13,7 @@ simd_support = ["rand/simd_support"]
 [dev-dependencies]
 rand = { path = "..", features = ["small_rng", "nightly"] }
 rand_pcg = { path = "../rand_pcg" }
-chacha20 = { version = "0.10.0-rc.7", default-features = false, features = ["rng"] }
+chacha20 = { version = "0.10.0-rc.10", default-features = false, features = ["rng"] }
 criterion = "0.5"
 criterion-cycles-per-byte = "0.6"
 

--- a/src/rngs/std.rs
+++ b/src/rngs/std.rs
@@ -11,9 +11,6 @@
 use core::convert::Infallible;
 use rand_core::{SeedableRng, TryCryptoRng, TryRng};
 
-#[cfg(any(test, feature = "sys_rng"))]
-pub(crate) use chacha20::ChaCha12Core as Core;
-
 use chacha20::ChaCha12Rng as Rng;
 
 /// A strong, fast (amortized), non-portable RNG

--- a/src/rngs/thread.rs
+++ b/src/rngs/thread.rs
@@ -14,7 +14,6 @@ use std::fmt;
 use std::rc::Rc;
 use std::thread_local;
 
-use super::std::Core;
 use super::{SysError, SysRng};
 use rand_core::SeedableRng;
 use rand_core::block::{BlockRng, Generator};
@@ -39,6 +38,7 @@ use rand_core::{TryCryptoRng, TryRng};
 // of 32 kB and less. We choose 64 kB to avoid significant overhead.
 const THREAD_RNG_RESEED_THRESHOLD: i64 = 1024 * 64;
 
+type Core = chacha20::ChaChaCore<chacha20::R12, chacha20::variants::Legacy>;
 type Results = <Core as Generator>::Output;
 
 struct ReseedingCore {


### PR DESCRIPTION
This is the more important part of #1726 and doesn't require a new chacha20 release.

Unfortunately we don't have any test vectors since `ThreadRng` is not designed for use with fixed seeds.