### PR TITLE
make_rng: document panic and add #[track_caller]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ A [separate changelog is kept for rand_core](https://github.com/rust-random/core
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [Unreleased]
+- Document panic behavior of `make_rng` and add `#[track_caller]` (#1761)
+
 ## [0.10.0] - 2026-02-08
 
 ### Changes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ use crate::distr::{Distribution, StandardUniform};
 /// [`ThreadRng`]: crate::rngs::ThreadRng
 /// [`ThreadRng#Security`]: crate::rngs::ThreadRng#security
 #[cfg(feature = "sys_rng")]
+#[track_caller]
 pub fn make_rng<R: SeedableRng>() -> R {
     #[cfg(feature = "thread_rng")]
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,11 @@ use crate::distr::{Distribution, StandardUniform};
 /// # let _ = rand::Rng::next_u32(&mut rng);
 /// ```
 ///
+/// # Panics
+///
+/// If [`SysRng`] fails to obtain entropy from the OS. This is unlikely
+/// outside of early boot or unusual system conditions.
+///
 /// # Security
 ///
 /// Refer to [`ThreadRng#Security`].


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Document that `make_rng` can panic, and add `#[track_caller]` to improve panic diagnostics.

# Motivation

`make_rng` calls `expect` on the result of `SysRng` seeding, but had no `# Panics` section in its doc comment. This is inconsistent with the rest of the crate where panicking functions document the conditions (e.g. `random_range`, `random_bool`, `random_ratio`), and the `#[track_caller]` convention established in #1447.

# Details

- Added a `# Panics` section following the existing crate style
- Added `#[track_caller]` so panics point to the call site rather than the `expect` inside `make_rng`