### PR TITLE
Expose ThreadRng internal as ThreadRngCore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 - Document required output order of fn `partial_shuffle` and apply `#[must_use]` ([#1769])
 - Avoid usage of `unsafe` in contexts where non-local memory corruption could invalidate contract ([#1791])
 
+### Additions
+- Expose `ThreadRng` internal as `ThreadRngCore` ([#1750])
+
+[#1750]: https://github.com/rust-random/rand/pull/1750
 [#1769]: https://github.com/rust-random/rand/pull/1769
 [#1790]: https://github.com/rust-random/rand/pull/1790
 [#1791]: https://github.com/rust-random/rand/pull/1791

--- a/src/rngs/mod.rs
+++ b/src/rngs/mod.rs
@@ -52,6 +52,9 @@
 //!
 //! ### Additional generators
 //!
+//! -   [`ThreadRngCore`] is the underlying, periodically seeded PRNG of
+//!     [`ThreadRng`] that allows users to utilize the same reseeding generator
+//!     where `Send` or `Sync` is required.
 //! -   The [`rdrand`] crate provides an interface to the RDRAND and RDSEED
 //!     instructions available in modern Intel and AMD CPUs.
 //! -   The [`rand_jitter`] crate provides a user-space implementation of
@@ -110,7 +113,7 @@ pub use xoshiro256plusplus::Xoshiro256PlusPlus;
 #[cfg(feature = "std_rng")]
 pub use self::std::StdRng;
 #[cfg(feature = "thread_rng")]
-pub use self::thread::ThreadRng;
+pub use self::thread::{ThreadRng, ThreadRngCore};
 
 #[cfg(feature = "chacha")]
 pub use chacha20::{ChaCha8Rng, ChaCha12Rng, ChaCha20Rng};

--- a/src/rngs/thread.rs
+++ b/src/rngs/thread.rs
@@ -72,6 +72,62 @@ impl ReseedingCore {
     }
 }
 
+/// The [`ThreadRng`] internal
+///
+/// This type is the underlying, periodically seeded pseudorandom number generator that powers
+/// [`ThreadRng`]. The same Security design criteria and consideration as those of [`ThreadRng`]
+/// apply, whereas it allows users to utilize the same reseeding generator where `Send` or `Sync`
+/// is required.
+struct ThreadRngCore {
+    inner: BlockRng<ReseedingCore>,
+}
+
+/// Debug implementation does not leak internal state
+impl fmt::Debug for ThreadRngCore {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "ThreadRngCore {{ .. }}")
+    }
+}
+
+impl ThreadRngCore {
+    /// Initialize the generator using [`SysRng`]
+    fn new() -> Result<Self, SysError> {
+        Core::try_from_rng(&mut SysRng).map(|result| Self {
+            inner: BlockRng::new(ReseedingCore { inner: result }),
+        })
+    }
+
+    /// Immediately reseed the generator
+    ///
+    /// This discards any remaining random data in the cache.
+    fn reseed(&mut self) -> Result<(), SysError> {
+        self.inner.reset_and_skip(0);
+        self.inner.core.reseed()
+    }
+}
+
+impl TryRng for ThreadRngCore {
+    type Error = Infallible;
+
+    #[inline(always)]
+    fn try_next_u32(&mut self) -> Result<u32, Infallible> {
+        Ok(self.inner.next_word())
+    }
+
+    #[inline(always)]
+    fn try_next_u64(&mut self) -> Result<u64, Infallible> {
+        Ok(self.inner.next_u64_from_u32())
+    }
+
+    #[inline(always)]
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Infallible> {
+        self.inner.fill_bytes(dest);
+        Ok(())
+    }
+}
+
+impl TryCryptoRng for ThreadRngCore {}
+
 /// A reference to the thread-local generator
 ///
 /// This type is a reference to a lazily-initialized thread-local generator.
@@ -131,7 +187,7 @@ impl ReseedingCore {
 #[derive(Clone)]
 pub struct ThreadRng {
     // Rc is explicitly !Send and !Sync
-    rng: Rc<UnsafeCell<BlockRng<ReseedingCore>>>,
+    rng: Rc<UnsafeCell<ThreadRngCore>>,
 }
 
 impl ThreadRng {
@@ -142,8 +198,7 @@ impl ThreadRng {
         // SAFETY: We must make sure to stop using `rng` before anyone else
         // creates another mutable reference
         let rng = unsafe { &mut *self.rng.get() };
-        rng.reset_and_skip(0);
-        rng.core.reseed()
+        rng.reseed()
     }
 }
 
@@ -157,13 +212,10 @@ impl fmt::Debug for ThreadRng {
 thread_local!(
     // We require Rc<..> to avoid premature freeing when ThreadRng is used
     // within thread-local destructors. See #968.
-    static THREAD_RNG_KEY: Rc<UnsafeCell<BlockRng<ReseedingCore>>> = {
-        Rc::new(UnsafeCell::new(BlockRng::new(ReseedingCore {
-            inner: Core::try_from_rng(&mut SysRng).unwrap_or_else(|err| {
-                panic!("could not initialize ThreadRng: {}", err)
-            }),
-        })))
-    }
+    static THREAD_RNG_KEY: Rc<UnsafeCell<ThreadRngCore>> = Rc::new(UnsafeCell::new(
+        ThreadRngCore::new()
+            .unwrap_or_else(|err| panic!("could not initialize ThreadRng: {}", err)),
+    ));
 );
 
 /// Access a fast, pre-initialized generator
@@ -217,7 +269,7 @@ impl TryRng for ThreadRng {
         // SAFETY: We must make sure to stop using `rng` before anyone else
         // creates another mutable reference
         let rng = unsafe { &mut *self.rng.get() };
-        Ok(rng.next_word())
+        rng.try_next_u32()
     }
 
     #[inline(always)]
@@ -225,7 +277,7 @@ impl TryRng for ThreadRng {
         // SAFETY: We must make sure to stop using `rng` before anyone else
         // creates another mutable reference
         let rng = unsafe { &mut *self.rng.get() };
-        Ok(rng.next_u64_from_u32())
+        rng.try_next_u64()
     }
 
     #[inline(always)]
@@ -233,8 +285,7 @@ impl TryRng for ThreadRng {
         // SAFETY: We must make sure to stop using `rng` before anyone else
         // creates another mutable reference
         let rng = unsafe { &mut *self.rng.get() };
-        rng.fill_bytes(dest);
-        Ok(())
+        rng.try_fill_bytes(dest)
     }
 }
 
@@ -251,9 +302,21 @@ mod test {
     }
 
     #[test]
+    fn test_thread_rng_core() {
+        use crate::RngExt;
+        let mut r = super::ThreadRngCore::new().unwrap();
+        r.random::<i32>();
+        assert_eq!(r.random_range(0..1), 0);
+    }
+
+    #[test]
     fn test_debug_output() {
         // We don't care about the exact output here, but it must not include
         // private CSPRNG state or the cache stored by BlockRng!
         assert_eq!(std::format!("{:?}", crate::rng()), "ThreadRng { .. }");
+        assert_eq!(
+            std::format!("{:?}", super::ThreadRngCore::new().unwrap()),
+            "ThreadRngCore { .. }"
+        );
     }
 }

--- a/src/rngs/thread.rs
+++ b/src/rngs/thread.rs
@@ -78,7 +78,7 @@ impl ReseedingCore {
 /// [`ThreadRng`]. The same Security design criteria and consideration as those of [`ThreadRng`]
 /// apply, whereas it allows users to utilize the same reseeding generator where `Send` or `Sync`
 /// is required.
-struct ThreadRngCore {
+pub struct ThreadRngCore {
     inner: BlockRng<ReseedingCore>,
 }
 
@@ -91,7 +91,7 @@ impl fmt::Debug for ThreadRngCore {
 
 impl ThreadRngCore {
     /// Initialize the generator using [`SysRng`]
-    fn new() -> Result<Self, SysError> {
+    pub fn new() -> Result<Self, SysError> {
         Core::try_from_rng(&mut SysRng).map(|result| Self {
             inner: BlockRng::new(ReseedingCore { inner: result }),
         })
@@ -100,7 +100,7 @@ impl ThreadRngCore {
     /// Immediately reseed the generator
     ///
     /// This discards any remaining random data in the cache.
-    fn reseed(&mut self) -> Result<(), SysError> {
+    pub fn reseed(&mut self) -> Result<(), SysError> {
         self.inner.reset_and_skip(0);
         self.inner.core.reseed()
     }


### PR DESCRIPTION
This commit refactors `ThreadRng` to separate its internal PRNG and reseeding logic as `ThreadRngCore` so the new type could be exposed to public in the future for those who want to copy `ThreadRng` behavior with an independent state or in a Send + Sync context.

See also #1748 
