### PR TITLE
Fix IteratorRandom::sample and sample_fill consuming the iterator when amount == 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ A [separate changelog is kept for rand_core](https://github.com/rust-random/core
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [Unreleased]
+
+### Fixes
+- Fix `IteratorRandom::sample` and `sample_fill` consuming the iterator and advancing the RNG when `amount == 0` ([#1810])
+
+[#1810]: https://github.com/rust-random/rand/pull/1810
+
 ## [0.10.2] — 2026-07-02
 
 ### Fixes

--- a/src/seq/iterator.rs
+++ b/src/seq/iterator.rs
@@ -205,6 +205,10 @@ pub trait IteratorRandom: Iterator + Sized {
         R: Rng + ?Sized,
     {
         let amount = buf.len();
+        if amount == 0 {
+            return 0;
+        }
+
         let mut len = 0;
         while len < amount {
             if let Some(elem) = self.next() {
@@ -245,6 +249,10 @@ pub trait IteratorRandom: Iterator + Sized {
     where
         R: Rng + ?Sized,
     {
+        if amount == 0 {
+            return Vec::new();
+        }
+
         let mut reservoir = Vec::from_iter(self.by_ref().take(amount));
 
         // Continue unless the iterator was exhausted
@@ -569,6 +577,31 @@ mod test {
                 .iter()
                 .all(|e| { **e >= min_val && **e <= max_val })
         );
+    }
+
+    #[test]
+    fn test_sample_amount_zero() {
+        // `sample` and `sample_fill` with `amount == 0` should neither
+        // consume the iterator nor advance the RNG.
+        let mut rng = crate::test::rng(413);
+
+        let mut consumed = 0;
+        let mut buf: [u32; 0] = [];
+        let len = (0..100)
+            .inspect(|_| consumed += 1)
+            .sample_fill(&mut rng, &mut buf);
+        assert_eq!(len, 0);
+        assert_eq!(consumed, 0);
+
+        #[cfg(feature = "alloc")]
+        {
+            let mut consumed = 0;
+            let samples = (0..100).inspect(|_| consumed += 1).sample(&mut rng, 0);
+            assert!(samples.is_empty());
+            assert_eq!(consumed, 0);
+        }
+
+        assert_eq!(rng.next_u32(), crate::test::rng(413).next_u32());
     }
 
     #[test]


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Make `IteratorRandom::sample` and `sample_fill` return early when `amount == 0` instead of consuming the iterator and advancing the RNG.

# Motivation

With `amount == 0`, `sample_fill` skips the initial fill loop (`len < amount` is immediately false) and `sample`'s `take(0)` reservoir is empty, so both fall through to the reservoir-sampling loop. That loop walks the *entire* remaining iterator and draws one random index per element, even though nothing can ever be selected. So the degenerate case is O(n) instead of O(1), exhausts an iterator passed `by_ref`, and perturbs the RNG state.

# Details

Added an early return in both methods: `sample` returns `Vec::new()` and `sample_fill` returns `0` when the buffer is empty. No behavior change for `amount > 0`.

New test `test_sample_amount_zero` checks that neither method consumes any items (counted via `inspect`) and that the RNG state is untouched afterwards; the `sample` half is gated on `feature = "alloc"`. Verified with `cargo test --lib seq::iterator` on default features and `--no-default-features`. Existing value-stability tests are unaffected since they use `amount > 0`.
