### PR TITLE
Use Xoshiro256PlusPlus in examples/rayon-monte-carlo.rs

### DIFF
--- a/benches/benches/generators.rs
+++ b/benches/benches/generators.rs
@@ -12,7 +12,7 @@ use core::time::Duration;
 use criterion::measurement::WallTime;
 use criterion::{BenchmarkGroup, Criterion, black_box, criterion_group, criterion_main};
 use rand::prelude::*;
-use rand::rngs::SysRng;
+use rand::rngs::{SysRng, Xoshiro128PlusPlus, Xoshiro256PlusPlus};
 use rand_pcg::{Pcg32, Pcg64, Pcg64Dxsm, Pcg64Mcg};
 
 criterion_group!(
@@ -45,8 +45,8 @@ pub fn random_bytes(c: &mut Criterion) {
     bench(&mut g, "chacha8", rand::make_rng::<ChaCha8Rng>());
     bench(&mut g, "chacha12", rand::make_rng::<ChaCha12Rng>());
     bench(&mut g, "chacha20", rand::make_rng::<ChaCha20Rng>());
-    bench(&mut g, "std", rand::make_rng::<StdRng>());
-    bench(&mut g, "small", rand::make_rng::<SmallRng>());
+    bench(&mut g, "xoshiro128++", rand::make_rng::<Xoshiro128PlusPlus>());
+    bench(&mut g, "xoshiro256++", rand::make_rng::<Xoshiro256PlusPlus>());
     bench(&mut g, "os", UnwrapErr(SysRng));
     bench(&mut g, "thread", rand::rng());
 
@@ -73,8 +73,8 @@ pub fn random_u32(c: &mut Criterion) {
     bench(&mut g, "chacha8", rand::make_rng::<ChaCha8Rng>());
     bench(&mut g, "chacha12", rand::make_rng::<ChaCha12Rng>());
     bench(&mut g, "chacha20", rand::make_rng::<ChaCha20Rng>());
-    bench(&mut g, "std", rand::make_rng::<StdRng>());
-    bench(&mut g, "small", rand::make_rng::<SmallRng>());
+    bench(&mut g, "xoshiro128++", rand::make_rng::<Xoshiro128PlusPlus>());
+    bench(&mut g, "xoshiro256++", rand::make_rng::<Xoshiro256PlusPlus>());
     bench(&mut g, "os", UnwrapErr(SysRng));
     bench(&mut g, "thread", rand::rng());
 
@@ -101,8 +101,8 @@ pub fn random_u64(c: &mut Criterion) {
     bench(&mut g, "chacha8", rand::make_rng::<ChaCha8Rng>());
     bench(&mut g, "chacha12", rand::make_rng::<ChaCha12Rng>());
     bench(&mut g, "chacha20", rand::make_rng::<ChaCha20Rng>());
-    bench(&mut g, "std", rand::make_rng::<StdRng>());
-    bench(&mut g, "small", rand::make_rng::<SmallRng>());
+    bench(&mut g, "xoshiro128++", rand::make_rng::<Xoshiro128PlusPlus>());
+    bench(&mut g, "xoshiro256++", rand::make_rng::<Xoshiro256PlusPlus>());
     bench(&mut g, "os", UnwrapErr(SysRng));
     bench(&mut g, "thread", rand::rng());
 
@@ -128,8 +128,8 @@ pub fn init_gen(c: &mut Criterion) {
     bench::<ChaCha8Rng>(&mut g, "chacha8");
     bench::<ChaCha12Rng>(&mut g, "chacha12");
     bench::<ChaCha20Rng>(&mut g, "chacha20");
-    bench::<StdRng>(&mut g, "std");
-    bench::<SmallRng>(&mut g, "small");
+    bench::<Xoshiro128PlusPlus>(&mut g, "xoshiro128++");
+    bench::<Xoshiro256PlusPlus>(&mut g, "xoshiro256++");
 
     g.finish()
 }
@@ -154,8 +154,8 @@ pub fn init_from_u64(c: &mut Criterion) {
     bench::<ChaCha8Rng>(&mut g, "chacha8");
     bench::<ChaCha12Rng>(&mut g, "chacha12");
     bench::<ChaCha20Rng>(&mut g, "chacha20");
-    bench::<StdRng>(&mut g, "std");
-    bench::<SmallRng>(&mut g, "small");
+    bench::<Xoshiro128PlusPlus>(&mut g, "xoshiro128++");
+    bench::<Xoshiro256PlusPlus>(&mut g, "xoshiro256++");
 
     g.finish()
 }
@@ -183,8 +183,8 @@ pub fn init_from_seed(c: &mut Criterion) {
     bench::<ChaCha8Rng>(&mut g, "chacha8");
     bench::<ChaCha12Rng>(&mut g, "chacha12");
     bench::<ChaCha20Rng>(&mut g, "chacha20");
-    bench::<StdRng>(&mut g, "std");
-    bench::<SmallRng>(&mut g, "small");
+    bench::<Xoshiro128PlusPlus>(&mut g, "xoshiro128++");
+    bench::<Xoshiro256PlusPlus>(&mut g, "xoshiro256++");
 
     g.finish()
 }

--- a/examples/rayon-monte-carlo.rs
+++ b/examples/rayon-monte-carlo.rs
@@ -24,28 +24,23 @@
 //! the square at random, calculate the fraction that fall within the circle,
 //! and multiply this fraction by 4.
 //!
-//! Note on determinism:
-//! It's slightly tricky to build a parallel simulation using Rayon
-//! which is both efficient *and* reproducible.
+//! ### A note on the use of explicit batching
 //!
-//! Rayon's ParallelIterator api does not guarantee that the work will be
-//! batched into identical batches on every run, so we can't simply use
-//! map_init to construct one RNG per Rayon batch.
+//! Rayon's `ParallelIterator::map_init` does not guarantee that the work will
+//! be batched identically on every run. By using the `map` function to
+//! construct fixed-size batches, each with a dedicated PRNG, we are able to
+//! achieve a deterministic result with little extra code.
 //!
-//! Instead, we do our own batching, so that a Rayon work item becomes a
-//! batch. Then we can fix our rng stream to the batched work item.
-//! Batching amortizes the cost of constructing the Rng from a fixed seed
-//! over BATCH_SIZE trials. Manually batching also turns out to be faster
-//! for the nondeterministic version of this program as well.
+//! Due to the small work-item size (the inner loop) batching also improves
+//! performance significantly due to the reduced scheduling overhead.
 
-use chacha20::ChaCha8Rng;
 use rand::distr::{Distribution, Uniform};
+use rand::rngs::Xoshiro256PlusPlus;
 use rand_core::SeedableRng;
 use rayon::prelude::*;
 
-static SEED: u64 = 0;
-static BATCH_SIZE: u64 = 10_000;
-static BATCHES: u64 = 1000;
+const BATCH_SIZE: u64 = 10_000;
+const BATCHES: u64 = 1000;
 
 fn main() {
     let range = Uniform::new(-1.0f64, 1.0).unwrap();
@@ -53,11 +48,10 @@ fn main() {
     let in_circle = (0..BATCHES)
         .into_par_iter()
         .map(|i| {
-            let mut rng = ChaCha8Rng::seed_from_u64(SEED);
-            // We chose ChaCha because it's fast, has suitable statistical properties for simulation,
-            // and because it supports this set_stream() api, which lets us choose a different stream
-            // per work item. ChaCha supports 2^64 independent streams.
-            rng.set_stream(i);
+            // If we didn't care for determinism we could use SmallRng instead:
+            // let mut rng: SmallRng = rand::make_rng();
+            let mut rng = Xoshiro256PlusPlus::seed_from_u64(i);
+
             let mut count = 0;
             for _ in 0..BATCH_SIZE {
                 let a = range.sample(&mut rng);
@@ -71,7 +65,7 @@ fn main() {
         .sum::<usize>();
 
     // assert this is deterministic
-    assert_eq!(in_circle, 7852263);
+    assert_eq!(in_circle, 7853568);
 
     // prints something close to 3.14159...
     println!(


### PR DESCRIPTION
# Summary

- Add the xoshiro PRNGs in rand::rngs to the local benchmark (redundant with the rngs repo benchmark).
- Remove `SmallRng` and `StdRng` from this benchmark (both are thin wrappers around another benchmarked PRNG)
- Adapt the `rayon-monte-carlo` example to use `Xoshiro256PlusPlus` instead of `ChaCha8Rng`

# Motivation

Upon consideration of #1781, it occurs to me that there is very little reason to use a thread-local `SmallRng` instead of a new local one. (In fact, a thread-local one would likely perform worse if we were to use the same per-usage locking as we do in `ThreadRng`.)

# Details

The rayon example now uses multiple seeds instead of a single seed with multiple streams/jumps. I believe this is acceptable. We could instead use `jump` or [`jump_n`](https://github.com/rust-random/rngs/pull/117), though (a) we don't have those facilities in the `rand::rngs` code and (b) I see no reason why this would be preferable. See also [the book: parallel RNGs](https://rust-random.github.io/book/guide-parallel.html). CC @vigna.