### PR TITLE
Prepare rand_core-0.2.3: use std::mem::transmute

### DIFF
--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.2.2" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.2.3" # NB: When modifying, also modify html_root_url in lib.rs
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -19,11 +19,10 @@
 //! to/from byte sequences, and since its purpose is reproducibility,
 //! non-reproducible sources (e.g. `OsRng`) need not bother with it.
 
-use core::intrinsics::transmute;
 use core::ptr::copy_nonoverlapping;
 use core::slice;
 use core::cmp::min;
-use core::mem::size_of;
+use core::mem::{size_of, transmute};
 use RngCore;
 
 

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -37,7 +37,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand_core/0.2.2")]
+       html_root_url = "https://docs.rs/rand_core/0.2.3")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Avoid usage of accidentally-stabilised fn `core::intrinsics::transmute` (see https://github.com/rust-random/rand_core/issues/82).

# Details

Tested locally using Rust 1.22.1 (05e2e1c41 2017-11-22) (required deleting the parent `Cargo.toml` and the `serde1` feature) and 1.100.0-nightly (fb6531d55 2026-08-23) (with `--lib --tests` as well as with `--features serde1`).