### PR TITLE
Check UniformChar validity on deser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 
 ## [Unreleased]
 
+### Fixes
+- Fix possible memory safety violation due to deserialization of `UniformChar` from bad source ([#1790])
+
 ### Changes
 - Document required output order of fn `partial_shuffle` and apply `#[must_use]` ([#1769])
 
 [#1769]: https://github.com/rust-random/rand/pull/1769
+[#1790]: https://github.com/rust-random/rand/pull/1790
 
 ## [0.10.1] — 2026-02-11
 This release includes a fix for a soundness bug; see [#1763].

--- a/src/distr/uniform_int.rs
+++ b/src/distr/uniform_int.rs
@@ -79,7 +79,7 @@ macro_rules! uniform_int_impl {
             #[allow(unused)]
             #[inline]
             pub(crate) fn max(&self) -> $ty {
-                self.low + self.range - 1
+                self.range.wrapping_sub(1).wrapping_add(self.low)
             }
         }
 
@@ -702,6 +702,7 @@ mod tests {
         let r = Uniform::try_from(2u32..7).unwrap();
         assert_eq!(r.0.low, 2);
         assert_eq!(r.0.range, 5);
+        assert_eq!(r.0.max(), 6);
     }
 
     #[test]
@@ -716,6 +717,7 @@ mod tests {
         let r = Uniform::try_from(2u32..=6).unwrap();
         assert_eq!(r.0.low, 2);
         assert_eq!(r.0.range, 5);
+        assert_eq!(r.0.max(), 6);
     }
 
     #[test]

--- a/src/distr/uniform_int.rs
+++ b/src/distr/uniform_int.rs
@@ -74,6 +74,15 @@ pub struct UniformInt<X> {
 
 macro_rules! uniform_int_impl {
     ($ty:ty, $uty:ty, $sample_ty:ident) => {
+        impl UniformInt<$ty> {
+            /// Get the maximum possible value
+            #[allow(unused)]
+            #[inline]
+            pub(crate) fn max(&self) -> $ty {
+                self.low + self.range - 1
+            }
+        }
+
         impl SampleUniform for $ty {
             type Sampler = UniformInt<$ty>;
         }

--- a/src/distr/uniform_other.rs
+++ b/src/distr/uniform_other.rs
@@ -33,7 +33,22 @@ impl SampleUniform for char {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UniformChar {
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "deser_sampler"))]
     sampler: UniformInt<u32>,
+}
+
+#[cfg(feature = "serde")]
+fn deser_sampler<'de, D>(d: D) -> Result<UniformInt<u32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let sampler = <UniformInt<u32> as serde::Deserialize>::deserialize(d)?;
+    if sampler.max() > char::MAX as u32 - CHAR_SURROGATE_LEN {
+        return Err(serde::de::Error::custom(
+            "bad sampler range for UniformChar",
+        ));
+    }
+    Ok(sampler)
 }
 
 /// UTF-16 surrogate range start
@@ -247,6 +262,7 @@ impl UniformSampler for UniformDuration {
 mod tests {
     use super::*;
     use crate::RngExt;
+    use std::string::ToString;
 
     #[test]
     #[cfg(feature = "serde")]
@@ -297,6 +313,18 @@ mod tests {
             .sample_string(&mut rng, 100);
             assert_eq!(string3.capacity(), 200);
         }
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_char_bad_deser() {
+        let json = r#"{"sampler":{"low":4294967200,"range":0,"thresh":0}}"#;
+        let result = serde_json::from_str::<Uniform<char>>(json);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "bad sampler range for UniformChar at line 1 column 51"
+        );
     }
 
     #[test]

--- a/src/distr/uniform_other.rs
+++ b/src/distr/uniform_other.rs
@@ -262,7 +262,6 @@ impl UniformSampler for UniformDuration {
 mod tests {
     use super::*;
     use crate::RngExt;
-    use std::string::ToString;
 
     #[test]
     #[cfg(feature = "serde")]
@@ -321,10 +320,16 @@ mod tests {
         let json = r#"{"sampler":{"low":4294967200,"range":0,"thresh":0}}"#;
         let result = serde_json::from_str::<Uniform<char>>(json);
         assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "bad sampler range for UniformChar at line 1 column 51"
-        );
+        let err = result.unwrap_err();
+        assert_eq!(err.classify(), serde_json::error::Category::Data);
+
+        #[cfg(feature = "alloc")]
+        {
+            assert_eq!(
+                alloc::string::ToString::to_string(&err),
+                "bad sampler range for UniformChar at line 1 column 51"
+            );
+        }
     }
 
     #[test]

--- a/src/seq/slice.rs
+++ b/src/seq/slice.rs
@@ -823,6 +823,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "std")]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_multiple_weighted_distributions() {
         use super::*;
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Prevent memory safety violation in `UniformChar` via deserialization.