### PR TITLE
Prepare rand_core-0.3.2: use std::mem::transmute

### DIFF
--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-09-02
+- Fix: use `std::mem::transmute` instead of unstable intrinsic ([#1834])
+
+[#1834]: https://github.com/rust-random/rand/pull/1834
+
 ## [0.3.1] - 2019-01-25
 - Compatibility shim around version 0.4
 

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -17,11 +17,10 @@
 //! to/from byte sequences, and since its purpose is reproducibility,
 //! non-reproducible sources (e.g. `OsRng`) need not bother with it.
 
-use core::intrinsics::transmute;
 use core::ptr::copy_nonoverlapping;
 use core::slice;
 use core::cmp::min;
-use core::mem::size_of;
+use core::mem::{size_of, transmute};
 use RngCore;
 
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Avoid usage of accidentally-stabilised fn `core::intrinsics::transmute` (see https://github.com/rust-random/rand_core/issues/82).

# Details

Tested locally using Rust 1.22.1 (05e2e1c41 2017-11-22) (required deleting the parent `Cargo.toml` and the `serde1` feature) and 1.100.0-nightly (fb6531d55 2026-08-23) (with `--lib --tests` as well as with `--features serde1`).