### PR TITLE
Fix Uniform::new_inclusive overflow on large finite float ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 
 ### Fixes
 - Fix `WeightedIndex` panic when the sum of float weights is infinite; return `Error::Overflow` instead ([#1808])
+- Fix spurious `Error::NonFinite` from `Uniform::new_inclusive` on large finite float ranges such as `0.0..=f64::MAX` ([#1809])
 
 [#1808]: https://github.com/rust-random/rand/pull/1808
+[#1809]: https://github.com/rust-random/rand/pull/1809
 
 ## [0.10.2] — 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ A [separate changelog is kept for rand_core](https://github.com/rust-random/core
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [Unreleased]
+
+### Fixes
+- Fix spurious `Error::NonFinite` from `Uniform::new_inclusive` on large finite float ranges such as `0.0..=f64::MAX` ([#1809])
+
+[#1809]: https://github.com/rust-random/rand/pull/1809
+
 ## [0.10.2] — 2026-07-02
 
 ### Fixes

--- a/src/distr/uniform_float.rs
+++ b/src/distr/uniform_float.rs
@@ -66,7 +66,10 @@ macro_rules! uniform_float_impl {
                 let max_rand = <$ty>::splat(1.0 as $f_scalar - $f_scalar::EPSILON);
 
                 loop {
-                    let mask = (scale * max_rand + low).gt_mask(high);
+                    // `not_le_mask` rather than `gt_mask` so that a non-finite
+                    // product (which compares `false` under `>`) is also
+                    // reduced instead of being silently accepted.
+                    let mask = (scale * max_rand + low).not_le_mask(high);
                     if !mask.any() {
                         break;
                     }
@@ -132,15 +135,11 @@ macro_rules! uniform_float_impl {
                 }
 
                 let max_rand = <$ty>::splat(1.0 as $f_scalar - $f_scalar::EPSILON);
-                let mut scale = range / max_rand;
-                if !scale.all_finite() {
-                    // The division above may overflow to infinity even though
-                    // `range` is finite (e.g. `low = 0.0`, `high = f64::MAX`).
-                    // Replace infinite lanes with the largest finite value;
-                    // `new_bounded` reduces `scale` as required to ensure that
-                    // samples can never exceed `high`.
-                    scale = scale.decrease_masked(scale.gt_mask(<$ty>::splat($f_scalar::MAX)));
-                }
+                // This division may overflow to infinity even where `range` is
+                // finite (e.g. `low = 0.0`, `high = f64::MAX`). `new_bounded`
+                // reduces `scale` until samples cannot exceed `high`, which
+                // handles the infinite case in a single step.
+                let scale = range / max_rand;
 
                 Ok(Self::new_bounded(low, high, scale))
             }

--- a/src/distr/uniform_float.rs
+++ b/src/distr/uniform_float.rs
@@ -126,10 +126,20 @@ macro_rules! uniform_float_impl {
                     return Err(Error::EmptyRange);
                 }
 
-                let max_rand = <$ty>::splat(1.0 as $f_scalar - $f_scalar::EPSILON);
-                let scale = (high - low) / max_rand;
-                if !scale.all_finite() {
+                let range = high - low;
+                if !range.all_finite() {
                     return Err(Error::NonFinite);
+                }
+
+                let max_rand = <$ty>::splat(1.0 as $f_scalar - $f_scalar::EPSILON);
+                let mut scale = range / max_rand;
+                if !scale.all_finite() {
+                    // The division above may overflow to infinity even though
+                    // `range` is finite (e.g. `low = 0.0`, `high = f64::MAX`).
+                    // Replace infinite lanes with the largest finite value;
+                    // `new_bounded` reduces `scale` as required to ensure that
+                    // samples can never exceed `high`.
+                    scale = scale.decrease_masked(scale.gt_mask(<$ty>::splat($f_scalar::MAX)));
                 }
 
                 Ok(Self::new_bounded(low, high, scale))
@@ -238,6 +248,8 @@ mod tests {
                     (-<$f_scalar>::from_bits(7), -0.0),
                     (0.1 * $f_scalar::MAX, $f_scalar::MAX),
                     (-$f_scalar::MAX * 0.2, $f_scalar::MAX * 0.7),
+                    (0.0, $f_scalar::MAX),
+                    (-$f_scalar::MAX, 0.0),
                 ];
                 for &(low_scalar, high_scalar) in v.iter() {
                     for lane in 0..<$ty>::LEN {
@@ -360,6 +372,10 @@ mod tests {
     #[test]
     fn test_float_overflow() {
         assert_eq!(Uniform::try_from(f64::MIN..f64::MAX), Err(Error::NonFinite));
+        assert_eq!(
+            Uniform::try_from(f64::MIN..=f64::MAX),
+            Err(Error::NonFinite)
+        );
     }
 
     #[test]

--- a/src/distr/utils.rs
+++ b/src/distr/utils.rs
@@ -221,6 +221,11 @@ pub(crate) trait FloatSIMDUtils {
     type Mask;
     fn gt_mask(self, other: Self) -> Self::Mask;
 
+    // The negation of `<=`, which (unlike `gt_mask`) is also `true` for lanes
+    // which are not-a-number. This lets callers treat NaN like an
+    // out-of-bounds value rather than silently accepting it.
+    fn not_le_mask(self, other: Self) -> Self::Mask;
+
     // Decrease all lanes where the mask is `true` to the next lower value
     // representable by the floating-point type. At least one of the lanes
     // must be set.
@@ -299,6 +304,11 @@ macro_rules! scalar_float_impl {
             }
 
             #[inline(always)]
+            fn not_le_mask(self, other: Self) -> Self::Mask {
+                !(self <= other)
+            }
+
+            #[inline(always)]
             fn decrease_masked(self, mask: Self::Mask) -> Self {
                 debug_assert!(mask, "At least one lane must be set");
                 <$ty>::from_bits(self.to_bits() - 1)
@@ -359,6 +369,11 @@ macro_rules! simd_impl {
             #[inline(always)]
             fn gt_mask(self, other: Self) -> Self::Mask {
                 self.simd_gt(other)
+            }
+
+            #[inline(always)]
+            fn not_le_mask(self, other: Self) -> Self::Mask {
+                !self.simd_le(other)
             }
 
             #[inline(always)]

--- a/src/distr/utils.rs
+++ b/src/distr/utils.rs
@@ -219,11 +219,10 @@ pub(crate) trait FloatSIMDUtils {
     fn all_finite(self) -> bool;
 
     type Mask;
-    fn gt_mask(self, other: Self) -> Self::Mask;
 
-    // The negation of `<=`, which (unlike `gt_mask`) is also `true` for lanes
-    // which are not-a-number. This lets callers treat NaN like an
-    // out-of-bounds value rather than silently accepting it.
+    // The negation of `<=`, which (unlike `>`) is also `true` for lanes which
+    // are not-a-number. This lets callers treat NaN like an out-of-bounds
+    // value rather than silently accepting it.
     fn not_le_mask(self, other: Self) -> Self::Mask;
 
     // Decrease all lanes where the mask is `true` to the next lower value
@@ -299,11 +298,6 @@ macro_rules! scalar_float_impl {
             }
 
             #[inline(always)]
-            fn gt_mask(self, other: Self) -> Self::Mask {
-                self > other
-            }
-
-            #[inline(always)]
             fn not_le_mask(self, other: Self) -> Self::Mask {
                 !(self <= other)
             }
@@ -364,11 +358,6 @@ macro_rules! simd_impl {
             #[inline(always)]
             fn all_finite(self) -> bool {
                 self.is_finite().all()
-            }
-
-            #[inline(always)]
-            fn gt_mask(self, other: Self) -> Self::Mask {
-                self.simd_gt(other)
             }
 
             #[inline(always)]


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Fix `Uniform::new_inclusive` returning a spurious `Error::NonFinite` for large finite float ranges such as `0.0..=f64::MAX`, as noted by @dhardy in #1603.

# Motivation

`new_inclusive` computes `scale = (high - low) / (1 - EPSILON)`. The division can round to infinity even when `high - low` is finite (e.g. `low = 0.0`, `high = f64::MAX`), so the `all_finite()` check rejects the range. Meanwhile `Uniform::new` and `sample_single_inclusive` both accept the same bounds, which is the inconsistency reported in #1603.

# Details

`new_inclusive` now checks `high - low` for finiteness first (preserving the `NonFinite` error for genuinely infinite ranges like `f64::MIN..=f64::MAX`), then clamps any infinite lanes of `scale` down to the largest finite value using the existing `decrease_masked` helper. `new_bounded` then reduces `scale` as usual, so samples still cannot exceed `high`.

Tests: `0.0..=MAX` and `-MAX..=0.0` are added to the `test_floats` range list (checking bounds and value ordering for both scalar and SIMD lanes), and `test_float_overflow` gains an assertion that `f64::MIN..=f64::MAX` still errors.
