### PR TITLE
Fix sample_weighted excluding items after the first `amount` infinite weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ A [separate changelog is kept for rand_core](https://github.com/rust-random/core
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [Unreleased]
+
+### Fixes
+- Fix `seq::index::sample_weighted` never sampling items after the first `amount` items with infinite weight; infinite-weight items are now sampled uniformly among themselves ([#1812])
+
+[#1812]: https://github.com/rust-random/rand/pull/1812
+
 ## [0.10.2] — 2026-07-02
 
 ### Fixes

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -290,6 +290,9 @@ where
 ///
 /// Function `weight` is called once for each index to provide weights.
 ///
+/// Items with infinite weight have priority over items with finite weight
+/// and are sampled uniformly among themselves.
+///
 /// This method is used internally by the slice sampling methods, but it can
 /// sometimes be useful to have the indices themselves so this is provided as
 /// an alternative.
@@ -335,6 +338,9 @@ where
 /// no guarantee of shuffling or ordering).
 ///
 /// Function `weight` is called once for each index to provide weights.
+///
+/// Items with infinite weight have priority over items with finite weight
+/// and are sampled uniformly among themselves.
 ///
 /// This implementation is based on the algorithm A-ExpJ as found in
 /// [Efraimidis and Spirakis, 2005](https://doi.org/10.1016/j.ipl.2005.11.003).
@@ -390,10 +396,26 @@ where
     impl<N> Eq for Element<N> {}
 
     let mut candidates = BinaryHeap::with_capacity(amount.as_usize());
+    // Items with infinite weight take priority over items with finite weight,
+    // which the A-ExpJ keys cannot represent (any key would be -0.0). They are
+    // sampled uniformly among themselves using reservoir sampling
+    // (Algorithm R), tracked separately from `candidates`.
+    let mut infinite = Vec::new();
+    let mut n_inf: usize = 0;
     let mut index = N::zero();
     while index < length && candidates.len() < amount.as_usize() {
         let weight = weight(index.as_usize()).into();
-        if weight > 0.0 {
+        if weight == f64::INFINITY {
+            n_inf += 1;
+            if infinite.len() < amount.as_usize() {
+                infinite.push(index);
+            } else {
+                let k = rng.random_range(0..n_inf);
+                if k < amount.as_usize() {
+                    infinite[k] = index;
+                }
+            }
+        } else if weight > 0.0 {
             // We use the log of the key used in A-ExpJ to improve precision
             // for small weights:
             let key = rng.random::<f64>().ln() / weight;
@@ -409,7 +431,17 @@ where
         let mut x = rng.random::<f64>().ln() / candidates.peek().unwrap().key;
         while index < length {
             let weight = weight(index.as_usize()).into();
-            if weight > 0.0 {
+            if weight == f64::INFINITY {
+                n_inf += 1;
+                if infinite.len() < amount.as_usize() {
+                    infinite.push(index);
+                } else {
+                    let k = rng.random_range(0..n_inf);
+                    if k < amount.as_usize() {
+                        infinite[k] = index;
+                    }
+                }
+            } else if weight > 0.0 {
                 x -= weight;
                 if x <= 0.0 {
                     let min_candidate = candidates.pop().unwrap();
@@ -427,9 +459,13 @@ where
         }
     }
 
-    Ok(IndexVec::from(
-        candidates.iter().map(|elt| elt.index).collect(),
-    ))
+    // Infinite-weight items fill the result first; drop the smallest keys so
+    // that the best finite-weight candidates fill the remaining slots.
+    while candidates.len() > amount.as_usize() - infinite.len() {
+        candidates.pop();
+    }
+    infinite.extend(candidates.iter().map(|elt| elt.index));
+    Ok(IndexVec::from(infinite))
 }
 
 /// Randomly sample exactly `amount` indices from `0..length`, using Floyd's
@@ -654,6 +690,61 @@ mod test {
 
         let r = sample_weighted(&mut seed_rng(423), 10, |i| i as f64, 10);
         assert_eq!(r.unwrap().len(), 9);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
+    fn test_sample_weighted_infinite() {
+        let mut rng = crate::test::rng(424);
+
+        // All weights are infinite: expect a uniform sample
+        let weights = [f64::INFINITY; 4];
+        let mut counts = [0i32; 4];
+        for _ in 0..1000 {
+            let v = sample_weighted(&mut rng, weights.len(), |i| weights[i], 2).unwrap();
+            assert_eq!(v.len(), 2);
+            for i in v {
+                counts[i] += 1;
+            }
+        }
+        // Each index is expected to be sampled with probability 2/4
+        for &count in &counts {
+            assert!((count - 500).abs() < 100, "counts: {counts:?}");
+        }
+
+        // Infinite weights dominate finite weights
+        let weights = [1.0, f64::INFINITY, f64::INFINITY, f64::INFINITY];
+        let mut counts = [0i32; 4];
+        for _ in 0..1000 {
+            let v = sample_weighted(&mut rng, weights.len(), |i| weights[i], 2).unwrap();
+            assert_eq!(v.len(), 2);
+            for i in v {
+                counts[i] += 1;
+            }
+        }
+        // Each infinite-weight index is expected to be sampled with
+        // probability 2/3; the finite-weight index should never be sampled.
+        assert_eq!(counts[0], 0, "counts: {counts:?}");
+        for &count in &counts[1..] {
+            assert!((count - 667).abs() < 100, "counts: {counts:?}");
+        }
+
+        // Same, but with the infinite weights appearing after `amount`
+        // finite weights
+        let weights = [1.0, 1.0, f64::INFINITY, f64::INFINITY, f64::INFINITY];
+        let mut counts = [0i32; 5];
+        for _ in 0..1000 {
+            let v = sample_weighted(&mut rng, weights.len(), |i| weights[i], 2).unwrap();
+            assert_eq!(v.len(), 2);
+            for i in v {
+                counts[i] += 1;
+            }
+        }
+        assert_eq!(&counts[..2], &[0, 0], "counts: {counts:?}");
+        for &count in &counts[2..] {
+            assert!((count - 667).abs() < 100, "counts: {counts:?}");
+        }
     }
 
     #[test]

--- a/src/seq/slice.rs
+++ b/src/seq/slice.rs
@@ -819,6 +819,31 @@ mod test {
         let choices = [('a', -0.0), ('b', 1.0), ('c', 1.0)];
         let r = choices.sample_weighted(&mut rng, 2, |item| item.1);
         assert!(r.is_ok());
+
+        // Case 9: More +infinity weights than the requested amount
+        let choices = [
+            ('a', 1.0),
+            ('b', f64::INFINITY),
+            ('c', f64::INFINITY),
+            ('d', f64::INFINITY),
+        ];
+        let mut counts = [0; 4];
+        for _ in 0..100 {
+            let result = choices
+                .sample_weighted(&mut rng, 2, |item| item.1)
+                .unwrap()
+                .collect::<Vec<_>>();
+
+            assert_eq!(result.len(), 2);
+            assert!(!result.iter().any(|val| val.0 == 'a'));
+            for val in result {
+                counts[(val.0 as u8 - b'a') as usize] += 1;
+            }
+        }
+        // Each infinite-weight item should be sampled some of the time
+        for &count in &counts[1..] {
+            assert!(count > 0);
+        }
     }
 
     #[test]


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

`seq::index::sample_weighted` (and therefore `sample_weighted` on slices) never samples any item that appears after the first `amount` items with infinite weight. Those first `amount` infinite-weight items win deterministically; every later item — finite or infinite weight — is selected with probability 0.

# Motivation

In `sample_efraimidis_spirakis`, an infinite weight produces the key `ln(r) / inf = -0.0`. Once the reservoir's minimum key is `-0.0`, the skip value `x = ln(r) / -0.0 = inf`, so `x -= weight` leaves `x` at `inf` for finite weights and `NaN` for infinite ones, and the replacement branch is never taken again:

```rust
let mut rng = rand::rng();
let weights = [1.0, 1.0, f64::INFINITY, f64::INFINITY, f64::INFINITY];
let v = rand::seq::index::sample_weighted(&mut rng, 5, |i| weights[i], 2).unwrap();
// always [0, 1]: the two finite-weight items, each of relative weight 0
```

Infinity is otherwise accepted as a weight (only `w < 0` and NaN are rejected), so this silently returns the least likely items instead of the most likely ones.

# Details

Infinite-weight items cannot be represented by A-ExpJ keys (any such key is `-0.0`), so they are diverted into a separate uniform reservoir (Algorithm R) that takes priority over the heap of finite-weight candidates. The resulting semantics, now documented on both `sample_weighted` variants: items with infinite weight have priority over items with finite weight and are sampled uniformly among themselves. Sampling among finite weights is unchanged, and the case of at most `amount` infinite weights appearing early keeps its old behavior (those items were and are always selected).

Tests:

- `seq::index::test_sample_weighted_infinite`: all-infinite weights are sampled uniformly (count check over 1000 runs); infinite weights dominate finite ones; and the failing case above — infinite weights appearing after `amount` finite ones — now excludes the finite items and picks uniformly among the infinite ones.
- `seq::slice::test_multiple_weighted_edge_cases`: added a case with more infinite weights than `amount` through the slice API.

`cargo test --features std`, `cargo fmt --check` and `cargo clippy --features std,alloc --lib` are clean.
