### PR TITLE
Return Error::Overflow from WeightedIndex on float weight overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ A [separate changelog is kept for rand_core](https://github.com/rust-random/core
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [Unreleased]
+
+### Fixes
+- Fix `WeightedIndex` panic when the sum of float weights is infinite; return `Error::Overflow` instead ([#1808])
+
+[#1808]: https://github.com/rust-random/rand/pull/1808
+
 ## [0.10.2] — 2026-07-02
 
 ### Fixes

--- a/src/distr/weighted/weighted_index.rs
+++ b/src/distr/weighted/weighted_index.rs
@@ -127,7 +127,7 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
         if total_weight == zero {
             return Err(Error::InsufficientNonZero);
         }
-        let distr = X::Sampler::new(zero, total_weight.clone()).unwrap();
+        let distr = X::Sampler::new(zero, total_weight.clone()).map_err(|_| Error::Overflow)?;
 
         Ok(WeightedIndex {
             cumulative_weights: weights,
@@ -152,6 +152,7 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
     ///     Note that due to floating-point loss of precision, this case is not
     ///     always correctly detected; usage of a fixed-point weight type may be
     ///     preferred.
+    /// -   [`Error::Overflow`] when the sum of all weights overflows.
     ///
     /// Updates take `O(N)` time. If you need to frequently update weights, consider
     /// [`rand_distr::weighted_tree`](https://docs.rs/rand_distr/*/rand_distr/weighted_tree/index.html)
@@ -203,6 +204,8 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
         if total_weight <= zero {
             return Err(Error::InsufficientNonZero);
         }
+        let weight_distribution =
+            X::Sampler::new(zero.clone(), total_weight.clone()).map_err(|_| Error::Overflow)?;
 
         // Update the weights. Because we checked all the preconditions in the
         // previous loop, this should never panic.
@@ -233,7 +236,7 @@ impl<X: SampleUniform + PartialOrd> WeightedIndex<X> {
         }
 
         self.total_weight = total_weight;
-        self.weight_distribution = X::Sampler::new(zero, self.total_weight.clone()).unwrap();
+        self.weight_distribution = weight_distribution;
 
         Ok(())
     }
@@ -628,5 +631,26 @@ mod test {
     #[test]
     fn overflow() {
         assert_eq!(WeightedIndex::new([2, usize::MAX]), Err(Error::Overflow));
+    }
+
+    #[test]
+    fn overflow_float() {
+        assert_eq!(
+            WeightedIndex::new([f64::MAX, f64::MAX]),
+            Err(Error::Overflow)
+        );
+        assert_eq!(
+            WeightedIndex::new([f32::MAX, f32::MAX]),
+            Err(Error::Overflow)
+        );
+        assert_eq!(WeightedIndex::new([f64::INFINITY]), Err(Error::Overflow));
+
+        // In case of error, self is not modified.
+        let mut distr = WeightedIndex::new([1.0f64, 2.0]).unwrap();
+        assert_eq!(
+            distr.update_weights(&[(0, &f64::MAX), (1, &f64::MAX)]),
+            Err(Error::Overflow)
+        );
+        assert_eq!(distr, WeightedIndex::new([1.0f64, 2.0]).unwrap());
     }
 }


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

`WeightedIndex::new` and `update_weights` panic when the sum of float weights reaches infinity. Return `Error::Overflow` instead, as already documented and as done for integer weights.

# Motivation

`WeightedIndex::new` documents `Error::Overflow` when the sum of weights overflows, but `Weight::checked_add_assign` never errors for floats — the sum just becomes infinite. `UniformFloat::new` then rejects the non-finite bound and the `.unwrap()` on `X::Sampler::new` panics:

```rust
WeightedIndex::new([f64::MAX, f64::MAX]); // panics: NonFinite
```

#1353 fixed this for integer weights; float weights were missed.

`update_weights` has the same unwrap, and worse: it panics *after* the cumulative weights have already been mutated, violating the documented "in case of error, `self` is not modified" contract.

# Details

- In `new`, map the sampler error to `Error::Overflow`.
- In `update_weights`, construct the new sampler during the pre-mutation check phase (mapping the error the same way) so a failure leaves `self` untouched, and document `Error::Overflow` in its error list.
- Added an `overflow_float` test covering `f64::MAX + f64::MAX`, `f32`, an explicitly infinite weight, and that a failed `update_weights` leaves the distribution unmodified.

Tested with `cargo test --lib weighted` (14 tests pass); `cargo fmt --check` and `cargo clippy --lib` are clean.
