### PR TITLE
Reject full-range and wrapping UniformChar samplers on deserialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 
 ### Fixes
 - Fix `WeightedIndex` panic when the sum of float weights is infinite; return `Error::Overflow` instead ([#1808])
+- Fix `Uniform<char>` deserialization accepting full-range and wrapping samplers that then panic in `sample` ([#1829])
 
 [#1808]: https://github.com/rust-random/rand/pull/1808
+[#1829]: https://github.com/rust-random/rand/pull/1829
 
 ## [0.10.2] — 2026-07-02
 

--- a/src/distr/uniform_other.rs
+++ b/src/distr/uniform_other.rs
@@ -43,7 +43,18 @@ where
     D: serde::Deserializer<'de>,
 {
     let sampler = <UniformInt<u32> as serde::Deserialize>::deserialize(d)?;
-    if sampler.max() > char::MAX as u32 - CHAR_SURROGATE_LEN {
+    // `range == 0` is `UniformInt`'s full-u32-range marker. That is a valid
+    // state for `Uniform<u32>`, but a char sampler is always built from a
+    // bounded range, so here it only comes from a crafted payload that would
+    // sample arbitrary u32 (non-char) values. Reject it, together with any
+    // (low, range) whose inclusive max overflows or leaves the char range:
+    // those clear a wrapping `low + range - 1` and later panic in `sample`.
+    let in_char_range = sampler
+        .range
+        .checked_sub(1)
+        .and_then(|r| r.checked_add(sampler.low))
+        .is_some_and(|max| max <= char::MAX as u32 - CHAR_SURROGATE_LEN);
+    if !in_char_range {
         return Err(serde::de::Error::custom(
             "bad sampler range for UniformChar",
         ));
@@ -328,6 +339,29 @@ mod tests {
                 alloc::string::ToString::to_string(&err),
                 "bad sampler range for UniformChar at line 1 column 51"
             );
+        }
+
+        // The `range == 0` full-range marker and payloads whose inclusive
+        // `low + range - 1` wraps also clear the old guard and then sample
+        // non-char code points, so they must be rejected too. See #1827.
+        for json in [
+            r#"{"sampler":{"low":5,"range":0,"thresh":0}}"#,
+            r#"{"sampler":{"low":4294967280,"range":32,"thresh":0}}"#,
+        ] {
+            assert!(serde_json::from_str::<Uniform<char>>(json).is_err());
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_char_deser_roundtrip() {
+        let mut rng = crate::test::rng(892);
+        let distr = Uniform::new_inclusive('a', 'z').unwrap();
+        let de_distr: Uniform<char> =
+            serde_json::from_str(&serde_json::to_string(&distr).unwrap()).unwrap();
+        for _ in 0..100 {
+            let c = de_distr.sample(&mut rng);
+            assert!(c.is_ascii_lowercase());
         }
     }
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Fixes #1827. The `Uniform<char>` deserialization guard checked `UniformInt::max()`, which is built from wrapping arithmetic, so a crafted payload could clear it and then panic inside `sample`. Validate `low` and `range` directly with checked arithmetic instead.

# Motivation

The guard added in #1790 rejects a sampler whose `max()` exceeds the char range, but `max()` is `range.wrapping_sub(1).wrapping_add(low)`. Two cases slip through:

```json
{"sampler":{"low":5,"range":0,"thresh":0}}
{"sampler":{"low":4294967280,"range":32,"thresh":0}}
```

`range == 0` is `UniformInt`'s full-u32-range marker, so `max()` reads `low - 1` (a small number that passes), and at sample time the full-range branch returns an arbitrary `u32`, almost always above `0x10FFFF`. The second payload wraps `low + range - 1` down to a small value. Both then hit `char::from_u32(x).expect(...)` and panic, which is reachable on attacker-influenced serde input.

The check can't move into `UniformInt::deserialize` because `range == 0` is a legitimate state for `Uniform<u32>` (e.g. `new_inclusive(0, u32::MAX)`), so it belongs in the char layer where a bounded range is always expected.

# Details

- Compute the inclusive max from `low` and `range` with `checked_sub`/`checked_add`, rejecting `range == 0` and any max that overflows or exceeds the compressed char range.
- Extended `test_char_bad_deser` with both payloads above, and added `test_char_deser_roundtrip` to confirm a normal `Uniform<char>` still serializes, deserializes, and samples.

Tested with `cargo test --features serde` (all pass); `cargo fmt --check` and `cargo clippy --all-targets --features serde -- -D warnings` are clean.