### PR TITLE
Prepare v0.9.3: deprecate feature `log`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
-## [0.9.2 — 2025-07-20]
+## [0.9.3] — 2026-02-09
+### Deprecated
+- Deprecate feature `log`
+
+## [0.9.2] — 2025-07-20
 ### Deprecated
 - Deprecate `rand::rngs::mock` module and `StepRng` generator (#1634)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ thread_rng = ["std", "std_rng", "os_rng"]
 # Note: enabling this option is expected to affect reproducibility of results.
 unbiased = []
 
-# Option: enable logging
-log = ["dep:log"]
+# Deprecated option: enable logging
+log = []
 
 [workspace]
 members = [
@@ -72,7 +72,6 @@ exclude = ["benches", "distr_test"]
 
 [dependencies]
 rand_core = { path = "rand_core", version = "0.9.0", default-features = false }
-log = { version = "0.4.4", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 rand_chacha = { path = "rand_chacha", version = "0.9.0", default-features = false, optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -71,10 +71,6 @@ Rand is built with these features enabled by default:
 -   `std_rng` enables inclusion of `StdRng`, `ThreadRng`
 -   `small_rng` enables inclusion of the `SmallRng` PRNG
 
-Optionally, the following dependencies can be enabled:
-
--   `log` enables logging via [log](https://crates.io/crates/log)
-
 Additionally, these features configure Rand:
 
 -   `nightly` includes some additions requiring nightly Rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,37 +66,6 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-#[allow(unused)]
-macro_rules! trace { ($($x:tt)*) => (
-    #[cfg(feature = "log")] {
-        log::trace!($($x)*)
-    }
-) }
-#[allow(unused)]
-macro_rules! debug { ($($x:tt)*) => (
-    #[cfg(feature = "log")] {
-        log::debug!($($x)*)
-    }
-) }
-#[allow(unused)]
-macro_rules! info { ($($x:tt)*) => (
-    #[cfg(feature = "log")] {
-        log::info!($($x)*)
-    }
-) }
-#[allow(unused)]
-macro_rules! warn { ($($x:tt)*) => (
-    #[cfg(feature = "log")] {
-        log::warn!($($x)*)
-    }
-) }
-#[allow(unused)]
-macro_rules! error { ($($x:tt)*) => (
-    #[cfg(feature = "log")] {
-        log::error!($($x)*)
-    }
-) }
-
 // Re-export rand_core itself
 pub use rand_core;
 

--- a/src/rngs/reseeding.rs
+++ b/src/rngs/reseeding.rs
@@ -214,13 +214,10 @@ where
 
     #[inline(never)]
     fn reseed_and_generate(&mut self, results: &mut <Self as BlockRngCore>::Results) {
-        trace!("Reseeding RNG (periodic reseed)");
-
         let num_bytes = size_of_val(results.as_ref());
 
         if let Err(e) = self.reseed() {
-            warn!("Reseeding RNG failed: {}", e);
-            let _ = e;
+            panic!("Reseeding RNG failed: {e}");
         }
 
         self.bytes_until_reseed = self.threshold - num_bytes as i64;


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Deprecates the `log` feature and removes the `log` dependency.