### PR TITLE
Fix incorrect docs for Bernoulli::from_ratio and add a doc-test

### DIFF
--- a/src/distr/bernoulli.rs
+++ b/src/distr/bernoulli.rs
@@ -117,13 +117,28 @@ impl Bernoulli {
     }
 
     /// Construct a new `Bernoulli` with the probability of success of
-    /// `numerator`-in-`denominator`. I.e. `new_ratio(2, 3)` will return
+    /// `numerator`-in-`denominator`. I.e. `from_ratio(2, 3)` will return
     /// a `Bernoulli` with a 2-in-3 chance, or about 67%, of returning `true`.
     ///
-    /// return `true`. If `numerator == 0` it will always return `false`.
-    /// For `numerator > denominator` and `denominator == 0`, this returns an
-    /// error. Otherwise, for `numerator == denominator`, samples are always
-    /// true; for `numerator == 0` samples are always false.
+    /// For `numerator == denominator`, the resulting distribution will always
+    /// return `true`; for `numerator == 0` it will always return `false`.
+    /// For `numerator > denominator` or `denominator == 0`, this returns an
+    /// error.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rand::distr::Bernoulli;
+    ///
+    /// let d = Bernoulli::from_ratio(2, 3).unwrap();
+    /// assert!((d.p() - 2.0 / 3.0).abs() < 1e-9);
+    ///
+    /// // Edge cases:
+    /// assert_eq!(Bernoulli::from_ratio(3, 3).unwrap().p(), 1.0); // always true
+    /// assert_eq!(Bernoulli::from_ratio(0, 3).unwrap().p(), 0.0); // always false
+    /// assert!(Bernoulli::from_ratio(4, 3).is_err());             // numerator > denominator
+    /// assert!(Bernoulli::from_ratio(1, 0).is_err());             // denominator == 0
+    /// ```
     #[inline]
     pub fn from_ratio(numerator: u32, denominator: u32) -> Result<Bernoulli, BernoulliError> {
         if numerator > denominator || denominator == 0 {


### PR DESCRIPTION
## What

Corrects the doc comment on `Bernoulli::from_ratio` and adds a runnable example.

The previous docs had three inaccuracies:

- The example referenced `new_ratio(2, 3)`, but the method is named `from_ratio`; `new_ratio` no longer exists, so following the example gives a compile error.
- A prior edit left an orphaned, subjectless fragment: *"return `true`. If `numerator == 0` it will always return `false`."*
- The error condition was described as *"For `numerator > denominator` and `denominator == 0`"*, but the implementation is `if numerator > denominator || denominator == 0` — two independent conditions joined by OR, not AND.

`from_ratio` also lacked a runnable example, unlike its siblings (`new`, etc.).

## Why

The rendered documentation was misleading: it named a nonexistent method, contained a garbled sentence, and mis-stated when an error is returned. A reader following the old example would hit a compile error, and the AND wording contradicts the actual OR behavior.

## Testing

- `cargo test --doc from_ratio` — the new doc-test compiles and passes. It checks `d.p()` is within `1e-9` of `2/3`, that `from_ratio(3, 3).p() == 1.0` and `from_ratio(0, 3).p() == 0.0`, and that `from_ratio(4, 3)` and `from_ratio(1, 0)` both return `Err`.
- `cargo fmt --check` — clean.
- `cargo clippy --lib` — clean.

Doc-only change; the function body is untouched.
