### PR TITLE
Reject non-finite weights in sample_weighted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ A [separate changelog is kept for rand_core](https://github.com/rust-random/core
 
 You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.html) useful.
 
+## [Unreleased]
+
+### Changes
+- `seq::index::sample_weighted` (and the `sample_weighted` / `choose_multiple_weighted` slice methods) now reject infinite weights with `WeightError::InvalidWeight`, as they already do for NaN and negative weights ([#1813])
+
+[#1813]: https://github.com/rust-random/rand/pull/1813
+
 ## [0.10.2] — 2026-07-02
 
 ### Fixes

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -295,7 +295,8 @@ where
 /// an alternative.
 ///
 /// Error cases:
-/// -   [`WeightError::InvalidWeight`] when a weight is not-a-number or negative.
+/// -   [`WeightError::InvalidWeight`] when a weight is not-a-number, negative
+///     or infinite.
 ///
 /// This implementation uses `O(length + amount)` space and `O(length)` time.
 #[cfg(feature = "std")]
@@ -341,7 +342,8 @@ where
 /// It uses `O(length + amount)` space and `O(length)` time.
 ///
 /// Error cases:
-/// -   [`WeightError::InvalidWeight`] when a weight is not-a-number or negative.
+/// -   [`WeightError::InvalidWeight`] when a weight is not-a-number, negative
+///     or infinite.
 #[cfg(feature = "std")]
 fn sample_efraimidis_spirakis<R, F, X, N>(
     rng: &mut R,
@@ -393,13 +395,17 @@ where
     let mut index = N::zero();
     while index < length && candidates.len() < amount.as_usize() {
         let weight = weight(index.as_usize()).into();
+        // An infinite weight has no A-ExpJ key: ln(r) / inf is -0.0 for every
+        // r, so such items cannot be ordered against each other or against
+        // finite weights.
+        if !weight.is_finite() || weight < 0.0 {
+            return Err(WeightError::InvalidWeight);
+        }
         if weight > 0.0 {
             // We use the log of the key used in A-ExpJ to improve precision
             // for small weights:
             let key = rng.random::<f64>().ln() / weight;
             candidates.push(Element { index, key });
-        } else if !(weight >= 0.0) {
-            return Err(WeightError::InvalidWeight);
         }
 
         index += N::one();
@@ -409,6 +415,9 @@ where
         let mut x = rng.random::<f64>().ln() / candidates.peek().unwrap().key;
         while index < length {
             let weight = weight(index.as_usize()).into();
+            if !weight.is_finite() || weight < 0.0 {
+                return Err(WeightError::InvalidWeight);
+            }
             if weight > 0.0 {
                 x -= weight;
                 if x <= 0.0 {
@@ -419,8 +428,6 @@ where
 
                     x = rng.random::<f64>().ln() / candidates.peek().unwrap().key;
                 }
-            } else if !(weight >= 0.0) {
-                return Err(WeightError::InvalidWeight);
             }
 
             index += N::one();

--- a/src/seq/slice.rs
+++ b/src/seq/slice.rs
@@ -801,14 +801,13 @@ mod test {
 
         // Case 6: +infinity weights
         let choices = [('a', f64::INFINITY), ('b', 1.0), ('c', 1.0)];
-        for _ in 0..100 {
-            let result = choices
-                .sample_weighted(&mut rng, 2, |item| item.1)
-                .unwrap()
-                .collect::<Vec<_>>();
-            assert_eq!(result.len(), 2);
-            assert!(result.iter().any(|val| val.0 == 'a'));
-        }
+        let r = choices.sample_weighted(&mut rng, 2, |item| item.1);
+        assert_eq!(r.unwrap_err(), WeightError::InvalidWeight);
+
+        // Case 6b: +infinity weights beyond the first `amount` items
+        let choices = [('a', 1.0), ('b', 1.0), ('c', f64::INFINITY)];
+        let r = choices.sample_weighted(&mut rng, 2, |item| item.1);
+        assert_eq!(r.unwrap_err(), WeightError::InvalidWeight);
 
         // Case 7: -infinity weights
         let choices = [('a', f64::NEG_INFINITY), ('b', 1.0), ('c', 1.0)];


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

Redo of #1812 along the lines you suggested there:

> If anything, non-finite weights should be considered an error; we certainly don't want this approach.

So this drops the separate-reservoir approach entirely and just rejects non-finite weights.

# The problem

`seq::index::sample_weighted` accepts infinite weights but cannot sample them correctly. In A-ExpJ an infinite weight gives the key `ln(r) / inf == -0.0` for every `r`, so infinite-weight items cannot be ordered against each other, or against finite ones. Once the reservoir's minimum key is `-0.0`, the skip value `x = ln(r) / -0.0` is `inf` and the replacement branch is never taken again:

```rust
let weights = [1.0, 1.0, f64::INFINITY, f64::INFINITY, f64::INFINITY];
let v = rand::seq::index::sample_weighted(&mut rng, 5, |i| weights[i], 2).unwrap();
// always [0, 1]: the two *finite*-weight items — i.e. the least likely ones
```

So the failure mode is a silently wrong result, not an error.

# The change

Reject any weight that is not finite and non-negative, which is where NaN and negative weights are already rejected. `-0.0` is still accepted (case 8), and sampling among finite weights is untouched.

# Behavior change

`test_multiple_weighted_edge_cases` case 6 previously asserted the opposite — that a `+inf` weight is accepted and its item always selected. That assertion is now `WeightError::InvalidWeight`. I've also added a case 6b for an infinite weight appearing *after* the first `amount` items, which is the path that produced the wrong answer above.

This is scoped to `seq`; `WeightedIndex` is untouched.

`cargo test --features std`, `cargo fmt --check` and `cargo clippy --features std,alloc --lib` are clean.
