### PR TITLE
rand v0.9.5: backport #1790

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [0.9.5] — 2026-07-02
+### Fixes
+- Fix possible memory safety violation due to deserialization of `UniformChar` from bad source ([#1803])
+
+[#1803]: https://github.com/rust-random/rand/pull/1803
+
 ## [0.9.4] — 2026-04-13
 ### Fixes
 - Fix doc build ([#1766])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/distr/uniform_int.rs
+++ b/src/distr/uniform_int.rs
@@ -76,6 +76,15 @@ pub struct UniformInt<X> {
 
 macro_rules! uniform_int_impl {
     ($ty:ty, $uty:ty, $sample_ty:ident) => {
+        impl UniformInt<$ty> {
+            /// Get the maximum possible value
+            #[allow(unused)]
+            #[inline]
+            pub(crate) fn max(&self) -> $ty {
+                self.range.wrapping_sub(1).wrapping_add(self.low)
+            }
+        }
+
         impl SampleUniform for $ty {
             type Sampler = UniformInt<$ty>;
         }
@@ -697,6 +706,7 @@ mod tests {
         let r = Uniform::try_from(2u32..7).unwrap();
         assert_eq!(r.0.low, 2);
         assert_eq!(r.0.range, 5);
+        assert_eq!(r.0.max(), 6);
     }
 
     #[test]
@@ -711,6 +721,7 @@ mod tests {
         let r = Uniform::try_from(2u32..=6).unwrap();
         assert_eq!(r.0.low, 2);
         assert_eq!(r.0.range, 5);
+        assert_eq!(r.0.max(), 6);
     }
 
     #[test]

--- a/src/distr/uniform_other.rs
+++ b/src/distr/uniform_other.rs
@@ -33,7 +33,22 @@ impl SampleUniform for char {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UniformChar {
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "deser_sampler"))]
     sampler: UniformInt<u32>,
+}
+
+#[cfg(feature = "serde")]
+fn deser_sampler<'de, D>(d: D) -> Result<UniformInt<u32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let sampler = <UniformInt<u32> as serde::Deserialize>::deserialize(d)?;
+    if sampler.max() > char::MAX as u32 - CHAR_SURROGATE_LEN {
+        return Err(serde::de::Error::custom(
+            "bad sampler range for UniformChar",
+        ));
+    }
+    Ok(sampler)
 }
 
 /// UTF-16 surrogate range start
@@ -295,6 +310,24 @@ mod tests {
             .unwrap()
             .sample_string(&mut rng, 100);
             assert_eq!(string3.capacity(), 200);
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_char_bad_deser() {
+        let json = r#"{"sampler":{"low":4294967200,"range":0,"thresh":0}}"#;
+        let result = serde_json::from_str::<Uniform<char>>(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.classify(), serde_json::error::Category::Data);
+
+        #[cfg(feature = "alloc")]
+        {
+            assert_eq!(
+                alloc::string::ToString::to_string(&err),
+                "bad sampler range for UniformChar at line 1 column 51"
+            );
         }
     }
 

--- a/src/seq/slice.rs
+++ b/src/seq/slice.rs
@@ -724,6 +724,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "std")]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_multiple_weighted_distributions() {
         use super::*;
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Backport #1790 to rand 0.9.5.

# Motivation

This changes address an unsoundness issue: code like the following could yield a `Distribution` object yielding invalid `char` values when sampled (unsound):
```rust
        let json = r#"{"sampler":{"low":4294967200,"range":0,"thresh":0}}"#;
        let result = serde_json::from_str::<Uniform<char>>(json);
```