### PR TITLE
Prepare rand_core-0.1.1: use std::mem::transmute

### DIFF
--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.1] - 2026-09-02
+- Fix: use `std::mem::transmute` instead of unstable intrinsic ([#1836])
+
+[#1833]: https://github.com/rust-random/rand/pull/1836
+
 ## [0.1.0] - TODO - date
 (Split out of the Rand crate, changes here are relative to rand 0.4.2)
 - `RngCore` and `SeedableRng` are now part of `rand_core`. (#288)

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.1.0" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.1.1" # NB: When modifying, also modify html_root_url in lib.rs
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -20,11 +20,10 @@
 //! non-reproducible sources (e.g. `OsRng`) need not bother with it.
 
 use core::convert::AsRef;
-use core::intrinsics::transmute;
 use core::ptr::copy_nonoverlapping;
 use core::{fmt, slice};
 use core::cmp::min;
-use core::mem::size_of;
+use core::mem::{size_of, transmute};
 use {RngCore, BlockRngCore, CryptoRng, SeedableRng, Error};
 
 #[cfg(feature="serde1")] use serde::{Serialize, Deserialize};

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -35,7 +35,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand_core/0.1.0")]
+       html_root_url = "https://docs.rs/rand_core/0.1.1")]
 
 #![deny(missing_debug_implementations)]
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Avoid usage of accidentally-stabilised fn `core::intrinsics::transmute` (see https://github.com/rust-random/rand_core/issues/82).

# Details

Tested locally using Rust 1.22.1 (05e2e1c41 2017-11-22) (required deleting the parent `Cargo.toml` and the `serde` dep) and 1.100.0-nightly (fb6531d55 2026-08-23) (with `--lib --tests` as well as with `--features serde1`).