### PR TITLE
Prepare v0.9.4: fix doc build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
-## [0.9.3] — 2026-02-11
+## [0.9.4] — 2026-04-13
+### Fixes
+- Fix doc build ([#1766])
+
+[#1766]: https://github.com/rust-random/rand/pull/1766
+
+## [0.9.3] — 2026-04-11
 This release back-ports a fix from v0.10. See also [#1763].
 
 ### Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -19,8 +19,8 @@ include = ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
 
 [package.metadata.docs.rs]
 # To build locally:
-# RUSTDOCFLAGS="--cfg docsrs -Zunstable-options --generate-link-to-definition" cargo +nightly doc --all --all-features --no-deps --open
-all-features = true
+# RUSTDOCFLAGS="--cfg docsrs -Zunstable-options --generate-link-to-definition" cargo +nightly doc --all --features serde,unbiased --no-deps --open
+features = ["serde", "unbiased"]
 rustdoc-args = ["--generate-link-to-definition"]
 
 [package.metadata.playground]

--- a/src/rngs/reseeding.rs
+++ b/src/rngs/reseeding.rs
@@ -41,14 +41,11 @@ use rand_core::{CryptoRng, RngCore, SeedableRng, TryCryptoRng, TryRngCore};
 ///
 /// # Error handling
 ///
-/// Although unlikely, reseeding the wrapped PRNG can fail. `ReseedingRng` will
-/// never panic but try to handle the error intelligently through some
-/// combination of retrying and delaying reseeding until later.
-/// If handling the source error fails `ReseedingRng` will continue generating
-/// data from the wrapped PRNG without reseeding.
+/// Errors during reseeding are extremely unlikely, assuming the same random
+/// source successfully initialized the inner PRNG. A reseeding failure will be
+/// reported via panic (new behaviour since v0.9.3).
 ///
-/// Manually calling [`reseed()`] will not have this retry or delay logic, but
-/// reports the error.
+/// Manually calling [`reseed()`] will report errors.
 ///
 /// # Example
 ///


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Fix doc build

(This wouldn't have happened if I'd completely removed `simd_support`.)