### PR TITLE
Avoid panic from deserialized `Uniform<char>` where `range == 0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ You may also find the [Upgrade Guide](https://rust-random.github.io/book/update.
 ### Fixes
 - Fix `WeightedIndex` panic when the sum of float weights is infinite; return `Error::Overflow` instead ([#1808])
 - Fix spurious `Error::NonFinite` from `Uniform::new_inclusive` on large finite float ranges such as `0.0..=f64::MAX` ([#1821])
+- Fix possible panic due to sampling a deserialized `Uniform<char>` ([#1831])
 
 [#1808]: https://github.com/rust-random/rand/pull/1808
 [#1821]: https://github.com/rust-random/rand/pull/1821
+[#1831]: https://github.com/rust-random/rand/pull/1831
 
 ## [0.10.2] — 2026-07-02
 

--- a/src/distr/uniform_int.rs
+++ b/src/distr/uniform_int.rs
@@ -79,7 +79,11 @@ macro_rules! uniform_int_impl {
             #[allow(unused)]
             #[inline]
             pub(crate) fn max(&self) -> $ty {
-                self.range.wrapping_sub(1).wrapping_add(self.low)
+                if self.range == 0 {
+                    return <$ty>::MAX;
+                } else {
+                    self.range.wrapping_sub(1).wrapping_add(self.low)
+                }
             }
         }
 

--- a/src/distr/uniform_int.rs
+++ b/src/distr/uniform_int.rs
@@ -82,7 +82,13 @@ macro_rules! uniform_int_impl {
                 if self.range == 0 {
                     return <$ty>::MAX;
                 } else {
-                    self.range.wrapping_sub(1).wrapping_add(self.low)
+                    // The checked_add op should not overflow with a correctly
+                    // constructed sampler, but it is possible to construct a
+                    // sampler that will overflow using serde.
+                    // In this case some sample value may yield MAX.
+                    self.low
+                        .checked_add(self.range.wrapping_sub(1))
+                        .unwrap_or(<$ty>::MAX)
                 }
             }
         }

--- a/src/distr/uniform_int.rs
+++ b/src/distr/uniform_int.rs
@@ -82,13 +82,11 @@ macro_rules! uniform_int_impl {
                 if self.range == 0 {
                     return <$ty>::MAX;
                 } else {
-                    // The checked_add op should not overflow with a correctly
-                    // constructed sampler, but it is possible to construct a
-                    // sampler that will overflow using serde.
-                    // In this case some sample value may yield MAX.
-                    self.low
-                        .checked_add(self.range.wrapping_sub(1))
-                        .unwrap_or(<$ty>::MAX)
+                    // Wrapping through <$ty>::MIN is possible with a valid
+                    // sampler over signed types. Wrapping through <$ty>::MAX is
+                    // possible with a bad sampler (constructible using serde).
+                    let max = self.low.wrapping_add(self.range.wrapping_sub(1));
+                    if max < self.low { <$ty>::MAX } else { max }
                 }
             }
         }

--- a/src/distr/uniform_other.rs
+++ b/src/distr/uniform_other.rs
@@ -316,19 +316,22 @@ mod tests {
     #[test]
     #[cfg(feature = "serde")]
     fn test_char_bad_deser() {
-        let json = r#"{"sampler":{"low":4294967200,"range":0,"thresh":0}}"#;
-        let result = serde_json::from_str::<Uniform<char>>(json);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert_eq!(err.classify(), serde_json::error::Category::Data);
+        fn do_test(json: &str, col: usize) {
+            let result = serde_json::from_str::<Uniform<char>>(json);
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert_eq!(err.classify(), serde_json::error::Category::Data);
 
-        #[cfg(feature = "alloc")]
-        {
-            assert_eq!(
-                alloc::string::ToString::to_string(&err),
-                "bad sampler range for UniformChar at line 1 column 51"
-            );
+            #[cfg(feature = "alloc")]
+            {
+                let msg =
+                    alloc::format!("bad sampler range for UniformChar at line 1 column {col}");
+                assert_eq!(alloc::string::ToString::to_string(&err), msg);
+            }
         }
+
+        do_test(r#"{"sampler":{"low":5,"range":0,"thresh":0}}"#, 0);
+        do_test(r#"{"sampler":{"low":4294967200,"range":0,"thresh":0}}"#, 51);
     }
 
     #[test]

--- a/src/distr/uniform_other.rs
+++ b/src/distr/uniform_other.rs
@@ -330,7 +330,7 @@ mod tests {
             }
         }
 
-        do_test(r#"{"sampler":{"low":5,"range":0,"thresh":0}}"#, 0);
+        do_test(r#"{"sampler":{"low":5,"range":0,"thresh":0}}"#, 42);
         do_test(r#"{"sampler":{"low":4294967200,"range":0,"thresh":0}}"#, 51);
     }
 

--- a/src/distr/uniform_other.rs
+++ b/src/distr/uniform_other.rs
@@ -332,6 +332,10 @@ mod tests {
 
         do_test(r#"{"sampler":{"low":5,"range":0,"thresh":0}}"#, 42);
         do_test(r#"{"sampler":{"low":4294967200,"range":0,"thresh":0}}"#, 51);
+        do_test(
+            r#"{"sampler":{"low":4294967280,"range":32,"thresh":0}}"#,
+            52,
+        );
     }
 
     #[test]


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Fixes #1827. Closes #1829.

# Details

Fixes the internal method `UniformInt::max` which previously ignored the special cases `range == 0` and where `low + range` overflows.