### PR TITLE
add must_use to partial_shuffle

### DIFF
--- a/benches/benches/shuffle.rs
+++ b/benches/benches/shuffle.rs
@@ -52,7 +52,7 @@ fn bench_rng<R: Rng + SeedableRng>(c: &mut Criterion, rng_name: &'static str) {
                 let mut rng = R::seed_from_u64(123);
                 let mut vec: Vec<usize> = (0..length).collect();
                 b.iter(|| {
-                    vec.partial_shuffle(&mut rng, length / 2);
+                    let _ = vec.partial_shuffle(&mut rng, length / 2);
                     vec[0]
                 })
             });

--- a/src/seq/slice.rs
+++ b/src/seq/slice.rs
@@ -441,7 +441,7 @@ pub trait SliceRandom: IndexedMutRandom {
     /// # Warning
     ///
     /// The position of the returned slices within the original slice is not guaranteed. 
-    /// 
+    ///
     /// # Example
     ///
     /// ```

--- a/src/seq/slice.rs
+++ b/src/seq/slice.rs
@@ -437,6 +437,23 @@ pub trait SliceRandom: IndexedMutRandom {
     /// will perform a full shuffle.
     ///
     /// For slices, complexity is `O(m)` where `m = amount`.
+    ///
+    /// # Warning
+    ///
+    /// The position of the returned slices within the original slice is not guaranteed. 
+    /// 
+    /// # Example
+    ///
+    /// ```
+    /// use rand::seq::SliceRandom;
+    ///
+    /// let mut rng = rand::rng();
+    /// let mut y = [1, 2, 3, 4, 5];
+    /// let (shuffled, rest) = y.partial_shuffle(&mut rng, 3);
+    /// assert_eq!(shuffled.len(), 3);
+    /// assert_eq!(rest.len(), 2);
+    /// ```
+    #[must_use = "the returned subslices should be used to access the shuffled elements; their position within the original slice is an implementation detail"]
     fn partial_shuffle<R>(
         &mut self,
         rng: &mut R,

--- a/src/seq/slice.rs
+++ b/src/seq/slice.rs
@@ -440,7 +440,7 @@ pub trait SliceRandom: IndexedMutRandom {
     ///
     /// # Warning
     ///
-    /// The position of the returned slices within the original slice is not guaranteed. 
+    /// The position of the returned slices within the original slice is not guaranteed.
     ///
     /// # Example
     ///

--- a/src/seq/slice.rs
+++ b/src/seq/slice.rs
@@ -481,7 +481,7 @@ impl<T> SliceRandom for [T] {
             // There is no need to shuffle an empty or single element slice
             return;
         }
-        self.partial_shuffle(rng, self.len());
+        let _ = self.partial_shuffle(rng, self.len());
     }
 
     fn partial_shuffle<R>(&mut self, rng: &mut R, amount: usize) -> (&mut [T], &mut [T])


### PR DESCRIPTION
- [ ] Added a `CHANGELOG.md` entry

# Summary

`partial_shuffle`'s returned slices are the only correct way to access the regions. Not using them is almost certainly an error.

# Motivation

I noticed that some users don't use the returned subslices of `partial_shuffle`.

Instead they typically assume the shuffled region is at the start of the original slice and are incorrect. Or assume correctly and may silently become incorrect if the implementation changes.

[Here's a Github search of examples.](https://github.com/search?utf8=%E2%9C%93&q=.partial_shuffle%28+lang%3Arust&type=code)
About 13 out of 60 uses ignore the returned slices.
Mostly due to the borrow checker or cloning/`Vec` related inflexibility.

Many users are accessing the unshuffled region instead of the shuffled. When `slice.len()` is much larger than `amount`, this means practically no shuffling occurs in the data they actually use.

# Alternatives

Of course we could instead just guarantee an order but that might prevent future optimizations and would break some users' code anyway.