### PR TITLE
seq: fix duplicate indices in sample_floyd

### DIFF
--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -451,8 +451,9 @@ where
         let t = rng.random_range(..=j);
         if let Some(pos) = indices.iter().position(|&x| x == t) {
             indices[pos] = j;
+        } else {
+            indices.push(t);
         }
-        indices.push(t);
     }
     IndexVec::from(indices)
 }


### PR DESCRIPTION
## Fix duplicate indices in [sample_floyd](cci:1://file://wsl.localhost/Ubuntu/home/prarthana/rust-random/src/seq/index.rs:434:0-458:1)

### Problem

[sample_floyd](cci:1://file://wsl.localhost/Ubuntu/home/prarthana/rust-random/src/seq/index.rs:434:0-458:1) implements Floyd's combination algorithm to sample
`amount` distinct indices from `0..length`. The algorithm has two cases
for each step:

- If the randomly picked value `t` is **already in the set** → add `j` instead
- If `t` is **new** → add `t`

The previous code unconditionally called `indices.push(t)` after the
`if let` block, so when `t` was a duplicate it was both replaced by `j`
at its old position **and** re-appended — producing duplicate indices
in the output.

### Fix

Move `push(t)` into the `else` branch so it only runs when `t` is
a genuinely new element:

```rust
// Before
if let Some(pos) = indices.iter().position(|&x| x == t) {
    indices[pos] = j;
}
indices.push(t); // always ran — bug!

// After
if let Some(pos) = indices.iter().position(|&x| x == t) {
    indices[pos] = j;
} else {
    indices.push(t); // only when t is new
}

